### PR TITLE
Restore private context routes and verify native judgment receipts

### DIFF
--- a/cli/cmd/ao/capabilities_truthfulness_test.go
+++ b/cli/cmd/ao/capabilities_truthfulness_test.go
@@ -152,10 +152,10 @@ func TestTruthfulnessProvenanceEvidenceContracts(t *testing.T) {
 	if family.ID != "ao.provenance" || family.Effects != "filesystem,environment,clock" {
 		t.Fatalf("family: %+v", family)
 	}
-	for _, name := range []string{"snapshot-intent", "manifest", "verify-manifest", "digest", "store-verdict", "verify-verdict", "verify-subject", "evidence-orphans"} {
+	for _, name := range []string{"snapshot-intent", "manifest", "verify-manifest", "digest", "store-verdict", "verify-verdict", "verify-subject", "evidence-orphans", "verify-judgments"} {
 		entry := capabilityEntry(t, "ao provenance "+name)
 		wantEffects := "filesystem"
-		if name == "snapshot-intent" || name == "manifest" || name == "store-verdict" {
+		if name == "snapshot-intent" || name == "manifest" || name == "store-verdict" || name == "verify-judgments" {
 			wantEffects = "filesystem,environment"
 		}
 		failureCode := "1"

--- a/cli/cmd/ao/config_module.go
+++ b/cli/cmd/ao/config_module.go
@@ -24,6 +24,7 @@ func newConfigCommand() *cobra.Command {
 		clicontract.HostOptions{OutputMode: GetOutput, Verbose: GetVerbose, DryRun: GetDryRun},
 	)
 	command := module.Command()
+	command.AddCommand(configcommands.NewContextCommand(configapp.NewCommandService(configadapter.Gateway{})))
 	command.GroupID = "config"
 	if err := clicontract.Attach(command, module.Contract()); err != nil {
 		panic(err)

--- a/cli/cmd/ao/context_judgments_composition_test.go
+++ b/cli/cmd/ao/context_judgments_composition_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestContextJudgmentsComposedPreflight(t *testing.T) {
+	bin := aoBinary(t)
+	base, consumer := t.TempDir(), t.TempDir()
+	configFile, profiles := filepath.Join(base, "config.yaml"), filepath.Join(base, "profiles.json")
+	for path, contents := range map[string]string{
+		configFile: "{}\n",
+		profiles:   `{"profiles":[{"id":"required","runtime":"claude","model":"claude-test","family":"anthropic","effort":""}]}`,
+	} {
+		if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("AGENTOPS_CONFIG", configFile)
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		// ao config context must reject invalid output selection before BD runs.
+		{"context-selection", []string{"config", "context", "--field", "invalid"}, "field must be bundle_root, evidence_root or staging_root"},
+		// ao provenance verify-judgments must reject a denied provider before
+		// reading nonexistent subject, acceptance or private candidate files.
+		{"provider-denial", []string{"provenance", "verify-judgments", "--root", filepath.Join(base, "missing-subject"),
+			"--manifest", filepath.Join(base, "missing-manifest"), "--intent", filepath.Join(base, "missing-intent"),
+			"--evidence-root", base, "--author-context-id", "author", "--required-profiles", profiles,
+			"--allowed-provider", "openai", "--verdict", filepath.Join(base, "missing-private-verdict")}, "provider_denied"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bin, test.args...)
+			cmd.Dir = consumer
+			for _, entry := range os.Environ() {
+				if !strings.HasPrefix(entry, "PATH=") {
+					cmd.Env = append(cmd.Env, entry)
+				}
+			}
+			cmd.Env = append(cmd.Env, "PATH=")
+			out, err := cmd.CombinedOutput()
+			var exit *exec.ExitError
+			if !errors.As(err, &exit) || exit.ExitCode() != 1 || !strings.Contains(string(out), test.want) {
+				t.Fatalf("wanted exit 1 for %q, got %v\n%s", test.want, err, out)
+			}
+			entries, err := os.ReadDir(consumer)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("preflight wrote consumer state: %v %v", entries, err)
+			}
+		})
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -567,7 +567,7 @@ ao completion [bash|zsh|fish|powershell]
 View and manage AgentOps configuration.
 
 ```
-ao config [flags]
+ao config [command]
 ```
 
 **Flags:**
@@ -575,6 +575,37 @@ ao config [flags]
 ```
   -h, --help   help for config
       --show   Show resolved configuration with sources
+```
+
+**Subcommands:**
+
+#### `ao config context`
+
+Resolve caller/home CDLC routes and read the selected native maintenance anchor.
+
+```
+ao config context [flags]
+```
+
+**Flags:**
+
+```
+      --access-policy-ref string      Existing caller-owned access policy JSON
+      --bundle-root string            Selected existing external bundle
+      --consumer-root string          Existing consumer checkout to exclude
+      --destination-ref string        Caller destination identity
+      --evidence-root string          Selected existing protected non-Git evidence
+      --field string                  Emit one checked root for its caller-owned consumer
+  -h, --help                          help for context
+      --maintenance-work-ref string   Known native maintenance anchor
+      --model-ref string              Caller model/provider identity
+      --native-directory string       Explicit native BD source directory
+      --owner-scope string            Expected separately authorized owner scope
+      --project-id string             Expected native project ID
+      --recover                       Recover the same route from its native maintenance anchor
+      --source-id string              Expected canonical native beads_dir
+      --staging-root string           Selected existing protected non-Git staging
+      --task-ref string               Caller task identity
 ```
 
 ---
@@ -824,6 +855,31 @@ ao provenance verify [flags]
 ```
   -h, --help   help for verify
       --json   Emit the machine-readable verify result as JSON
+```
+
+#### `ao provenance verify-judgments`
+
+Check caller-selected required judgment legs using existing verdict.v2 evidence_refs.
+
+```
+ao provenance verify-judgments [flags]
+```
+
+**Flags:**
+
+```
+      --allowed-provider stringArray   Independently authorized provider: openai or anthropic (repeatable)
+      --author-context-id string       Independent native author context identity
+      --base-manifest string           Base manifest for deletions
+      --evidence-root string           Explicit private non-Git root for receipts, transcripts and verdicts
+  -h, --help                           help for verify-judgments
+      --helper-version string          Required evidence helper version (default "1")
+      --intent string                  Independent expected immutable acceptance file
+      --json                           Emit JSON (the default)
+      --manifest string                Expected subject-manifest.v1 file
+      --required-profiles string       Independent JSON object containing the required profiles array
+      --root string                    Explicit subject directory
+      --verdict stringArray            Content-addressed verdict.v2 file inside evidence root (repeatable)
 ```
 
 #### `ao provenance verify-manifest`

--- a/cli/internal/adapters/config/context.go
+++ b/cli/internal/adapters/config/context.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	configapp "github.com/boshu2/agentops/cli/internal/config"
+)
+
+// Native reads are bounded and fail on process errors or output truncation.
+// In particular, show --include-comments is never a substitute for comments.
+func contextBD(ctx context.Context, directory string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	argv := append([]string{"--readonly", "--sandbox", "-C", directory}, args...)
+	command := exec.CommandContext(ctx, "bd", argv...)
+	command.Dir = directory
+	var out limitedContextOutput
+	var diagnostic limitedContextOutput
+	command.Stdout = &out
+	command.Stderr = &diagnostic
+	if err := command.Run(); err != nil {
+		return nil, fmt.Errorf("native bd read failed: %w", err)
+	}
+	if out.overflow || diagnostic.overflow {
+		return nil, fmt.Errorf("native bd response exceeded complete-read limit")
+	}
+	return out.Bytes(), nil
+}
+
+type limitedContextOutput struct {
+	bytes.Buffer
+	overflow bool
+}
+
+func (b *limitedContextOutput) Write(p []byte) (int, error) {
+	n := len(p)
+	remaining := (16 << 20) - b.Len()
+	if n > remaining {
+		b.overflow = true
+		p = p[:remaining]
+	}
+	_, _ = b.Buffer.Write(p)
+	return n, nil
+}
+func (Gateway) NativeContext(ctx context.Context, directory string) (configapp.NativeContext, error) {
+	var value configapp.NativeContext
+	data, err := contextBD(ctx, directory, "context", "--json")
+	if err != nil {
+		return value, err
+	}
+	err = json.Unmarshal(data, &value)
+	return value, err
+}
+func (Gateway) AnchorComments(ctx context.Context, directory, anchor string) ([]configapp.AnchorComment, error) {
+	// Native show establishes anchor existence; its comments are never requested.
+	data, err := contextBD(ctx, directory, "show", anchor, "--json")
+	if err != nil {
+		return nil, err
+	}
+	var issues []struct {
+		ID string `json:"id"`
+	}
+	if err = json.Unmarshal(data, &issues); err != nil {
+		return nil, err
+	}
+	if len(issues) != 1 || issues[0].ID != anchor {
+		return nil, fmt.Errorf("native maintenance anchor missing or ambiguous")
+	}
+	data, err = contextBD(ctx, directory, "comments", anchor, "--json")
+	if err != nil {
+		return nil, err
+	}
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil, fmt.Errorf("native comments unavailable")
+	}
+	var value []configapp.AnchorComment
+	if err = json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}

--- a/cli/internal/adapters/config/context_test.go
+++ b/cli/internal/adapters/config/context_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDirectCommentErrorsAreNotHiddenByShow(t *testing.T) {
+	root := t.TempDir()
+	bd := filepath.Join(root, "bd")
+	// This adapter-only fixture makes show succeed while the direct comments read
+	// fails, reproducing the native failure the service must never swallow.
+	script := "#!/bin/sh\ncase \" $* \" in\n*' show '*) printf '[{\"id\":\"fixture-anchor\"}]';;\n*' comments '*) exit 17;;\n*) exit 19;;\nesac\n"
+	if err := os.WriteFile(bd, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", root)
+	_, err := (Gateway{}).AnchorComments(context.Background(), root, "fixture-anchor")
+	if err == nil || !strings.Contains(err.Error(), "exit status 17") {
+		t.Fatalf("direct read failure swallowed: %v", err)
+	}
+}
+func TestNativeResponseLimitRejectsRatherThanTruncates(t *testing.T) {
+	var out limitedContextOutput
+	payload := make([]byte, (16<<20)+1)
+	if n, err := out.Write(payload); err != nil || n != len(payload) {
+		t.Fatalf("bounded sink: %d %v", n, err)
+	}
+	if !out.overflow || out.Len() != 16<<20 {
+		t.Fatalf("overflow not retained as failure: %+v", out.overflow)
+	}
+	if _, err := out.Write([]byte("trailing")); err != nil || out.Len() != 16<<20 {
+		t.Fatal("overflow sink grew")
+	}
+}

--- a/cli/internal/commands/config/context.go
+++ b/cli/internal/commands/config/context.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	configapp "github.com/boshu2/agentops/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type ContextUseCases interface {
+	Context(context.Context, configapp.ContextRequest) (configapp.ContextResult, error)
+}
+
+// NewContextCommand is a read-only consumer of configured routes. --field emits
+// a checked root for an existing caller-selected evidence/staging operation.
+func NewContextCommand(useCases ContextUseCases) *cobra.Command {
+	var req configapp.ContextRequest
+	var field string
+	command := &cobra.Command{Use: "context", Short: "Resolve an authorized external context route without writing", Args: cobra.NoArgs,
+		Long: `Resolve caller/home CDLC routes and read the selected native maintenance anchor.
+Flags override AGENTOPS_CONTEXT_* variables, then project and home configuration.
+AGENTOPS_CONFIG selects only that file. No roots or policies have defaults.
+An existing schema_version 1 policy must bind the requested source, project,
+owner, task, model, destination and exact storage roots. This selects policy;
+it does not attest native access enforcement (T39).
+Native BD 1.2.2 must support context schema 1, show --json and direct comments --json.
+Missing, conflicting, malformed or incomplete inputs fail before any write.
+--recover reads context.route.v1 from the same independently selected anchor;
+it never creates replacement configuration, knowledge or work.`,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if field != "" && field != "bundle_root" && field != "evidence_root" && field != "staging_root" {
+				return fmt.Errorf("field must be bundle_root, evidence_root or staging_root")
+			}
+			result, err := useCases.Context(command.Context(), req)
+			if err != nil {
+				return err
+			}
+			switch field {
+			case "bundle_root":
+				_, err = fmt.Fprintln(command.OutOrStdout(), result.Route.BundleRoot)
+			case "evidence_root":
+				_, err = fmt.Fprintln(command.OutOrStdout(), result.Route.EvidenceRoot)
+			case "staging_root":
+				_, err = fmt.Fprintln(command.OutOrStdout(), result.Route.StagingRoot)
+			default:
+				return writeJSON(command, result, "context route")
+			}
+			return err
+		}}
+	flags := command.Flags()
+	for _, item := range []struct {
+		name string
+		dst  *string
+		help string
+	}{
+		{"source-id", &req.SourceID, "Expected canonical native beads_dir"}, {"project-id", &req.ProjectID, "Expected native project ID"}, {"owner-scope", &req.OwnerScope, "Expected separately authorized owner scope"},
+		{"task-ref", &req.TaskRef, "Caller task identity"}, {"model-ref", &req.ModelRef, "Caller model/provider identity"}, {"destination-ref", &req.DestinationRef, "Caller destination identity"},
+		{"consumer-root", &req.ConsumerRoot, "Existing consumer checkout to exclude"}, {"native-directory", &req.NativeDirectory, "Explicit native BD source directory"},
+		{"bundle-root", &req.Overrides.BundleRoot, "Selected existing external bundle"}, {"evidence-root", &req.Overrides.EvidenceRoot, "Selected existing protected non-Git evidence"}, {"staging-root", &req.Overrides.StagingRoot, "Selected existing protected non-Git staging"},
+		{"access-policy-ref", &req.Overrides.AccessPolicyRef, "Existing caller-owned access policy JSON"}, {"maintenance-work-ref", &req.Overrides.MaintenanceWorkRef, "Known native maintenance anchor"},
+	} {
+		flags.StringVar(item.dst, item.name, "", item.help)
+	}
+	flags.StringVar(&field, "field", "", "Emit one checked root for its caller-owned consumer")
+	flags.BoolVar(&req.Recover, "recover", false, "Recover the same route from its native maintenance anchor")
+	contract := clicontract.CommandContract{ID: "ao.config.context", Profiles: clicontract.ProfileDefault | clicontract.ProfileLegacy | clicontract.ProfileCombined, Args: clicontract.ArgsPolicy{Name: "none", Validate: cobra.NoArgs}, Output: clicontract.OutputStructured, Effects: clicontract.EffectFilesystem | clicontract.EffectEnvironment | clicontract.EffectProcess, ExitClasses: map[int]clicontract.ExitClass{0: clicontract.ExitSuccess, 1: clicontract.ExitFailure}}
+	if err := clicontract.Attach(command, contract); err != nil {
+		panic(err)
+	}
+	return command
+}

--- a/cli/internal/commands/config/context_native_test.go
+++ b/cli/internal/commands/config/context_native_test.go
@@ -1,0 +1,239 @@
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	adapter "github.com/boshu2/agentops/cli/internal/adapters/config"
+	command "github.com/boshu2/agentops/cli/internal/commands/config"
+	app "github.com/boshu2/agentops/cli/internal/config"
+	"github.com/boshu2/agentops/cli/internal/evidence"
+	"gopkg.in/yaml.v3"
+)
+
+// Opt-in because it creates a synthetic embedded Dolt fixture using installed BD.
+// Every command has an explicit directory, isolated HOME and a timeout. It never
+// accesses the repository's native store or initializes a consumer project.
+func TestContextInstalledBDRecovery(t *testing.T) {
+	if os.Getenv("AO_TEST_BD_NATIVE") != "1" {
+		t.Skip("set AO_TEST_BD_NATIVE=1 to exercise installed BD with a synthetic store")
+	}
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Fatal(err)
+	}
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"BEADS_DIR", "BEADS_DB", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_SERVER_DATABASE", "BD_GLOBAL", "AGENTOPS_CONFIG", "GIT_DIR", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_INDEX_FILE", "GIT_WORK_TREE"} {
+		t.Setenv(key, "")
+		if err = os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, key := range []string{"SOURCE_ID", "PROJECT_ID", "OWNER_SCOPE", "BUNDLE_ID", "BUNDLE_ROOT", "EVIDENCE_ROOT", "STAGING_ROOT", "ACCESS_POLICY_REF", "OWNER_POLICY_REF", "TASK_POLICY_REF", "MODEL_POLICY_REF", "DESTINATION_POLICY_REF", "MAINTENANCE_WORK_REF"} {
+		t.Setenv("AGENTOPS_CONTEXT_"+key, "")
+	}
+	home := filepath.Join(base, "home")
+	native := filepath.Join(base, "native")
+	consumer := filepath.Join(base, "consumer")
+	for _, path := range []string{home, native, consumer, filepath.Join(base, "bundle"), filepath.Join(base, "staging"), filepath.Join(base, "evidence")} {
+		if err = os.Mkdir(path, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("BEADS_ACTOR", "synthetic-context-fixture")
+	t.Chdir(consumer)
+	run := func(name string, dir string, args ...string) []byte {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		c := exec.CommandContext(ctx, name, args...)
+		c.Dir = dir
+		b, err := c.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %v: %v\n%s", name, args, err, b)
+		}
+		return b
+	}
+	bd := func(args ...string) []byte {
+		t.Helper()
+		return run("bd", native, append([]string{"--sandbox", "--actor", "synthetic-context-fixture"}, args...)...)
+	}
+	t.Logf("installed %s", strings.TrimSpace(string(bd("version"))))
+	bd("init", "--non-interactive", "--skip-agents", "--skip-hooks", "--prefix", "ctxfixture")
+	var n app.NativeContext
+	if err = json.Unmarshal(bd("--readonly", "context", "--json"), &n); err != nil {
+		t.Fatal(err)
+	}
+	if n.Backend != "dolt" || n.BeadsDir != filepath.Join(native, ".beads") {
+		t.Fatalf("fixture routing escaped: %+v", n)
+	}
+	var anchor struct {
+		ID string `json:"id"`
+	}
+	if err = json.Unmarshal(bd("create", "Synthetic retained maintenance anchor", "--type", "epic", "--json"), &anchor); err != nil {
+		t.Fatal(err)
+	}
+	c := app.ContextConfig{SourceID: n.BeadsDir, ProjectID: n.ProjectID, OwnerScope: "synthetic-personal", BundleID: "synthetic-bundle", BundleRoot: filepath.Join(base, "bundle"), EvidenceRoot: filepath.Join(base, "evidence"), StagingRoot: filepath.Join(base, "staging"), AccessPolicyRef: filepath.Join(base, "policy.json"), OwnerPolicyRef: filepath.Join(base, "owner-policy"), TaskPolicyRef: filepath.Join(base, "task-policy"), ModelPolicyRef: filepath.Join(base, "model-policy"), DestinationPolicyRef: filepath.Join(base, "destination-policy"), MaintenanceWorkRef: anchor.ID}
+	p := app.ContextPolicy{SchemaVersion: 1, SourceID: c.SourceID, ProjectID: c.ProjectID, OwnerScope: c.OwnerScope, TaskRef: "synthetic-task", ModelRef: "synthetic-model", DestinationRef: "synthetic-destination", BundleID: c.BundleID, BundleRoot: c.BundleRoot, EvidenceRoot: c.EvidenceRoot, StagingRoot: c.StagingRoot, OwnerPolicyRef: c.OwnerPolicyRef, TaskPolicyRef: c.TaskPolicyRef, ModelPolicyRef: c.ModelPolicyRef, DestinationPolicyRef: c.DestinationPolicyRef, MaintenanceWorkRef: anchor.ID}
+	writeJSON := func(path string, value any) {
+		t.Helper()
+		b, err := json.Marshal(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err = os.WriteFile(path, b, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeJSON(c.AccessPolicyRef, p)
+	for _, path := range []string{c.OwnerPolicyRef, c.TaskPolicyRef, c.ModelPolicyRef, c.DestinationPolicyRef} {
+		if err = os.WriteFile(path, []byte("synthetic policy locator"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configPath := filepath.Join(home, ".agents", "ao", "config.yaml")
+	if err = os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := yaml.Marshal(&app.Config{Context: c})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(configPath, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	factPath := filepath.Join(base, "fact.json")
+	writeJSON(factPath, app.ContextFact{Type: "context.route.v1", FactID: "route-1", Route: &c})
+	bd("comments", "add", anchor.ID, "-f", factPath, "--json")
+	for i := 0; i < 55; i++ {
+		bd("comments", "add", anchor.ID, fmt.Sprintf("Synthetic ordinary comment %d", i), "--json")
+	}
+	withdrawal := app.ContextFact{Type: "context.withdrawal.v1", FactID: "withdrawal-1", BundleID: c.BundleID, PageID: "synthetic-page", PageDigest: strings.Repeat("a", 64), Counterevidence: []string{"synthetic:counterexample"}}
+	writeJSON(factPath, withdrawal)
+	bd("comments", "add", anchor.ID, "-f", factPath, "--json")
+	var child struct {
+		ID string `json:"id"`
+	}
+	if err = json.Unmarshal(bd("create", "Synthetic investigation", "--parent", anchor.ID, "--metadata", `{"ao.context.bundle_id":"synthetic-bundle","ao.context.fact_id":"withdrawal-1"}`, "--json"), &child); err != nil {
+		t.Fatal(err)
+	}
+	bd("close", child.ID, "--reason", "Synthetic fixture closed; anchor withdrawal remains", "--json")
+	var closed []struct{ ID, Status string }
+	if err = json.Unmarshal(bd("--readonly", "list", "--all", "--status", "closed", "--parent", anchor.ID, "--metadata-field", "ao.context.fact_id=withdrawal-1", "--limit", "0", "--json"), &closed); err != nil {
+		t.Fatal(err)
+	}
+	if len(closed) != 1 || closed[0].ID != child.ID || closed[0].Status != "closed" {
+		t.Fatalf("native closed flat-metadata query mismatch: %s", closed)
+	}
+	run("git", consumer, "init", "-q")
+	run("git", consumer, "-c", "user.name=Synthetic", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-qm", "synthetic consumer")
+	if err = os.WriteFile(filepath.Join(c.BundleRoot, "retained.md"), []byte("synthetic retained knowledge"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	run("git", c.BundleRoot, "init", "-q")
+	run("git", c.BundleRoot, "add", "retained.md")
+	run("git", c.BundleRoot, "-c", "user.name=Synthetic", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "synthetic retained knowledge")
+	beforeConsumer := contextTreeDigest(t, consumer)
+	beforeBundle := contextTreeDigest(t, c.BundleRoot)
+	invoke := func(extra ...string) ([]byte, error) {
+		t.Helper()
+		cmd := command.NewContextCommand(app.NewCommandService(adapter.Gateway{}))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		args := []string{"--source-id", c.SourceID, "--project-id", c.ProjectID, "--owner-scope", c.OwnerScope, "--task-ref", p.TaskRef, "--model-ref", p.ModelRef, "--destination-ref", p.DestinationRef, "--consumer-root", consumer, "--native-directory", native}
+		cmd.SetArgs(append(args, extra...))
+		err := cmd.ExecuteContext(context.Background())
+		return out.Bytes(), err
+	}
+	result, err := invoke()
+	if err != nil {
+		t.Fatalf("resolve: %v %s", err, result)
+	}
+	var initial app.ContextResult
+	if err = json.Unmarshal(result, &initial); err != nil {
+		t.Fatal(err)
+	}
+	if initial.CommentsRead != 57 || len(initial.Facts) != 2 || initial.Facts[1].FactID != "withdrawal-1" {
+		t.Fatalf("direct complete read lost fact after 50: %+v", initial)
+	}
+	if err = os.Remove(configPath); err != nil {
+		t.Fatal(err)
+	}
+	recoveryFlags := []string{"--recover", "--access-policy-ref", c.AccessPolicyRef, "--maintenance-work-ref", anchor.ID}
+	result, err = invoke(recoveryFlags...)
+	if err != nil {
+		t.Fatalf("recover: %v %s", err, result)
+	}
+	var recovered app.ContextResult
+	if err = json.Unmarshal(result, &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if recovered.Route != initial.Route || !recovered.Recovered || recovered.CommentsRead != 57 {
+		t.Fatal("recovery did not preserve exact bundle and native withdrawal source")
+	}
+	root, err := invoke(append(recoveryFlags, "--field", "evidence_root")...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := evidence.SnapshotIntent(strings.TrimSpace(string(root)), []byte("synthetic exact intent"), consumer, c.BundleRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot == nil {
+		t.Fatal("existing evidence consumer did not use resolved root")
+	}
+	if contextTreeDigest(t, consumer) != beforeConsumer || contextTreeDigest(t, c.BundleRoot) != beforeBundle {
+		t.Fatal("lookup/recovery/evidence consumption changed consumer files, index, objects or retained knowledge")
+	}
+	if _, err = os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatal("recovery wrote replacement config")
+	}
+	if _, err = (adapter.Gateway{}).AnchorComments(context.Background(), native, "ctxfixture-missing"); err == nil {
+		t.Fatal("native missing anchor accepted")
+	}
+	if _, err = (adapter.Gateway{}).AnchorComments(context.Background(), filepath.Join(base, "missing-source"), anchor.ID); err == nil {
+		t.Fatal("native source read error accepted")
+	}
+	t.Log("BD direct comments returned all 57 comments including the withdrawal after comment 50; closed-child flat metadata query returned the investigation; same anchor and bundle recovered after home config removal; consumer files/index/all Git objects and bundle bytes unchanged; resolved evidence root consumed by SnapshotIntent; missing anchor and source errors rejected")
+}
+func contextTreeDigest(t *testing.T, root string) string {
+	t.Helper()
+	hash := sha256.New()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(hash, "%s\x00%s\x00", rel, d.Type())
+		if !d.IsDir() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			hash.Write(data)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/cli/internal/commands/config/module.go
+++ b/cli/internal/commands/config/module.go
@@ -172,4 +172,5 @@ Environment variables:
 
 Examples:
   ao config --show           # Show resolved configuration
-  ao config --show --json   # Output as JSON`
+  ao config --show --json   # Output as JSON
+  ao config context --help  # Resolve explicit external context without writing`

--- a/cli/internal/commands/provenance/judgments.go
+++ b/cli/internal/commands/provenance/judgments.go
@@ -1,0 +1,84 @@
+package provenance
+
+import (
+	"fmt"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"github.com/boshu2/agentops/cli/internal/evidence"
+	"github.com/spf13/cobra"
+)
+
+func (m *Module) verifyJudgmentsCommand() *cobra.Command {
+	var options evidence.JudgmentOptions
+	var profiles, version string
+	var localJSON bool
+	cmd := &cobra.Command{
+		Use: "verify-judgments", Short: "Check required judge profiles against native receipts and exact expected subject/intent", Args: cobra.NoArgs,
+		Long: `Check caller-selected required judgment legs using existing verdict.v2 evidence_refs.
+
+Supply independent profiles, provider authorization, immutable acceptance, subject
+manifest and author identity. Receipt references use
+judgment-receipt:/absolute/private/path.json#sha256=<exact-receipt-byte-hash>.
+Referenced receipts, transcripts and verdicts must be private regular files in the
+explicit non-Git --evidence-root. Each read is limited to 16 MiB. Native JSONL spans
+use zero-based, end-exclusive byte offsets and must end on line boundaries.
+
+Profiles cannot grant provider access: denied required providers fail before any
+candidate or subject read. This local verifier never transmits content or starts a
+judge; the invoking runtime must enforce task/owner/disclosure policy before launch.
+Actual model/context comes only from supported native transcript envelope fields;
+requested options and assistant self-descriptions cannot satisfy identity. Missing
+identity, mismatches, omissions, incomplete termination and missing legs fail closed.
+
+JSON (default) or YAML reports each unchanged verdict and mechanical satisfaction,
+not a new semantic judgment. Exit 0 means all required supplied PASS legs match;
+exit 1 means unsatisfied coverage, invalid input or a read error. Evidence helper
+version 1 is required; no Python, Git, configuration lookup or tracker is invoked.`,
+	}
+	flag := func(target *string, name, help string) {
+		cmd.Flags().StringVar(target, name, "", help)
+		_ = cmd.MarkFlagRequired(name)
+	}
+	flag(&options.Root, "root", "Explicit subject directory")
+	flag(&options.Manifest, "manifest", "Expected subject-manifest.v1 file")
+	flag(&options.Intent, "intent", "Independent expected immutable acceptance file")
+	flag(&options.EvidenceRoot, "evidence-root", "Explicit private non-Git root for receipts, transcripts and verdicts")
+	flag(&options.AuthorContextID, "author-context-id", "Independent native author context identity")
+	flag(&profiles, "required-profiles", "Independent JSON object containing the required profiles array")
+	cmd.Flags().StringVar(&options.BaseManifest, "base-manifest", "", "Base manifest for deletions")
+	cmd.Flags().StringArrayVar(&options.AllowedProviders, "allowed-provider", nil, "Independently authorized provider: openai or anthropic (repeatable)")
+	_ = cmd.MarkFlagRequired("allowed-provider")
+	cmd.Flags().StringArrayVar(&options.Verdicts, "verdict", nil, "Content-addressed verdict.v2 file inside evidence root (repeatable)")
+	cmd.Flags().StringVar(&version, "helper-version", evidence.HelperVersion, "Required evidence helper version")
+	cmd.Flags().BoolVar(&localJSON, "json", false, "Emit JSON (the default)")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		if err := m.checkEvidenceRequest(cmd, "verify-judgments", &evidenceOptions{localJSON: localJSON, version: version}); err != nil {
+			return err
+		}
+		var err error
+		options.Required, err = evidence.LoadJudgeProfiles(profiles)
+		if err != nil {
+			return err
+		}
+		result, err := evidence.VerifyJudgments(options)
+		if err != nil {
+			return err
+		}
+		if _, err = m.emitStructured(cmd.OutOrStdout(), true, result); err != nil {
+			return err
+		}
+		if !result.Satisfied {
+			return fmt.Errorf("required judgment coverage is unsatisfied")
+		}
+		return nil
+	}
+	contract := m.Contract()
+	contract.ID = "ao.provenance.verify-judgments"
+	contract.Args = clicontract.ArgsPolicy{Name: "no-args", Validate: cobra.NoArgs}
+	contract.Output = clicontract.OutputStructured
+	contract.Effects = clicontract.EffectFilesystem | clicontract.EffectEnvironment
+	if err := clicontract.Attach(cmd, contract); err != nil {
+		panic(err)
+	}
+	return cmd
+}

--- a/cli/internal/commands/provenance/judgments_test.go
+++ b/cli/internal/commands/provenance/judgments_test.go
@@ -1,0 +1,66 @@
+package provenance
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"github.com/boshu2/agentops/cli/internal/evidence"
+)
+
+func TestVerifyJudgmentsCommandMissingLegAndProviderDenial(t *testing.T) {
+	root, out := t.TempDir(), t.TempDir()
+	write := func(path string, b []byte) {
+		t.Helper()
+		if err := os.WriteFile(path, b, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(root, "toy"), []byte("2 + 2 = 4\n"))
+	manifest, err := evidence.BuildManifest(root, []string{"toy"}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mb, err := evidence.Canonical(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(filepath.Join(out, "manifest.json"), mb)
+	write(filepath.Join(out, "intent"), []byte("Check arithmetic.\n"))
+	write(filepath.Join(out, "profiles.json"), []byte(`{"profiles":[{"id":"other","runtime":"claude","model":"claude-test","family":"anthropic","effort":""}]}`))
+	args := []string{"verify-judgments", "--root", root, "--manifest", filepath.Join(out, "manifest.json"), "--intent", filepath.Join(out, "intent"), "--evidence-root", out, "--author-context-id", "author", "--required-profiles", filepath.Join(out, "profiles.json"), "--allowed-provider", "anthropic"}
+	execute := func(args []string) (string, error) {
+		cmd := NewModule(clicontract.HostOptions{}).Command()
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		return buf.String(), err
+	}
+	got, err := execute(args)
+	if err == nil || !strings.Contains(got, `"missing_required_leg"`) || !strings.Contains(got, `"satisfied": false`) {
+		t.Fatalf("missing leg output %s, %v", got, err)
+	}
+	denied := append([]string(nil), args...)
+	denied[len(denied)-1] = "openai"
+	got, err = execute(append(denied, "--verdict", filepath.Join(out, "missing-private-verdict")))
+	if err == nil || !strings.Contains(err.Error(), "provider_denied") {
+		t.Fatalf("provider denial %s, %v", got, err)
+	}
+	got, err = execute(append(args, "--helper-version", "unsupported"))
+	if err == nil || !strings.Contains(err.Error(), "incompatible evidence helper") {
+		t.Fatalf("version preflight %s, %v", got, err)
+	}
+}
+
+func TestVerifyJudgmentsCommandContract(t *testing.T) {
+	cmd := NewModule(clicontract.HostOptions{}).verifyJudgmentsCommand()
+	contract, ok := clicontract.ContractFor(cmd)
+	if !ok || contract.ID != "ao.provenance.verify-judgments" || contract.Effects.String() != "filesystem,environment" {
+		t.Fatalf("wrong declared effects: %+v", contract)
+	}
+}

--- a/cli/internal/commands/provenance/module.go
+++ b/cli/internal/commands/provenance/module.go
@@ -142,6 +142,7 @@ judgment. See each leaf for evidence helper version and mutation conditions.`,
 	root.AddCommand(m.mineSessionCommand())
 	root.AddCommand(m.evidenceCommands()...)
 	root.AddCommand(m.evidenceOrphansCommand())
+	root.AddCommand(m.verifyJudgmentsCommand())
 	if err := clicontract.Attach(root, m.Contract()); err != nil {
 		panic(err)
 	}

--- a/cli/internal/commands/provenance/module_test.go
+++ b/cli/internal/commands/provenance/module_test.go
@@ -58,7 +58,7 @@ func TestModuleConstructsCommandTree(t *testing.T) {
 	want := map[string]bool{
 		"add": true, "list": true, "export": true, "show": true,
 		"position": true, "trace": true, "verify": true, "mine-session": true,
-		"snapshot-intent": true, "manifest": true, "verify-manifest": true, "digest": true, "store-verdict": true, "verify-verdict": true, "verify-subject": true, "evidence-orphans": true,
+		"snapshot-intent": true, "manifest": true, "verify-manifest": true, "digest": true, "store-verdict": true, "verify-verdict": true, "verify-subject": true, "evidence-orphans": true, "verify-judgments": true,
 	}
 	got := map[string]bool{}
 	for _, c := range root.Commands() {

--- a/cli/internal/config/command_service.go
+++ b/cli/internal/config/command_service.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 )
 
 // showEnvironmentKeys deliberately omits AGENTOPS_NO_SC: it only toggles
@@ -61,4 +62,12 @@ func (service *CommandService) Show(_ context.Context, output string, verbose bo
 		Resolved: service.gateway.Resolve(output, verbose), ConfigFiles: files,
 		Environment: service.gateway.Environment(showEnvironmentKeys),
 	}, nil
+}
+
+func (service *CommandService) Context(ctx context.Context, req ContextRequest) (ContextResult, error) {
+	gateway, ok := service.gateway.(ContextGateway)
+	if !ok {
+		return ContextResult{}, fmt.Errorf("native context adapter unavailable")
+	}
+	return ResolveContext(ctx, gateway, req)
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -44,6 +44,9 @@ type Config struct {
 	// Models settings
 	Models ModelsConfig `yaml:"models" json:"models"`
 
+	// Context explicitly selects external CDLC storage; it has no defaults.
+	Context ContextConfig `yaml:"context" json:"context"`
+
 	// Compile settings for ao compile headless runtime preference.
 	Compile CompileConfig `yaml:"compile" json:"compile"`
 }
@@ -487,6 +490,7 @@ func envBool(envKey string) bool {
 
 // applyEnv applies environment variable overrides.
 func applyEnv(cfg *Config) *Config {
+	applyContextEnv(&cfg.Context)
 	applyEnvStr(&cfg.Output, "AGENTOPS_OUTPUT")
 	applyEnvStr(&cfg.BaseDir, "AGENTOPS_BASE_DIR")
 	if envBool("AGENTOPS_VERBOSE") {
@@ -541,6 +545,7 @@ func merge(dst, src *Config) *Config {
 	mergeRPI(&dst.RPI, &src.RPI)
 	mergeModels(&dst.Models, &src.Models)
 	mergePaths(&dst.Paths, &src.Paths)
+	mergeContext(&dst.Context, src.Context)
 
 	return dst
 }

--- a/cli/internal/config/context.go
+++ b/cli/internal/config/context.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ContextConfig holds caller-owned locators, never source content or work status.
+// No field falls back to paths.learnings_dir or a public corpus.
+type ContextConfig struct {
+	SourceID             string `yaml:"source_id" json:"source_id"`
+	ProjectID            string `yaml:"project_id" json:"project_id"`
+	OwnerScope           string `yaml:"owner_scope" json:"owner_scope"`
+	BundleID             string `yaml:"bundle_id" json:"bundle_id"`
+	BundleRoot           string `yaml:"bundle_root" json:"bundle_root"`
+	EvidenceRoot         string `yaml:"evidence_root" json:"evidence_root"`
+	StagingRoot          string `yaml:"staging_root" json:"staging_root"`
+	AccessPolicyRef      string `yaml:"access_policy_ref" json:"access_policy_ref"`
+	OwnerPolicyRef       string `yaml:"owner_policy_ref" json:"owner_policy_ref"`
+	TaskPolicyRef        string `yaml:"task_policy_ref" json:"task_policy_ref"`
+	ModelPolicyRef       string `yaml:"model_policy_ref" json:"model_policy_ref"`
+	DestinationPolicyRef string `yaml:"destination_policy_ref" json:"destination_policy_ref"`
+	MaintenanceWorkRef   string `yaml:"maintenance_work_ref" json:"maintenance_work_ref"`
+}
+
+func (c *ContextConfig) fields() map[string]*string {
+	return map[string]*string{
+		"source_id": &c.SourceID, "project_id": &c.ProjectID, "owner_scope": &c.OwnerScope,
+		"bundle_id": &c.BundleID, "bundle_root": &c.BundleRoot, "evidence_root": &c.EvidenceRoot,
+		"staging_root": &c.StagingRoot, "access_policy_ref": &c.AccessPolicyRef,
+		"owner_policy_ref": &c.OwnerPolicyRef, "task_policy_ref": &c.TaskPolicyRef,
+		"model_policy_ref": &c.ModelPolicyRef, "destination_policy_ref": &c.DestinationPolicyRef,
+		"maintenance_work_ref": &c.MaintenanceWorkRef,
+	}
+}
+
+func mergeContext(dst *ContextConfig, src ContextConfig) {
+	for key, value := range src.fields() {
+		mergeStr(dst.fields()[key], *value)
+	}
+}
+func applyContextEnv(c *ContextConfig) {
+	for key, value := range c.fields() {
+		applyEnvStr(value, "AGENTOPS_CONTEXT_"+strings.ToUpper(key))
+	}
+}
+
+// LoadContext uses the existing precedence and explicit-file override. Unlike
+// legacy generic configuration, unreadable/malformed ambient files are errors:
+// a broken owner route must not silently expose a lower-priority route.
+func LoadContext(overrides ContextConfig) (ContextConfig, map[string]Source, error) {
+	var value ContextConfig
+	sources := map[string]Source{}
+	add := func(c ContextConfig, source Source) {
+		for key, field := range c.fields() {
+			if *field != "" {
+				*value.fields()[key] = *field
+				sources[key] = source
+			}
+		}
+	}
+	paths := []struct {
+		path   string
+		source Source
+	}{}
+	explicit := strings.TrimSpace(os.Getenv("AGENTOPS_CONFIG"))
+	if explicit != "" {
+		paths = append(paths, struct {
+			path   string
+			source Source
+		}{explicit, Source(explicit)})
+	} else {
+		hp, hl := homeConfigReadInfo()
+		pp, pl := projectConfigReadInfo()
+		hs, ps := SourceHome, SourceProject
+		if hl {
+			hs = SourceHomeLegacy
+		}
+		if pl {
+			ps = SourceProjectLegacy
+		}
+		paths = append(paths, struct {
+			path   string
+			source Source
+		}{hp, hs}, struct {
+			path   string
+			source Source
+		}{pp, ps})
+	}
+	for _, p := range paths {
+		cfg, err := loadFromPath(p.path)
+		if err != nil {
+			if explicit == "" && os.IsNotExist(err) {
+				continue
+			}
+			return value, nil, fmt.Errorf("context config: %w", err)
+		}
+		if cfg != nil {
+			add(cfg.Context, p.source)
+		}
+	}
+	var environment ContextConfig
+	applyContextEnv(&environment)
+	add(environment, SourceEnv)
+	add(overrides, SourceFlag)
+	return value, sources, nil
+}

--- a/cli/internal/config/context_facts.go
+++ b/cli/internal/config/context_facts.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ContextFact is the versioned JSON text of one native maintenance comment.
+// Fact identity survives investigation closure/deletion and knowledge Git rollback.
+// Resolutions cite the withdrawal, its original digest, an exact fresh review,
+// and an explicitly covered successor digest. Parsing does not judge the review.
+type ContextFact struct {
+	Type            string         `json:"type"`
+	FactID          string         `json:"fact_id"`
+	BundleID        string         `json:"bundle_id,omitempty"`
+	PageID          string         `json:"page_id,omitempty"`
+	PageDigest      string         `json:"page_digest,omitempty"`
+	Counterevidence []string       `json:"counterevidence,omitempty"`
+	ResolvesFactID  string         `json:"resolves_fact_id,omitempty"`
+	ReviewRef       string         `json:"review_ref,omitempty"`
+	ReviewDigest    string         `json:"review_digest,omitempty"`
+	SuccessorDigest string         `json:"successor_digest,omitempty"`
+	Route           *ContextConfig `json:"route,omitempty"`
+}
+
+func ParseContextFacts(comments []AnchorComment, anchor string) ([]ContextFact, error) {
+	facts := []ContextFact{}
+	seen := map[string]bool{}
+	commentIDs := map[string]bool{}
+	for _, comment := range comments {
+		if comment.ID == "" || comment.IssueID != anchor || commentIDs[comment.ID] {
+			return nil, fmt.Errorf("incomplete, duplicate or wrong-anchor comment response")
+		}
+		commentIDs[comment.ID] = true
+		text := strings.TrimSpace(comment.Text)
+		if !strings.HasPrefix(text, "{") {
+			continue
+		}
+		var header struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(text), &header); err != nil {
+			return nil, fmt.Errorf("malformed structured anchor comment")
+		}
+		if !strings.HasPrefix(header.Type, "context.") {
+			continue
+		}
+		var fact ContextFact
+		if err := decodeContextObject([]byte(text), &fact, []string{"type", "fact_id"}, []string{"bundle_id", "page_id", "page_digest", "counterevidence", "resolves_fact_id", "review_ref", "review_digest", "successor_digest", "route"}); err != nil {
+			return nil, fmt.Errorf("invalid context fact: %w", err)
+		}
+		if fact.FactID == "" || seen[fact.FactID] {
+			return nil, fmt.Errorf("missing or duplicate context fact ID")
+		}
+		seen[fact.FactID] = true
+		if err := validateContextFact(fact, anchor); err != nil {
+			return nil, err
+		}
+
+		facts = append(facts, fact)
+	}
+	return facts, nil
+}
+func contextDigest(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && value == strings.ToLower(value)
+}
+
+func validateContextFact(fact ContextFact, anchor string) error {
+	switch fact.Type {
+	case "context.route.v1":
+		if fact.Route == nil || fact.Route.MaintenanceWorkRef != anchor {
+			return fmt.Errorf("route fact must preserve this maintenance anchor")
+		}
+	case "context.withdrawal.v1":
+		if fact.BundleID == "" || fact.PageID == "" || !contextDigest(fact.PageDigest) || len(fact.Counterevidence) == 0 {
+			return fmt.Errorf("incomplete withdrawal fact")
+		}
+		for _, ref := range fact.Counterevidence {
+			if strings.TrimSpace(ref) == "" {
+				return fmt.Errorf("empty withdrawal counterevidence")
+			}
+		}
+	case "context.resolution.v1":
+		if fact.BundleID == "" || fact.PageID == "" || !contextDigest(fact.PageDigest) || fact.ResolvesFactID == "" || fact.ReviewRef == "" || !contextDigest(fact.ReviewDigest) || !contextDigest(fact.SuccessorDigest) {
+			return fmt.Errorf("incomplete resolution fact")
+		}
+	default:
+		return fmt.Errorf("unsupported context fact type")
+	}
+	return nil
+}

--- a/cli/internal/config/context_red_test.go
+++ b/cli/internal/config/context_red_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Context routing must be a real config consumer, independent of legacy learning paths.
+func TestContextConfigurationIsLoaded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("context:\n  bundle_root: /caller/private/bundle\n  evidence_root: /caller/private/evidence\n  maintenance_work_ref: fixture-anchor\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTOPS_CONFIG", path)
+	cfg, err := Load(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]json.RawMessage
+	if err = json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	var route map[string]string
+	if err = json.Unmarshal(got["context"], &route); err != nil {
+		t.Fatalf("caller context routing is not loaded: %v", err)
+	}
+	if route["bundle_root"] != "/caller/private/bundle" || route["maintenance_work_ref"] != "fixture-anchor" {
+		t.Fatalf("context routing lost: %v", route)
+	}
+}

--- a/cli/internal/config/context_route.go
+++ b/cli/internal/config/context_route.go
@@ -1,0 +1,358 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/evidencepath"
+	"github.com/boshu2/agentops/cli/internal/verdictcheck"
+)
+
+// ContextRequest supplies the native identity and invocation purpose separately
+// from mutable route configuration. SourceID is the canonical native beads_dir.
+type ContextRequest struct {
+	Overrides                         ContextConfig
+	SourceID, ProjectID, OwnerScope   string
+	TaskRef, ModelRef, DestinationRef string
+	ConsumerRoot, NativeDirectory     string
+	Recover                           bool
+}
+
+// ContextPolicy selects an exact scope. It is not native access enforcement or
+// semantic clearance, and is never supplied by a candidate knowledge page.
+type ContextPolicy struct {
+	MaintenanceWorkRef   string `json:"maintenance_work_ref"`
+	SchemaVersion        int    `json:"schema_version"`
+	SourceID             string `json:"source_id"`
+	ProjectID            string `json:"project_id"`
+	OwnerScope           string `json:"owner_scope"`
+	TaskRef              string `json:"task_ref"`
+	ModelRef             string `json:"model_ref"`
+	DestinationRef       string `json:"destination_ref"`
+	BundleID             string `json:"bundle_id"`
+	BundleRoot           string `json:"bundle_root"`
+	EvidenceRoot         string `json:"evidence_root"`
+	StagingRoot          string `json:"staging_root"`
+	OwnerPolicyRef       string `json:"owner_policy_ref"`
+	TaskPolicyRef        string `json:"task_policy_ref"`
+	ModelPolicyRef       string `json:"model_policy_ref"`
+	DestinationPolicyRef string `json:"destination_policy_ref"`
+}
+
+type NativeContext struct {
+	BDVersion     string `json:"bd_version"`
+	SchemaVersion int    `json:"schema_version"`
+	Backend       string `json:"backend"`
+	ProjectID     string `json:"project_id"`
+	BeadsDir      string `json:"beads_dir"`
+}
+
+type AnchorComment struct {
+	ID      string `json:"id"`
+	IssueID string `json:"issue_id"`
+	Text    string `json:"text"`
+}
+
+type ContextGateway interface {
+	NativeContext(context.Context, string) (NativeContext, error)
+	AnchorComments(context.Context, string, string) ([]AnchorComment, error)
+}
+
+type ContextResult struct {
+	Route             ContextConfig     `json:"context"`
+	Sources           map[string]Source `json:"sources"`
+	Recovered         bool              `json:"recovered"`
+	CommentsRead      int               `json:"comments_read"`
+	Facts             []ContextFact     `json:"facts"`
+	AccessEnforcement string            `json:"access_enforcement"`
+}
+
+// ResolveContext resolves configuration and verifies the exact native anchor.
+// It creates no directory, config, bundle, index, object, anchor or work item.
+func ResolveContext(ctx context.Context, gateway ContextGateway, req ContextRequest) (ContextResult, error) {
+	result := ContextResult{AccessEnforcement: "not_attested"}
+	for name, value := range map[string]string{"source_id": req.SourceID, "project_id": req.ProjectID, "owner_scope": req.OwnerScope, "task_ref": req.TaskRef, "model_ref": req.ModelRef, "destination_ref": req.DestinationRef, "consumer_root": req.ConsumerRoot, "native_directory": req.NativeDirectory} {
+		if strings.TrimSpace(value) == "" {
+			return result, fmt.Errorf("explicit context %s is required", name)
+		}
+	}
+	route, sources, err := LoadContext(req.Overrides)
+	if err != nil {
+		return result, err
+	}
+	policy, err := loadContextPolicy(route, req)
+	if err != nil {
+		return result, err
+	}
+	facts, count, err := readContextAnchor(ctx, gateway, req, route.MaintenanceWorkRef)
+	if err != nil {
+		return result, err
+	}
+	recorded, err := recordedContextRoute(facts)
+	if err != nil {
+		return result, err
+	}
+	if req.Recover {
+		for key, value := range route.fields() {
+			if *value != "" && *value != *recorded.fields()[key] {
+				return result, fmt.Errorf("recovery conflicts with selected context.%s", key)
+			}
+		}
+		route = *recorded
+		result.Recovered = true
+		for key := range route.fields() {
+			if _, ok := sources[key]; !ok {
+				sources[key] = Source("maintenance-anchor")
+			}
+		}
+	}
+	if route != *recorded {
+		return result, fmt.Errorf("selected route conflicts with maintenance recovery fact")
+	}
+	if err = validateRoute(&route, policy, req); err != nil {
+		return result, err
+	}
+	for _, fact := range facts {
+		if fact.BundleID != "" && fact.BundleID != route.BundleID {
+			return result, fmt.Errorf("anchor fact belongs to a different bundle")
+		}
+	}
+	result.Route = route
+	result.Sources = sources
+	result.CommentsRead = count
+	result.Facts = facts
+	return result, nil
+}
+
+func policyMatchesRequest(p ContextPolicy, r ContextRequest) error {
+	if p.SchemaVersion != 1 || p.SourceID != r.SourceID || p.ProjectID != r.ProjectID || p.OwnerScope != r.OwnerScope || p.TaskRef != r.TaskRef || p.ModelRef != r.ModelRef || p.DestinationRef != r.DestinationRef {
+		return fmt.Errorf("context policy denies source/owner/task/model/destination or is unsupported")
+	}
+	return nil
+}
+func validateRoute(r *ContextConfig, p ContextPolicy, req ContextRequest) error {
+	for key, value := range r.fields() {
+		if strings.TrimSpace(*value) == "" {
+			return fmt.Errorf("context.%s is required", key)
+		}
+	}
+	if r.SourceID != req.SourceID || r.ProjectID != req.ProjectID || r.OwnerScope != req.OwnerScope || r.BundleID != p.BundleID {
+		return fmt.Errorf("context route identity conflicts with selected policy")
+	}
+	consumer, err := canonical(req.ConsumerRoot, true)
+	if err != nil {
+		return err
+	}
+	for _, pair := range []struct {
+		value     *string
+		allowed   string
+		directory bool
+	}{
+		{&r.BundleRoot, p.BundleRoot, true}, {&r.EvidenceRoot, p.EvidenceRoot, true}, {&r.StagingRoot, p.StagingRoot, true},
+		{&r.OwnerPolicyRef, p.OwnerPolicyRef, false}, {&r.TaskPolicyRef, p.TaskPolicyRef, false}, {&r.ModelPolicyRef, p.ModelPolicyRef, false}, {&r.DestinationPolicyRef, p.DestinationPolicyRef, false},
+	} {
+		actual, err := canonical(*pair.value, pair.directory)
+		if err != nil {
+			return err
+		}
+		allowed, err := canonical(pair.allowed, pair.directory)
+		if err != nil {
+			return err
+		}
+		if filepath.Clean(pair.allowed) != allowed {
+			return fmt.Errorf("policy path must name its canonical destination, not an alias")
+		}
+		if actual != allowed {
+			return fmt.Errorf("context path escapes selected policy")
+		}
+		*pair.value = actual
+	}
+	if overlap(r.BundleRoot, consumer) {
+		return fmt.Errorf("context bundle overlaps consumer checkout")
+	}
+	for _, root := range []string{r.StagingRoot, r.EvidenceRoot} {
+		if _, err := evidencepath.Validate(root, r.BundleRoot, consumer); err != nil {
+			return err
+		}
+	}
+	if overlap(r.StagingRoot, r.EvidenceRoot) {
+		return fmt.Errorf("context staging and evidence roots overlap")
+	}
+	return nil
+}
+func canonical(path string, directory bool) (string, error) {
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("context path must be absolute")
+	}
+	real, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(real)
+	if err != nil {
+		return "", err
+	}
+	if directory && !info.IsDir() || !directory && !info.Mode().IsRegular() {
+		return "", fmt.Errorf("context path has wrong type")
+	}
+	return real, nil
+}
+func overlap(a, b string) bool {
+	ai, err := os.Stat(a)
+	if err != nil {
+		return true
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		return true
+	}
+	for _, pair := range []struct {
+		path   string
+		target os.FileInfo
+	}{{a, bi}, {b, ai}} {
+		for dir := pair.path; ; dir = filepath.Dir(dir) {
+			info, err := os.Stat(dir)
+			if err != nil {
+				return true
+			}
+			if os.SameFile(info, pair.target) {
+				return true
+			}
+			if filepath.Dir(dir) == dir {
+				break
+			}
+		}
+	}
+	return false
+}
+func readContextFile(path string) (data []byte, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("context policy must be a regular file")
+	}
+	data, err = io.ReadAll(io.LimitReader(file, (1<<20)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 1<<20 {
+		return nil, fmt.Errorf("context policy exceeds 1 MiB")
+	}
+	return data, nil
+}
+
+// Every supplied locator is checked before private comments are opened; recovery
+// may fill only absent locators and never override a conflicting owner.
+func preflightRoute(route ContextConfig, p ContextPolicy, req ContextRequest) error {
+	expected := ContextConfig{SourceID: req.SourceID, ProjectID: req.ProjectID, OwnerScope: req.OwnerScope, BundleID: p.BundleID, BundleRoot: p.BundleRoot, EvidenceRoot: p.EvidenceRoot, StagingRoot: p.StagingRoot, OwnerPolicyRef: p.OwnerPolicyRef, TaskPolicyRef: p.TaskPolicyRef, ModelPolicyRef: p.ModelPolicyRef, DestinationPolicyRef: p.DestinationPolicyRef}
+	for key, field := range expected.fields() {
+		if *field != "" && *route.fields()[key] != "" && *field != *route.fields()[key] {
+			return fmt.Errorf("selected context.%s conflicts with policy", key)
+		}
+	}
+	expected.AccessPolicyRef = route.AccessPolicyRef
+	expected.MaintenanceWorkRef = route.MaintenanceWorkRef
+	return validateRoute(&expected, p, req)
+}
+
+func loadContextPolicy(route ContextConfig, req ContextRequest) (ContextPolicy, error) {
+	var policy ContextPolicy
+	// Access policy and anchor must remain independently selected even in recovery.
+	if route.AccessPolicyRef == "" || route.MaintenanceWorkRef == "" {
+		return policy, fmt.Errorf("context access_policy_ref and maintenance_work_ref are required")
+	}
+	if strings.HasPrefix(route.MaintenanceWorkRef, "-") || strings.ContainsAny(route.MaintenanceWorkRef, " \t\r\n") {
+		return policy, fmt.Errorf("invalid maintenance_work_ref")
+	}
+	policyPath, err := canonical(route.AccessPolicyRef, false)
+	if err != nil {
+		return policy, fmt.Errorf("access policy: %w", err)
+	}
+	data, err := readContextFile(policyPath)
+	if err != nil {
+		return policy, err
+	}
+	if err = decodeContextObject(data, &policy, []string{"schema_version", "source_id", "project_id", "owner_scope", "task_ref", "model_ref", "destination_ref", "bundle_id", "bundle_root", "evidence_root", "staging_root", "owner_policy_ref", "task_policy_ref", "model_policy_ref", "destination_policy_ref", "maintenance_work_ref"}, nil); err != nil {
+		return policy, fmt.Errorf("invalid context policy: %w", err)
+	}
+	if err = policyMatchesRequest(policy, req); err != nil {
+		return policy, err
+	}
+	if policy.MaintenanceWorkRef != route.MaintenanceWorkRef {
+		return policy, fmt.Errorf("context policy denies maintenance anchor")
+	}
+	if err = preflightRoute(route, policy, req); err != nil {
+		return policy, err
+	}
+	return policy, nil
+}
+func readContextAnchor(ctx context.Context, gateway ContextGateway, req ContextRequest, anchor string) ([]ContextFact, int, error) {
+	// Policy is selected and purpose-bound before any private native comment read.
+	native, err := gateway.NativeContext(ctx, req.NativeDirectory)
+	if err != nil {
+		return nil, 0, fmt.Errorf("native context unavailable: %w", err)
+	}
+	source, err := canonical(req.SourceID, true)
+	if err != nil {
+		return nil, 0, err
+	}
+	nativeSource, err := canonical(native.BeadsDir, true)
+	if err != nil {
+		return nil, 0, err
+	}
+	if native.BDVersion != "1.2.2" || native.SchemaVersion != 1 || native.Backend != "dolt" || native.ProjectID != req.ProjectID || nativeSource != source {
+		return nil, 0, fmt.Errorf("native project/source identity mismatch or unsupported context")
+	}
+	comments, err := gateway.AnchorComments(ctx, req.NativeDirectory, anchor)
+	if err != nil {
+		return nil, 0, fmt.Errorf("maintenance anchor unavailable: %w", err)
+	}
+	facts, err := ParseContextFacts(comments, anchor)
+	if err != nil {
+		return nil, 0, err
+	}
+	return facts, len(comments), nil
+}
+func recordedContextRoute(facts []ContextFact) (*ContextConfig, error) {
+	var recorded *ContextConfig
+	for _, fact := range facts {
+		if fact.Type == "context.route.v1" {
+			candidate := *fact.Route
+			if recorded != nil && *recorded != candidate {
+				return nil, fmt.Errorf("conflicting maintenance route facts")
+			}
+			recorded = &candidate
+		}
+	}
+	if recorded == nil {
+		return nil, fmt.Errorf("maintenance anchor has no context.route.v1 recovery fact")
+	}
+	return recorded, nil
+}
+
+func decodeContextObject(data []byte, value any, required, optional []string) error {
+	raw, err := verdictcheck.DecodeObject(data)
+	if err != nil {
+		return err
+	}
+	if err = verdictcheck.ExactFields(raw, required, optional); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(value)
+}

--- a/cli/internal/config/context_test.go
+++ b/cli/internal/config/context_test.go
@@ -1,0 +1,407 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type contextFixtureGateway struct {
+	native   NativeContext
+	comments []AnchorComment
+	err      error
+	reads    int
+}
+
+func (g *contextFixtureGateway) NativeContext(context.Context, string) (NativeContext, error) {
+	g.reads++
+	return g.native, g.err
+}
+func (g *contextFixtureGateway) AnchorComments(context.Context, string, string) ([]AnchorComment, error) {
+	g.reads++
+	return g.comments, g.err
+}
+func writeContextJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	b, e := json.Marshal(value)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = os.WriteFile(path, b, 0600); e != nil {
+		t.Fatal(e)
+	}
+}
+func writeContextYAML(t *testing.T, path string, value ContextConfig) {
+	t.Helper()
+	if e := os.MkdirAll(filepath.Dir(path), 0700); e != nil {
+		t.Fatal(e)
+	}
+	b, e := yaml.Marshal(&Config{Context: value})
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = os.WriteFile(path, b, 0600); e != nil {
+		t.Fatal(e)
+	}
+}
+func contextFixture(t *testing.T) (ContextConfig, ContextPolicy, ContextRequest, *contextFixtureGateway, string) {
+	t.Helper()
+	t.Setenv("AGENTOPS_CONFIG", "")
+	base, canonicalErr := filepath.EvalSymlinks(t.TempDir())
+	if canonicalErr != nil {
+		t.Fatal(canonicalErr)
+	}
+	t.Setenv("HOME", filepath.Join(base, "home"))
+	consumer := filepath.Join(base, "consumer")
+	t.Chdir(base)
+	for key := range (&ContextConfig{}).fields() {
+		t.Setenv("AGENTOPS_CONTEXT_"+strings.ToUpper(key), "")
+	}
+	for _, k := range []string{"GIT_DIR", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_WORK_TREE", "GIT_INDEX_FILE"} {
+		t.Setenv(k, "")
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"consumer", "source", "bundle", "evidence", "staging", "home"} {
+		if e := os.Mkdir(filepath.Join(base, name), 0700); e != nil {
+			t.Fatal(e)
+		}
+	}
+	c := ContextConfig{SourceID: filepath.Join(base, "source"), ProjectID: "project-native-id", OwnerScope: "personal", BundleID: "bundle-id", BundleRoot: filepath.Join(base, "bundle"), EvidenceRoot: filepath.Join(base, "evidence"), StagingRoot: filepath.Join(base, "staging"), AccessPolicyRef: filepath.Join(base, "policy.json"), OwnerPolicyRef: filepath.Join(base, "owner-policy"), TaskPolicyRef: filepath.Join(base, "task-policy"), ModelPolicyRef: filepath.Join(base, "model-policy"), DestinationPolicyRef: filepath.Join(base, "destination-policy"), MaintenanceWorkRef: "fixture-anchor"}
+	for _, path := range []string{c.OwnerPolicyRef, c.TaskPolicyRef, c.ModelPolicyRef, c.DestinationPolicyRef} {
+		if e := os.WriteFile(path, []byte("synthetic policy locator"), 0600); e != nil {
+			t.Fatal(e)
+		}
+	}
+	p := ContextPolicy{SchemaVersion: 1, SourceID: c.SourceID, ProjectID: c.ProjectID, OwnerScope: c.OwnerScope, TaskRef: "fixture-task", ModelRef: "fixture-model", DestinationRef: "fixture-destination", BundleID: c.BundleID, BundleRoot: c.BundleRoot, EvidenceRoot: c.EvidenceRoot, StagingRoot: c.StagingRoot, OwnerPolicyRef: c.OwnerPolicyRef, TaskPolicyRef: c.TaskPolicyRef, ModelPolicyRef: c.ModelPolicyRef, DestinationPolicyRef: c.DestinationPolicyRef, MaintenanceWorkRef: c.MaintenanceWorkRef}
+	writeContextJSON(t, c.AccessPolicyRef, p)
+	path := filepath.Join(base, "home", ".agents", "ao", "config.yaml")
+	writeContextYAML(t, path, c)
+	r := ContextRequest{SourceID: c.SourceID, ProjectID: c.ProjectID, OwnerScope: c.OwnerScope, TaskRef: p.TaskRef, ModelRef: p.ModelRef, DestinationRef: p.DestinationRef, ConsumerRoot: consumer, NativeDirectory: base}
+	b, _ := json.Marshal(ContextFact{Type: "context.route.v1", FactID: "route-1", Route: &c})
+	g := &contextFixtureGateway{native: NativeContext{BDVersion: "1.2.2", SchemaVersion: 1, Backend: "dolt", ProjectID: c.ProjectID, BeadsDir: c.SourceID}, comments: []AnchorComment{{ID: "1", IssueID: c.MaintenanceWorkRef, Text: string(b)}}}
+	return c, p, r, g, path
+}
+func TestContextPrecedenceAndSameAnchorRecovery(t *testing.T) {
+	c, _, req, g, path := contextFixture(t)
+	got, err := ResolveContext(context.Background(), g, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Route != c || got.Recovered || got.Sources["bundle_root"] != SourceHome {
+		t.Fatalf("route/source mismatch: %+v", got)
+	}
+	if err = os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	req.Overrides = ContextConfig{AccessPolicyRef: c.AccessPolicyRef, MaintenanceWorkRef: c.MaintenanceWorkRef}
+	req.Recover = true
+	recovered, err := ResolveContext(context.Background(), g, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recovered.Recovered || recovered.Route != got.Route || recovered.Route.MaintenanceWorkRef != c.MaintenanceWorkRef {
+		t.Fatalf("recovery replaced identity: %+v", recovered)
+	}
+	if _, err = os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("recovery recreated config")
+	}
+	req.Recover = false
+	if _, err = ResolveContext(context.Background(), g, req); err == nil {
+		t.Fatal("missing route accepted without explicit recovery")
+	}
+}
+func TestContextEveryFieldUsesExistingPrecedence(t *testing.T) {
+	_, _, _, _, _ = contextFixture(t)
+	home := ContextConfig{}
+	project := ContextConfig{}
+	flags := ContextConfig{}
+	for key, p := range home.fields() {
+		*p = "home-" + key
+		*project.fields()[key] = "project-" + key
+		*flags.fields()[key] = "flag-" + key
+	}
+	writeContextYAML(t, homeConfigPath(), home)
+	got, sources, err := LoadContext(ContextConfig{})
+	if err != nil || !reflect.DeepEqual(got, home) || sources["bundle_root"] != SourceHome {
+		t.Fatalf("home: %+v %v", got, err)
+	}
+	writeContextYAML(t, projectConfigPath(), project)
+	got, sources, err = LoadContext(ContextConfig{})
+	if err != nil || got != project || sources["bundle_root"] != SourceProject {
+		t.Fatalf("project: %+v %v", got, err)
+	}
+	for key := range home.fields() {
+		t.Setenv("AGENTOPS_CONTEXT_"+strings.ToUpper(key), "env-"+key)
+	}
+	got, sources, err = LoadContext(ContextConfig{})
+	if err != nil || sources["bundle_root"] != SourceEnv {
+		t.Fatal(err)
+	}
+	for key, p := range got.fields() {
+		if *p != "env-"+key {
+			t.Fatalf("environment lost %s", key)
+		}
+	}
+	got, sources, err = LoadContext(flags)
+	if err != nil || got != flags || sources["bundle_root"] != SourceFlag {
+		t.Fatalf("flags: %+v %v", got, err)
+	}
+	for key := range home.fields() {
+		t.Setenv("AGENTOPS_CONTEXT_"+strings.ToUpper(key), "")
+	}
+	explicit := filepath.Join(t.TempDir(), "explicit.yaml")
+	writeContextYAML(t, explicit, ContextConfig{BundleRoot: "explicit-only"})
+	t.Setenv("AGENTOPS_CONFIG", explicit)
+	got, _, err = LoadContext(ContextConfig{})
+	if err != nil || got.BundleRoot != "explicit-only" || got.OwnerScope != "" {
+		t.Fatalf("explicit leaked ambient config: %+v %v", got, err)
+	}
+	if err = os.Remove(explicit); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err = LoadContext(ContextConfig{}); err == nil {
+		t.Fatal("missing explicit config fell back")
+	}
+}
+func TestContextDeniedBeforeNativeRead(t *testing.T) {
+	for _, name := range []string{"missing-policy", "missing-task-policy", "owner", "project", "source", "task", "model", "destination", "anchor", "policy-version", "configured-owner", "configured-root", "missing-root", "invalid-config"} {
+		t.Run(name, func(t *testing.T) {
+			c, p, req, g, path := contextFixture(t)
+			switch name {
+			case "missing-policy":
+				os.Remove(c.AccessPolicyRef)
+			case "missing-task-policy":
+				os.Remove(c.TaskPolicyRef)
+			case "owner":
+				req.OwnerScope = "employer"
+			case "project":
+				req.ProjectID = "other"
+			case "source":
+				req.SourceID = filepath.Dir(c.SourceID)
+			case "task":
+				req.TaskRef = "other"
+			case "model":
+				req.ModelRef = "other"
+			case "destination":
+				req.DestinationRef = "public"
+			case "anchor":
+				req.Overrides.MaintenanceWorkRef = "replacement"
+			case "policy-version":
+				p.SchemaVersion = 2
+				writeContextJSON(t, c.AccessPolicyRef, p)
+			case "configured-owner":
+				c.OwnerScope = "customer"
+				writeContextYAML(t, path, c)
+			case "configured-root":
+				c.EvidenceRoot = c.StagingRoot
+				writeContextYAML(t, path, c)
+			case "missing-root":
+				os.Remove(c.EvidenceRoot)
+			case "invalid-config":
+				os.WriteFile(path, []byte("context: ["), 0600)
+			}
+			if _, err := ResolveContext(context.Background(), g, req); err == nil {
+				t.Fatal("denied route accepted")
+			}
+			if g.reads != 0 {
+				t.Fatalf("private native source read before denial: %d", g.reads)
+			}
+		})
+	}
+}
+func TestContextNonGitRoots(t *testing.T) {
+	for _, kind := range []string{"bundle", "consumer", "unrelated-worktree", "bare-objects", "linked-worktree", "linked-admin", "symlink-bundle", "symlink-object", "active-objects", "overlap"} {
+		for _, which := range []string{"staging", "evidence"} {
+			t.Run(kind+"/"+which, func(t *testing.T) {
+				c, p, req, g, path := contextFixture(t)
+				base := filepath.Dir(c.BundleRoot)
+				bad := c.BundleRoot
+				git := func(args ...string) {
+					t.Helper()
+					cmd := exec.Command("git", args...)
+					if b, e := cmd.CombinedOutput(); e != nil {
+						t.Fatalf("git: %v %s", e, b)
+					}
+				}
+				switch kind {
+				case "consumer":
+					bad = req.ConsumerRoot
+				case "unrelated-worktree":
+					bad = filepath.Join(base, "unrelated")
+					git("init", "-q", bad)
+				case "bare-objects":
+					repo := filepath.Join(base, "bare")
+					git("init", "--bare", "-q", repo)
+					bad = filepath.Join(repo, "objects")
+				case "linked-worktree", "linked-admin":
+					repo := filepath.Join(base, "other")
+					git("init", "-q", repo)
+					git("-C", repo, "-c", "user.name=Synthetic", "-c", "user.email=fixture@example.invalid", "commit", "--allow-empty", "-qm", "fixture")
+					linked := filepath.Join(base, "linked")
+					git("-C", repo, "worktree", "add", "-q", linked)
+					bad = linked
+					if kind == "linked-admin" {
+						bad = filepath.Join(repo, ".git", "worktrees", "linked")
+					}
+				case "symlink-bundle":
+					bad = filepath.Join(base, "alias")
+					os.Symlink(c.BundleRoot, bad)
+				case "symlink-object":
+					repo := filepath.Join(base, "bare")
+					git("init", "--bare", "-q", repo)
+					bad = filepath.Join(base, "alias")
+					os.Symlink(filepath.Join(repo, "objects"), bad)
+				case "active-objects":
+					bad = filepath.Join(base, "relocated-objects")
+					os.Mkdir(bad, 0700)
+					t.Setenv("GIT_OBJECT_DIRECTORY", bad)
+				case "overlap":
+					bad = c.EvidenceRoot
+					if which == "evidence" {
+						bad = c.StagingRoot
+					}
+				}
+				if which == "staging" {
+					c.StagingRoot = bad
+					p.StagingRoot = bad
+				} else {
+					c.EvidenceRoot = bad
+					p.EvidenceRoot = bad
+				}
+				writeContextJSON(t, c.AccessPolicyRef, p)
+				writeContextYAML(t, path, c)
+				if _, err := ResolveContext(context.Background(), g, req); err == nil {
+					t.Fatalf("accepted %s", bad)
+				}
+				if g.reads != 0 {
+					t.Fatal("read native source before path denial")
+				}
+			})
+		}
+	}
+}
+func TestContextAnchorFailuresAndCompleteFacts(t *testing.T) {
+	c, _, req, g, _ := contextFixture(t)
+	for i := 2; i <= 60; i++ {
+		g.comments = append(g.comments, AnchorComment{ID: strconv.Itoa(i), IssueID: c.MaintenanceWorkRef, Text: "unrelated ordinary comment"})
+	}
+	withdrawal := ContextFact{Type: "context.withdrawal.v1", FactID: "negative-1", BundleID: c.BundleID, PageID: "page", PageDigest: strings.Repeat("a", 64), Counterevidence: []string{"native:counterexample"}}
+	b, _ := json.Marshal(withdrawal)
+	g.comments = append(g.comments, AnchorComment{ID: "61", IssueID: c.MaintenanceWorkRef, Text: string(b)})
+	result, err := ResolveContext(context.Background(), g, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CommentsRead != 61 || len(result.Facts) != 2 || result.Facts[1].FactID != "negative-1" {
+		t.Fatal("late withdrawal lost")
+	}
+	g.err = errors.New("native read failure")
+	if _, err = ResolveContext(context.Background(), g, req); err == nil {
+		t.Fatal("native failure interpreted as clearance")
+	}
+	g.err = nil
+	saved := g.comments
+	g.comments = nil
+	if _, err = ResolveContext(context.Background(), g, req); err == nil {
+		t.Fatal("missing route fact created empty replacement")
+	}
+	g.comments = saved
+	g.native.ProjectID = "other"
+	if _, err = ResolveContext(context.Background(), g, req); err == nil {
+		t.Fatal("native source conflict accepted")
+	}
+}
+
+func TestContextFactContract(t *testing.T) {
+	c, _, _, _, _ := contextFixture(t)
+	withdrawal := ContextFact{Type: "context.withdrawal.v1", FactID: "negative", BundleID: c.BundleID, PageID: "page", PageDigest: strings.Repeat("a", 64), Counterevidence: []string{"native:counterexample"}}
+	resolution := ContextFact{Type: "context.resolution.v1", FactID: "resolution", BundleID: c.BundleID, PageID: "page", PageDigest: withdrawal.PageDigest, ResolvesFactID: withdrawal.FactID, ReviewRef: "evidence:exact-fresh-review", ReviewDigest: strings.Repeat("b", 64), SuccessorDigest: strings.Repeat("c", 64)}
+	for _, fact := range []ContextFact{withdrawal, resolution} {
+		data, _ := json.Marshal(fact)
+		if got, err := ParseContextFacts([]AnchorComment{{ID: "native-string-id", IssueID: c.MaintenanceWorkRef, Text: string(data)}}, c.MaintenanceWorkRef); err != nil || len(got) != 1 {
+			t.Fatalf("valid fact: %+v %v", got, err)
+		}
+	}
+	for _, name := range []string{"missing-review", "missing-successor", "missing-counterevidence", "duplicate-key", "wrong-anchor", "missing-comment-id", "duplicate-comment", "unknown-type", "truncated-json", "duplicate-fact"} {
+		t.Run(name, func(t *testing.T) {
+			fact := resolution
+			switch name {
+			case "missing-review":
+				fact.ReviewRef = ""
+			case "missing-successor":
+				fact.SuccessorDigest = ""
+			case "missing-counterevidence":
+				fact = withdrawal
+				fact.Counterevidence = nil
+			case "unknown-type":
+				fact.Type = "context.resolution.v2"
+			}
+			data, _ := json.Marshal(fact)
+			text := string(data)
+			if name == "duplicate-key" {
+				text = strings.Replace(text, `"fact_id":"resolution"`, `"fact_id":"first","fact_id":"resolution"`, 1)
+			}
+			if name == "truncated-json" {
+				text = text[:len(text)-1]
+			}
+			comments := []AnchorComment{{ID: "comment-1", IssueID: c.MaintenanceWorkRef, Text: text}}
+			switch name {
+			case "wrong-anchor":
+				comments[0].IssueID = "other"
+			case "missing-comment-id":
+				comments[0].ID = ""
+			case "duplicate-comment":
+				comments = append(comments, comments[0])
+			case "duplicate-fact":
+				comments = append(comments, AnchorComment{ID: "comment-2", IssueID: c.MaintenanceWorkRef, Text: text})
+			}
+			if _, err := ParseContextFacts(comments, c.MaintenanceWorkRef); err == nil {
+				t.Fatal("malformed/ambiguous fact accepted")
+			}
+		})
+	}
+}
+func TestContextRejectsAmbiguousPolicyAndAliasedPolicyRoot(t *testing.T) {
+	for _, name := range []string{"duplicate", "unknown", "case-key", "symlink-escape", "version"} {
+		t.Run(name, func(t *testing.T) {
+			c, p, req, g, _ := contextFixture(t)
+			switch name {
+			case "symlink-escape":
+				alias := filepath.Join(filepath.Dir(c.BundleRoot), "redirected-policy-root")
+				if err := os.Symlink(c.StagingRoot, alias); err != nil {
+					t.Fatal(err)
+				}
+				p.StagingRoot = alias
+			case "version":
+				g.native.BDVersion = "9.0.0"
+			}
+			data, _ := json.Marshal(p)
+			text := string(data)
+			switch name {
+			case "duplicate":
+				text = strings.Replace(text, `"schema_version":1`, `"schema_version":2,"schema_version":1`, 1)
+			case "unknown":
+				text = strings.Replace(text, `"schema_version":1`, `"schema_version":1,"allow_anything":true`, 1)
+			case "case-key":
+				text = strings.Replace(text, `"schema_version":1`, `"Schema_Version":1`, 1)
+			}
+			if err := os.WriteFile(c.AccessPolicyRef, []byte(text), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ResolveContext(context.Background(), g, req); err == nil {
+				t.Fatal("ambiguous/unsupported policy accepted")
+			}
+		})
+	}
+}

--- a/cli/internal/config/context_test.go
+++ b/cli/internal/config/context_test.go
@@ -230,6 +230,9 @@ func TestContextNonGitRoots(t *testing.T) {
 				git := func(args ...string) {
 					t.Helper()
 					cmd := exec.Command("git", args...)
+					// contextFixture isolates HOME and clears active Git bindings;
+					// capture that environment explicitly for this child process.
+					cmd.Env = os.Environ()
 					if b, e := cmd.CombinedOutput(); e != nil {
 						t.Fatalf("git: %v %s", e, b)
 					}

--- a/cli/internal/evidence/judgment.go
+++ b/cli/internal/evidence/judgment.go
@@ -1,0 +1,244 @@
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/parser"
+	"github.com/boshu2/agentops/cli/internal/verdictcheck"
+)
+
+// VerifyJudgments checks the consumer-selected required legs over independently
+// supplied exact subject/acceptance. It preserves every supplied verdict and
+// fails closed on unverified native identity, omissions or missing legs. It
+// attests available runtime reporting, not provider weights or OS isolation.
+func VerifyJudgments(o JudgmentOptions) (*JudgmentResult, error) {
+	if err := checkJudgePolicy(o); err != nil {
+		return nil, err
+	} // before candidate/source retrieval
+	root, err := judgmentRoot(o.EvidenceRoot)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := LoadManifest(o.Manifest)
+	if err != nil {
+		return nil, err
+	}
+	var base *Manifest
+	if o.BaseManifest != "" {
+		base, err = LoadManifest(o.BaseManifest)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err = VerifyManifest(o.Root, manifest, base); err != nil {
+		return nil, err
+	}
+	intent, err := os.ReadFile(o.Intent)
+	if err != nil {
+		return nil, err
+	}
+	result := &JudgmentResult{Satisfied: true, SubjectManifestDigest: manifest.Digest, AcceptanceDigest: Hash(intent), Legs: []JudgmentLeg{}, Problems: []string{}}
+	state := judgmentState{options: o, root: root, result: result, seen: map[string]bool{}, contexts: map[string]string{}}
+	for _, path := range o.Verdicts {
+		state.inspectVerdict(path)
+	}
+	for _, profile := range o.Required {
+		if !state.seen[profile.ID] {
+			result.Legs = append(result.Legs, JudgmentLeg{ID: profile.ID, Problems: []string{"missing_required_leg"}})
+			result.Satisfied = false
+		}
+	}
+	return result, nil
+}
+
+func checkJudgePolicy(o JudgmentOptions) error {
+	if len(o.Required) == 0 || !knownJudgeIdentity(o.AuthorContextID) {
+		return fmt.Errorf("required profiles and independent author identity must be nonempty")
+	}
+	ids := map[string]bool{}
+	for _, p := range o.Required {
+		if !knownJudgeIdentity(p.ID) || !knownJudgeIdentity(p.Model) || ids[p.ID] {
+			return fmt.Errorf("required profile IDs/models must be nonempty and IDs unique")
+		}
+		ids[p.ID] = true
+		family := map[string]string{"codex": "openai", "claude": "anthropic"}[p.Runtime]
+		if family == "" || p.Family != family {
+			return fmt.Errorf("unsupported required runtime/family profile")
+		}
+		if !slices.Contains(o.AllowedProviders, p.Family) {
+			return fmt.Errorf("provider_denied: required leg %s remains unsatisfied", p.ID)
+		}
+	}
+	return nil
+}
+
+type judgmentState struct {
+	options  JudgmentOptions
+	root     string
+	result   *JudgmentResult
+	seen     map[string]bool
+	contexts map[string]string
+}
+
+func (s *judgmentState) problem(problem string) {
+	s.result.Problems = append(s.result.Problems, problem)
+	s.result.Satisfied = false
+}
+
+func (s *judgmentState) inspectVerdict(path string) {
+	b, err := privateRead(s.root, path)
+	if err != nil {
+		s.problem("verdict_read: " + err.Error())
+		return
+	}
+	digest := strings.TrimSuffix(filepath.Base(path), ".json")
+	if err = verdictcheck.VerifyArtifact(b, digest); err != nil {
+		s.problem("verdict_integrity: " + err.Error())
+		return
+	}
+	var verdict verdictcheck.Verdict
+	if err = json.Unmarshal(b, &verdict); err != nil {
+		s.problem("verdict_decode: " + err.Error())
+		return
+	}
+	found := false
+	for _, ref := range verdict.EvidenceRefs {
+		if !strings.HasPrefix(ref, judgmentPrefix) {
+			continue
+		}
+		found = true
+		receipt, err := readJudgmentReceipt(s.root, ref)
+		if err != nil {
+			s.problem("receipt_integrity: " + err.Error())
+			continue
+		}
+		s.inspectLeg(path, ref, &verdict, receipt)
+	}
+	if !found {
+		s.problem("verdict_missing_judgment_receipt")
+	}
+}
+
+func (s *judgmentState) inspectLeg(path, ref string, v *verdictcheck.Verdict, r *JudgmentReceipt) {
+	leg := JudgmentLeg{ID: r.Requested.ID, VerdictPath: path, Verdict: v.Verdict, ReceiptRef: ref, Problems: []string{}}
+	index := slices.IndexFunc(s.options.Required, func(p JudgeProfile) bool { return p.ID == r.Requested.ID })
+	if index < 0 {
+		s.problem("unexpected_judgment_leg: " + r.Requested.ID)
+		return
+	}
+	if s.seen[leg.ID] {
+		leg.Problems = append(leg.Problems, "duplicate_required_leg")
+	}
+	s.seen[leg.ID] = true
+	profile := s.options.Required[index]
+	if r.Requested != profile {
+		leg.Problems = append(leg.Problems, "requested_profile_mismatch")
+	}
+	leg.Problems = append(leg.Problems, receiptBindingProblems(s.options, s.result, v, r)...)
+	// Runtime/family identity is chosen by the independent profile. A receipt
+	// cannot route parsing or retrieval to a substituted/disallowed provider.
+	if r.Requested.Runtime == profile.Runtime && r.Requested.Family == profile.Family {
+		s.inspectNative(&leg, profile, v, r)
+	}
+	leg.Satisfied = len(leg.Problems) == 0
+	if !leg.Satisfied {
+		s.result.Satisfied = false
+	}
+	s.result.Legs = append(s.result.Legs, leg)
+}
+
+func receiptBindingProblems(o JudgmentOptions, result *JudgmentResult, v *verdictcheck.Verdict, r *JudgmentReceipt) []string {
+	problems := []string{}
+	if r.SubjectManifestDigest != result.SubjectManifestDigest || v.SubjectManifestDigest != result.SubjectManifestDigest {
+		problems = append(problems, "subject_mismatch")
+	}
+	if r.AcceptanceDigest != result.AcceptanceDigest || v.AcceptanceDigest != result.AcceptanceDigest {
+		problems = append(problems, "acceptance_mismatch")
+	}
+	if r.AuthorContextID != o.AuthorContextID || v.AuthorContextID == nil || *v.AuthorContextID != o.AuthorContextID {
+		problems = append(problems, "author_context_mismatch")
+	}
+	if v.FreshnessAttestation == nil {
+		problems = append(problems, "freshness_unverified")
+	}
+	if v.Verdict != "PASS" {
+		problems = append(problems, "verdict_not_pass")
+	}
+	if len(r.Omissions) > 0 {
+		problems = append(problems, "omitted_evidence")
+	}
+	if !runtimeComplete(r) {
+		problems = append(problems, "incomplete_runtime")
+	}
+	return problems
+}
+
+func runtimeComplete(r *JudgmentReceipt) bool {
+	return r.ExitCode != nil && *r.ExitCode == 0 && r.TimedOut != nil && !*r.TimedOut && r.Truncated != nil && !*r.Truncated && r.CleanupVerified != nil && *r.CleanupVerified
+}
+
+func (s *judgmentState) inspectNative(leg *JudgmentLeg, p JudgeProfile, v *verdictcheck.Verdict, r *JudgmentReceipt) {
+	b, err := readNativeSpan(s.root, r.Transcript)
+	if err != nil {
+		leg.Problems = append(leg.Problems, err.Error())
+		return
+	}
+	native, err := parser.NewParser().ParseRuntime(b, p.Runtime)
+	if err != nil {
+		leg.Problems = append(leg.Problems, "native_parse: "+err.Error())
+		return
+	}
+	// Parser offsets are relative to its input; reports use absolute file spans.
+	for i := range native.Spans {
+		native.Spans[i].Start += r.Transcript.Start
+		native.Spans[i].End += r.Transcript.Start
+	}
+	leg.Native = native
+	leg.Problems = append(leg.Problems, nativeProblems(p, s.options.AuthorContextID, v, native)...)
+	if native.ContextID != "" {
+		if previous, ok := s.contexts[native.ContextID]; ok {
+			leg.Problems = append(leg.Problems, "reused_peer_context: "+previous)
+		}
+		s.contexts[native.ContextID] = leg.ID
+	}
+}
+
+func nativeProblems(p JudgeProfile, author string, v *verdictcheck.Verdict, n *parser.RuntimeMetadata) []string {
+	problems := []string{}
+	if !knownJudgeIdentity(n.Model) || !knownJudgeIdentity(n.ContextID) || !knownJudgeIdentity(n.Provider) {
+		problems = append(problems, "identity_unverified")
+	}
+	if n.Model != "" && n.Model != p.Model {
+		problems = append(problems, "runtime_model_mismatch")
+	}
+	if n.Provider != "" && n.Provider != p.Family {
+		problems = append(problems, "runtime_family_mismatch")
+	}
+	if p.Effort != "" && n.Effort != p.Effort {
+		problems = append(problems, "runtime_effort_mismatch")
+	}
+	if n.ContextID == author {
+		problems = append(problems, "reused_author_context")
+	}
+	if v.ValidatorContextID == nil || *v.ValidatorContextID != n.ContextID {
+		problems = append(problems, "validator_context_mismatch")
+	}
+	if !n.Completed {
+		problems = append(problems, "native_termination_unverified")
+	}
+	return problems
+}
+
+func knownJudgeIdentity(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "unknown", "unavailable", "unverified", "identity_unverified", "null", "default":
+		return false
+	default:
+		return value == strings.TrimSpace(value)
+	}
+}

--- a/cli/internal/evidence/judgment_read.go
+++ b/cli/internal/evidence/judgment_read.go
@@ -1,0 +1,200 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/evidencepath"
+	"github.com/boshu2/agentops/cli/internal/verdictcheck"
+)
+
+const judgmentPrefix = "judgment-receipt:"
+const maxJudgmentBytes = 16 << 20
+
+var profileFields = []string{"id", "runtime", "model", "family", "effort"}
+
+// LoadJudgeProfiles loads the consumer's explicit required profiles. Provider
+// authorization is deliberately supplied separately; no profile can grant it.
+func LoadJudgeProfiles(path string) ([]JudgeProfile, error) {
+	raw, err := ReadObject(path)
+	if err != nil {
+		return nil, err
+	}
+	if err = verdictcheck.ExactFields(raw, []string{"profiles"}, nil); err != nil {
+		return nil, err
+	}
+	entries, ok := raw["profiles"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("profiles must be an array")
+	}
+	for _, entry := range entries {
+		if err = strictJudgeProfile(entry); err != nil {
+			return nil, err
+		}
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Profiles []JudgeProfile `json:"profiles"`
+	}
+	if err = json.Unmarshal(b, &result); err != nil {
+		return nil, err
+	}
+	return result.Profiles, nil
+}
+
+func strictJudgmentObject(value any, fields []string) error {
+	obj, ok := value.(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected receipt object")
+	}
+	return verdictcheck.ExactFields(obj, fields, nil)
+}
+
+func strictJudgeProfile(value any) error {
+	if err := strictJudgmentObject(value, profileFields); err != nil {
+		return err
+	}
+	obj := value.(map[string]any)
+	for _, field := range profileFields {
+		if _, ok := obj[field].(string); !ok {
+			return fmt.Errorf("profile %s must be a string", field)
+		}
+	}
+	return nil
+}
+
+func decodeJudgmentReceipt(b []byte) (*JudgmentReceipt, error) {
+	raw, err := verdictcheck.DecodeObject(b)
+	if err != nil {
+		return nil, err
+	}
+	if err = verdictcheck.ExactFields(raw, []string{"version", "requested", "subject_manifest_digest", "acceptance_digest", "author_context_id", "transcript", "exit_code", "timed_out", "truncated", "cleanup_verified", "omissions"}, nil); err != nil {
+		return nil, err
+	}
+	if err = strictJudgeProfile(raw["requested"]); err != nil {
+		return nil, err
+	}
+	if err = strictJudgmentObject(raw["transcript"], []string{"path", "start", "end", "sha256"}); err != nil {
+		return nil, err
+	}
+	if _, ok := raw["omissions"].([]any); !ok {
+		return nil, fmt.Errorf("omissions must be an explicit array")
+	}
+	var receipt JudgmentReceipt
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+	if err = decoder.Decode(&receipt); err != nil {
+		return nil, err
+	}
+	if receipt.Version != "1" {
+		return nil, fmt.Errorf("unsupported judgment receipt version")
+	}
+	return &receipt, nil
+}
+
+// privateRead confines candidate-selected references to the independently
+// supplied evidence root. It never follows an outside-root symlink, retrieves
+// a URL or opens a FIFO/device. Files must be private regular files.
+func privateRead(root, path string) (payload []byte, err error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return nil, fmt.Errorf("evidence reference must be an absolute canonical private path")
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(path))
+	if err != nil {
+		return nil, err
+	}
+	path = filepath.Join(parent, filepath.Base(path))
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("evidence reference escapes authorized root")
+	}
+	handle, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = joinCleanupError(err, handle.Close()) }()
+	info, err := handle.Lstat(rel)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("evidence reference must be a private regular file")
+	}
+	f, err := handle.Open(rel)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = joinCleanupError(err, f.Close()) }()
+	info, err = f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("evidence reference must be a private regular file")
+	}
+	b, err := io.ReadAll(io.LimitReader(f, maxJudgmentBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > maxJudgmentBytes {
+		return nil, fmt.Errorf("evidence reference exceeds 16 MiB read bound")
+	}
+	return b, nil
+}
+
+func readJudgmentReceipt(root, ref string) (*JudgmentReceipt, error) {
+	if !strings.HasPrefix(ref, judgmentPrefix) {
+		return nil, fmt.Errorf("not a judgment receipt reference")
+	}
+	path, digest, ok := strings.Cut(strings.TrimPrefix(ref, judgmentPrefix), "#sha256=")
+	if !ok || !verdictcheck.ValidDigest(digest) {
+		return nil, fmt.Errorf("invalid receipt reference digest")
+	}
+	b, err := privateRead(root, path)
+	if err != nil {
+		return nil, err
+	}
+	if Hash(b) != digest {
+		return nil, fmt.Errorf("receipt_digest_mismatch")
+	}
+	return decodeJudgmentReceipt(b)
+}
+
+func readNativeSpan(root string, binding TranscriptBinding) ([]byte, error) {
+	b, err := privateRead(root, binding.Path)
+	if err != nil {
+		return nil, err
+	}
+	if binding.Start < 0 || binding.End <= binding.Start || binding.End > int64(len(b)) {
+		return nil, fmt.Errorf("invalid transcript_span")
+	}
+	if binding.Start > 0 && b[binding.Start-1] != '\n' {
+		return nil, fmt.Errorf("transcript_span must start at native line boundary")
+	}
+	if binding.End < int64(len(b)) && b[binding.End-1] != '\n' {
+		return nil, fmt.Errorf("transcript_span must end at native line boundary")
+	}
+	span := b[binding.Start:binding.End]
+	if Hash(span) != binding.SHA256 {
+		return nil, fmt.Errorf("transcript_digest_mismatch")
+	}
+	return span, nil
+}
+
+func judgmentRoot(root string) (string, error) {
+	if root == "" {
+		return "", fmt.Errorf("missing independently supplied evidence root")
+	}
+	return evidencepath.Validate(root)
+}

--- a/cli/internal/evidence/judgment_test.go
+++ b/cli/internal/evidence/judgment_test.go
@@ -1,0 +1,361 @@
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+type judgmentFixture struct {
+	options                JudgmentOptions
+	receipt                JudgmentReceipt
+	out, transcript, draft string
+}
+
+func newJudgmentFixture(t *testing.T, runtime string) *judgmentFixture {
+	t.Helper()
+	store, manifest := fixture(t)
+	profile := JudgeProfile{ID: "primary", Runtime: runtime, Model: "gpt-test", Family: "openai", Effort: "high"}
+	native := `{"type":"session_meta","payload":{"id":"judge","model":"gpt-test","model_provider":"openai","reasoning_effort":"high"}}
+{"type":"event_msg","payload":{"type":"task_complete"}}
+`
+	if runtime == "claude" {
+		profile.Model, profile.Family, profile.Effort = "claude-test", "anthropic", ""
+		native = `{"type":"system","subtype":"init","session_id":"judge","model":"requested-echo"}
+{"type":"assistant","session_id":"judge","message":{"role":"assistant","model":"claude-test","content":[{"type":"text","text":"PASS"}]}}
+{"type":"result","subtype":"success","is_error":false,"session_id":"judge"}
+`
+	}
+	transcript := filepath.Join(store.EvidenceRoot, "native.jsonl")
+	write(t, transcript, []byte(native))
+	receipt := JudgmentReceipt{
+		Version: "1", Requested: profile, SubjectManifestDigest: manifest.Digest, AcceptanceDigest: Hash([]byte("independent source-support acceptance\n")), AuthorContextID: "author",
+		Transcript: TranscriptBinding{transcript, 0, int64(len(native)), Hash([]byte(native))}, ExitCode: ptr(0), TimedOut: ptr(false), Truncated: ptr(false), CleanupVerified: ptr(true), Omissions: []string{},
+	}
+	return &judgmentFixture{JudgmentOptions{Root: store.Root, EvidenceRoot: store.EvidenceRoot, Manifest: store.SubjectManifest, Intent: store.IntentSource, AuthorContextID: "author", Required: []JudgeProfile{profile}, AllowedProviders: []string{profile.Family}}, receipt, store.EvidenceRoot, transcript, store.Draft}
+}
+
+func (f *judgmentFixture) publish(t *testing.T, mutate func(map[string]any)) {
+	t.Helper()
+	receiptBytes, err := Canonical(f.receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptPath := filepath.Join(f.out, "receipt-"+Hash(receiptBytes)+".json")
+	write(t, receiptPath, receiptBytes)
+	ref := "judgment-receipt:" + receiptPath + "#sha256=" + Hash(receiptBytes)
+	v := draft()
+	v["schema_version"] = "verdict.v2"
+	v["acceptance_digest"] = f.receipt.AcceptanceDigest
+	v["subject_manifest_digest"] = f.receipt.SubjectManifestDigest
+	v["author_context_id"] = "author"
+	v["validator_context_id"] = "judge"
+	v["freshness_attestation"] = map[string]any{"source": "runtime", "attester_identity": "native-launch"}
+	v["evidence_refs"] = []string{ref}
+	if mutate != nil {
+		mutate(v)
+	}
+	digest, err := Digest(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v["artifact_digest"] = digest
+	path := filepath.Join(f.out, digest+".json")
+	writeJSON(t, path, v)
+	f.options.Verdicts = []string{path}
+}
+
+func TestJudgmentsNativeRequiredLegs(t *testing.T) {
+	for _, runtime := range []string{"codex", "claude"} {
+		t.Run(runtime, func(t *testing.T) {
+			f := newJudgmentFixture(t, runtime)
+			f.publish(t, nil)
+			result, err := VerifyJudgments(f.options)
+			if err != nil || !result.Satisfied || len(result.Legs) != 1 || result.Legs[0].Native.Model != f.receipt.Requested.Model {
+				t.Fatalf("result %+v error %v", result, err)
+			}
+		})
+	}
+}
+
+func TestJudgmentsRequiredFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*testing.T, *judgmentFixture)
+		verdict  func(map[string]any)
+		contains string
+	}{
+		{name: "missing leg", mutate: func(_ *testing.T, f *judgmentFixture) {
+			p := f.options.Required[0]
+			p.ID = "second"
+			f.options.Required = append(f.options.Required, p)
+		}, contains: "missing_required_leg"},
+		{name: "requested model substitution", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.Requested.Model = "other" }, contains: "requested_profile_mismatch"},
+		{name: "actual model substitution", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, "gpt-test", "other") }, contains: "runtime_model_mismatch"},
+		{name: "wrong family", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, "openai", "other") }, contains: "runtime_family_mismatch"},
+		{name: "wrong effort", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, "high", "low") }, contains: "runtime_effort_mismatch"},
+		{name: "unknown model", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, `"model":"gpt-test",`, "") }, contains: "identity_unverified"},
+		{name: "reused author", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, `"id":"judge"`, `"id":"author"`) }, contains: "reused_author_context"},
+		{name: "native context substitution", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, `"id":"judge"`, `"id":"different"`) }, contains: "validator_context_mismatch"},
+		{name: "wrong expected author", mutate: func(_ *testing.T, f *judgmentFixture) { f.options.AuthorContextID = "different" }, contains: "author_context_mismatch"},
+		{name: "wrong acceptance", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.AcceptanceDigest = strings.Repeat("a", 64) }, contains: "acceptance_mismatch"},
+		{name: "stale subject", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.SubjectManifestDigest = strings.Repeat("b", 64) }, contains: "subject_mismatch"},
+		{name: "timed out", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.TimedOut = ptr(true) }, contains: "incomplete_runtime"},
+		{name: "missing exit", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.ExitCode = nil }, contains: "incomplete_runtime"},
+		{name: "truncated", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.Truncated = ptr(true) }, contains: "incomplete_runtime"},
+		{name: "cleanup unverified", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.CleanupVerified = ptr(false) }, contains: "incomplete_runtime"},
+		{name: "omitted input", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.Omissions = []string{"subject unread"} }, contains: "omitted_evidence"},
+		{name: "no completion", mutate: func(t *testing.T, f *judgmentFixture) { f.changeTranscript(t, "task_complete", "turn_aborted") }, contains: "native_termination_unverified"},
+		{name: "wrong transcript digest", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.Transcript.SHA256 = strings.Repeat("a", 64) }, contains: "transcript_digest_mismatch"},
+		{name: "wrong span", mutate: func(_ *testing.T, f *judgmentFixture) { f.receipt.Transcript.End++ }, contains: "transcript_span"},
+		{name: "missing receipt", verdict: func(v map[string]any) { v["evidence_refs"] = []string{"unresolvable"} }, contains: "missing_required_leg"},
+		{name: "unchanged failure", verdict: func(v map[string]any) { v["verdict"] = "FAIL" }, contains: "verdict_not_pass"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newJudgmentFixture(t, "codex")
+			if tt.mutate != nil {
+				tt.mutate(t, f)
+			}
+			f.publish(t, tt.verdict)
+			before, err := os.ReadFile(f.options.Verdicts[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := VerifyJudgments(f.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, marshalErr := json.Marshal(result)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			if result.Satisfied || !strings.Contains(string(raw), tt.contains) {
+				t.Fatalf("wanted %s, got %s", tt.contains, raw)
+			}
+			after, err := os.ReadFile(f.options.Verdicts[0])
+			if err != nil || string(before) != string(after) {
+				t.Fatal("verdict was changed")
+			}
+		})
+	}
+}
+
+func (f *judgmentFixture) changeTranscript(t *testing.T, old, new string) {
+	t.Helper()
+	b, err := os.ReadFile(f.transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b = []byte(strings.ReplaceAll(string(b), old, new))
+	write(t, f.transcript, b)
+	f.receipt.Transcript.End = int64(len(b))
+	f.receipt.Transcript.SHA256 = Hash(b)
+}
+
+func TestJudgmentsDeniedBeforeCandidateReads(t *testing.T) {
+	f := newJudgmentFixture(t, "claude")
+	f.options.AllowedProviders = []string{"openai"}
+	f.options.Verdicts = []string{"nonexistent-private-verdict"}
+	f.options.Manifest = "nonexistent-private-manifest"
+	_, err := VerifyJudgments(f.options)
+	if err == nil || !strings.Contains(err.Error(), "provider_denied") {
+		t.Fatalf("expected policy denial before reading candidate: %v", err)
+	}
+}
+
+func TestJudgmentsReceiptsStrictAndBound(t *testing.T) {
+	for _, kind := range []string{"digest", "unknown-field", "duplicate-field", "unsafe-path"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newJudgmentFixture(t, "codex")
+			f.publish(t, nil)
+			receiptBytes, err := Canonical(f.receipt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(f.out, "receipt-"+Hash(receiptBytes)+".json")
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch kind {
+			case "digest":
+				write(t, path, append(b, ' '))
+			case "unknown-field":
+				f.publish(t, func(v map[string]any) {
+					write(t, path, []byte(`{"unknown":true}`))
+					v["evidence_refs"] = []string{"judgment-receipt:" + path + "#sha256=" + Hash([]byte(`{"unknown":true}`))}
+				})
+			case "duplicate-field":
+				f.publish(t, func(v map[string]any) {
+					b = []byte(`{"version":"1","version":"2"}`)
+					write(t, path, b)
+					v["evidence_refs"] = []string{"judgment-receipt:" + path + "#sha256=" + Hash(b)}
+				})
+			case "unsafe-path":
+				f.publish(t, func(v map[string]any) {
+					v["evidence_refs"] = []string{"judgment-receipt:relative.json#sha256=" + Hash(b)}
+				})
+			}
+			result, err := VerifyJudgments(f.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Satisfied {
+				t.Fatalf("accepted %s: %+v", kind, result)
+			}
+		})
+	}
+}
+
+func TestJudgmentsReusedPeerContext(t *testing.T) {
+	f := newJudgmentFixture(t, "codex")
+	f.publish(t, nil)
+	first := f.options.Verdicts[0]
+	p := f.options.Required[0]
+	p.ID = "second"
+	f.options.Required = append(f.options.Required, p)
+	f.receipt.Requested = p
+	f.publish(t, nil)
+	f.options.Verdicts = append(f.options.Verdicts, first)
+	result, err := VerifyJudgments(f.options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if result.Satisfied || !strings.Contains(string(b), "reused_peer_context") {
+		t.Fatalf("%s", b)
+	}
+}
+
+func ExampleJudgmentReceipt() {
+	fmt.Println("judgment-receipt:/private/evidence/receipt.json#sha256=<exact-receipt-byte-hash>")
+	// Output: judgment-receipt:/private/evidence/receipt.json#sha256=<exact-receipt-byte-hash>
+}
+
+func TestJudgmentsClaudeNativeIdentityNotRequestedEcho(t *testing.T) {
+	tests := []struct{ name, old, replacement, want string }{
+		{"actual model differs from request", `"model":"claude-test"`, `"model":"different-model"`, "runtime_model_mismatch"},
+		{"unknown actual with fake text", `"model":"claude-test",`, `"requested_model":"claude-test",`, "identity_unverified"},
+		{"native reused author", `"session_id":"judge"`, `"session_id":"author"`, "reused_author_context"},
+		{"failed result despite successful exit", `"subtype":"success"`, `"subtype":"error_max_turns"`, "native_termination_unverified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newJudgmentFixture(t, "claude")
+			f.changeTranscript(t, tt.old, tt.replacement)
+			f.publish(t, nil)
+			got, err := VerifyJudgments(f.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Satisfied || !strings.Contains(string(raw), tt.want) {
+				t.Fatalf("%s", raw)
+			}
+		})
+	}
+}
+
+func TestJudgmentsRejectsPartialLineAndOutsideRoot(t *testing.T) {
+	f := newJudgmentFixture(t, "codex")
+	native, err := os.ReadFile(f.transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.receipt.Transcript.Start = 1
+	f.receipt.Transcript.SHA256 = Hash(native[1:])
+	f.publish(t, nil)
+	got, err := VerifyJudgments(f.options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Satisfied || !strings.Contains(string(raw), "native line boundary") {
+		t.Fatalf("accepted interior JSON: %s", raw)
+	}
+	f.receipt.Transcript.Start = 0
+	f.receipt.Transcript.SHA256 = Hash(native)
+	outside := filepath.Join(t.TempDir(), "private.jsonl")
+	write(t, outside, native)
+	f.receipt.Transcript.Path = outside
+	f.publish(t, nil)
+	got, err = VerifyJudgments(f.options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err = json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Satisfied || !strings.Contains(string(raw), "authorized root") {
+		t.Fatalf("accepted outside read: %s", raw)
+	}
+}
+
+func TestJudgmentsSymlinkRootAndCanonicalReceipt(t *testing.T) {
+	f := newJudgmentFixture(t, "codex")
+	f.publish(t, nil)
+	alias := filepath.Join(t.TempDir(), "evidence-alias")
+	if err := os.Symlink(f.out, alias); err != nil {
+		t.Fatal(err)
+	}
+	f.options.EvidenceRoot = alias
+	got, err := VerifyJudgments(f.options)
+	if err != nil || !got.Satisfied {
+		t.Fatalf("caller root alias lost file identity: %+v %v", got, err)
+	}
+}
+
+func TestJudgmentsUnknownIdentityIsNeverDiversity(t *testing.T) {
+	f := newJudgmentFixture(t, "codex")
+	f.changeTranscript(t, "gpt-test", "unknown")
+	f.publish(t, nil)
+	got, err := VerifyJudgments(f.options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Satisfied || !strings.Contains(string(raw), "identity_unverified") {
+		t.Fatalf("unknown reported model: %s", raw)
+	}
+	f.options.Required[0].Model = "unknown"
+	if _, err = VerifyJudgments(f.options); err == nil {
+		t.Fatal("caller unknown model satisfied identity")
+	}
+}
+
+func TestJudgmentsRequiredEffortMissingFromNativeReporting(t *testing.T) {
+	f := newJudgmentFixture(t, "claude")
+	f.options.Required[0].Effort = "low"
+	f.receipt.Requested.Effort = "low"
+	f.publish(t, nil)
+	got, err := VerifyJudgments(f.options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Satisfied || !strings.Contains(string(raw), "runtime_effort_mismatch") || got.Legs[0].Native.Model != "claude-test" {
+		t.Fatalf("requested effort was treated as observed: %s", raw)
+	}
+}

--- a/cli/internal/evidence/judgment_types.go
+++ b/cli/internal/evidence/judgment_types.go
@@ -1,0 +1,77 @@
+package evidence
+
+import "github.com/boshu2/agentops/cli/internal/parser"
+
+// JudgeProfile is supplied independently by the consumer, never selected by a
+// verdict or receipt. An empty effort imposes no actual-effort requirement;
+// a nonempty effort requires runtime reporting, not a launch-option echo.
+type JudgeProfile struct {
+	ID      string `json:"id"`
+	Runtime string `json:"runtime"`
+	Model   string `json:"model"`
+	Family  string `json:"family"`
+	Effort  string `json:"effort"`
+}
+
+// TranscriptBinding points to exact native invocation bytes. SHA256 covers the
+// selected [Start,End) span without normalization, not reconstructed JSON.
+type TranscriptBinding struct {
+	Path   string `json:"path"`
+	Start  int64  `json:"start"`
+	End    int64  `json:"end"`
+	SHA256 string `json:"sha256"`
+}
+
+// JudgmentReceipt is an external, caller/runtime-authored receipt referenced by
+// verdict.v2 evidence_refs. It adds no fields to verdict.v2. The verifier
+// independently parses model/context/termination from Transcript; it never
+// treats Requested or a model-authored identity claim as an actual identity.
+type JudgmentReceipt struct {
+	Version               string            `json:"version"`
+	Requested             JudgeProfile      `json:"requested"`
+	SubjectManifestDigest string            `json:"subject_manifest_digest"`
+	AcceptanceDigest      string            `json:"acceptance_digest"`
+	AuthorContextID       string            `json:"author_context_id"`
+	Transcript            TranscriptBinding `json:"transcript"`
+	ExitCode              *int              `json:"exit_code"`
+	TimedOut              *bool             `json:"timed_out"`
+	Truncated             *bool             `json:"truncated"`
+	CleanupVerified       *bool             `json:"cleanup_verified"`
+	Omissions             []string          `json:"omissions"`
+}
+
+// JudgmentOptions separates the consumer's expected subject, immutable intent,
+// author, required profiles and provider access policy from candidate evidence.
+// The helper is a local reader: it never transmits bytes or authorizes a model
+// launch. The invoking runtime must enforce disclosure policy before dispatch.
+type JudgmentOptions struct {
+	Root             string
+	EvidenceRoot     string
+	Manifest         string
+	BaseManifest     string
+	Intent           string
+	AuthorContextID  string
+	Required         []JudgeProfile
+	AllowedProviders []string
+	Verdicts         []string
+}
+
+type JudgmentLeg struct {
+	ID          string                  `json:"id"`
+	Satisfied   bool                    `json:"satisfied"`
+	VerdictPath string                  `json:"verdict_path,omitempty"`
+	Verdict     string                  `json:"verdict,omitempty"`
+	ReceiptRef  string                  `json:"receipt_ref,omitempty"`
+	Native      *parser.RuntimeMetadata `json:"native,omitempty"`
+	Problems    []string                `json:"problems"`
+}
+
+// JudgmentResult describes mechanical coverage only. All original verdicts and
+// their evidence files remain unchanged; Satisfied is not a new semantic PASS.
+type JudgmentResult struct {
+	Satisfied             bool          `json:"satisfied"`
+	SubjectManifestDigest string        `json:"subject_manifest_digest"`
+	AcceptanceDigest      string        `json:"acceptance_digest"`
+	Legs                  []JudgmentLeg `json:"legs"`
+	Problems              []string      `json:"problems"`
+}

--- a/cli/internal/parser/runtime.go
+++ b/cli/internal/parser/runtime.go
@@ -1,0 +1,169 @@
+package parser
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/boshu2/agentops/cli/internal/verdictcheck"
+)
+
+// RuntimeSpan identifies exact bytes in the supplied native JSONL span. Offsets
+// are zero-based, end-exclusive; newlines are included, never normalized.
+type RuntimeSpan struct {
+	Start  int64  `json:"start"`
+	End    int64  `json:"end"`
+	SHA256 string `json:"sha256"`
+	Kind   string `json:"kind"`
+}
+
+// RuntimeMetadata reports native envelope facts only, never assistant text.
+// A model absent from runtime reporting stays unknown even when launch options,
+// Claude's init event or Codex turn_context repeat the requested model.
+type RuntimeMetadata struct {
+	Model       string        `json:"model"`
+	ContextID   string        `json:"context_id"`
+	Provider    string        `json:"provider"`
+	Effort      string        `json:"effort"`
+	Completed   bool          `json:"completed"`
+	Termination string        `json:"termination"`
+	Spans       []RuntimeSpan `json:"spans"`
+}
+
+type runtimeEnvelope struct {
+	Type            string `json:"type"`
+	Subtype         string `json:"subtype"`
+	SessionID       string `json:"sessionId"`
+	NativeSessionID string `json:"session_id"`
+	IsError         *bool  `json:"is_error"`
+	Message         *struct {
+		Role  string `json:"role"`
+		Model string `json:"model"`
+	} `json:"message"`
+	Payload struct {
+		Type     string `json:"type"`
+		ID       string `json:"id"`
+		Model    string `json:"model"`
+		Provider string `json:"model_provider"`
+		Effort   string `json:"reasoning_effort"`
+	} `json:"payload"`
+}
+
+// ParseRuntime is the strict metadata seam beside Parse's tolerant content
+// reader. It rejects malformed/duplicate JSON and conflicting native identities
+// across the complete supplied invocation span. It does not parse nested text
+// as an envelope or infer actual model identity from requested configuration.
+func (p *Parser) ParseRuntime(payload []byte, runtime string) (*RuntimeMetadata, error) {
+	if runtime != "codex" && runtime != "claude" {
+		return nil, fmt.Errorf("unsupported native runtime %q", runtime)
+	}
+	result := &RuntimeMetadata{Spans: []RuntimeSpan{}}
+	offset := int64(0)
+	for _, line := range bytes.SplitAfter(payload, []byte("\n")) {
+		end := offset + int64(len(line))
+		if len(bytes.TrimSpace(line)) != 0 {
+			observed, kind, err := nativeObservation(line, runtime)
+			if err != nil {
+				return nil, fmt.Errorf("native transcript at byte %d: %w", offset, err)
+			}
+			if kind != "" {
+				if err = mergeRuntime(result, observed); err != nil {
+					return nil, err
+				}
+				sum := sha256.Sum256(line)
+				result.Spans = append(result.Spans, RuntimeSpan{offset, end, hex.EncodeToString(sum[:]), kind})
+			}
+		}
+		offset = end
+	}
+	return result, nil
+}
+
+func nativeObservation(line []byte, runtime string) (RuntimeMetadata, string, error) {
+	if _, err := verdictcheck.DecodeObject(line); err != nil {
+		return RuntimeMetadata{}, "", err
+	}
+	var row runtimeEnvelope
+	if err := json.Unmarshal(line, &row); err != nil {
+		return RuntimeMetadata{}, "", err
+	}
+	if runtime == "claude" {
+		return claudeObservation(row)
+	}
+	return codexObservation(row)
+}
+
+func claudeObservation(row runtimeEnvelope) (RuntimeMetadata, string, error) {
+	obs := RuntimeMetadata{}
+	if row.SessionID != "" && row.NativeSessionID != "" && row.SessionID != row.NativeSessionID {
+		return obs, "", fmt.Errorf("conflicting native session IDs")
+	}
+	obs.ContextID = coalesce(row.NativeSessionID, row.SessionID)
+	switch {
+	case row.Type == "assistant" && row.Message != nil && row.Message.Role == "assistant":
+		obs.Model = row.Message.Model
+		obs.Provider = "anthropic"
+		return obs, "assistant.message.model", nil
+	case row.Type == "system" && row.Subtype == "init":
+		return obs, "system.init.session_id", nil
+	case row.Type == "result":
+		obs.Completed = row.Subtype == "success" && row.IsError != nil && !*row.IsError
+		obs.Termination = row.Subtype
+		if obs.Termination == "" {
+			obs.Termination = "unknown"
+		}
+		return obs, "result", nil
+	default:
+		return RuntimeMetadata{}, "", nil
+	}
+}
+
+func codexObservation(row runtimeEnvelope) (RuntimeMetadata, string, error) {
+	obs := RuntimeMetadata{}
+	switch {
+	case row.Type == "session_meta":
+		obs.ContextID = row.Payload.ID
+		obs.Model = row.Payload.Model
+		obs.Provider = row.Payload.Provider
+		obs.Effort = row.Payload.Effort
+		return obs, "session_meta.payload", nil
+	case row.Type == "event_msg" && row.Payload.Type == "task_complete":
+		obs.Completed = true
+		obs.Termination = "task_complete"
+		return obs, "event_msg.task_complete", nil
+	case row.Type == "event_msg" && (row.Payload.Type == "turn_aborted" || row.Payload.Type == "error"):
+		obs.Termination = row.Payload.Type
+		return obs, "event_msg.termination", nil
+	default:
+		return obs, "", nil
+	}
+}
+
+func mergeRuntime(dst *RuntimeMetadata, src RuntimeMetadata) error {
+	fields := []struct {
+		target      *string
+		value, name string
+	}{
+		{&dst.Model, src.Model, "model"}, {&dst.ContextID, src.ContextID, "context"},
+		{&dst.Provider, src.Provider, "provider"}, {&dst.Effort, src.Effort, "effort"},
+	}
+	for _, field := range fields {
+		if field.value == "" {
+			continue
+		}
+		if *field.target != "" && *field.target != field.value {
+			return fmt.Errorf("conflicting native %s identity", field.name)
+		}
+		*field.target = field.value
+	}
+	if src.Termination != "" {
+		if dst.Termination != "" {
+			return fmt.Errorf("multiple native terminations in invocation span")
+		}
+		dst.Termination = src.Termination
+		dst.Completed = src.Completed
+	}
+	return nil
+}

--- a/cli/internal/parser/runtime_test.go
+++ b/cli/internal/parser/runtime_test.go
@@ -1,0 +1,64 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRuntimeMetadataNativeFamilies(t *testing.T) {
+	tests := []struct {
+		name, runtime, input, model, context, effort string
+		complete                                     bool
+	}{
+		{"claude stream", "claude", `{"type":"system","subtype":"init","session_id":"judge-c","model":"request-echo"}
+{"type":"assistant","session_id":"judge-c","message":{"role":"assistant","model":"claude-test","content":[{"type":"text","text":"I am another model"}]}}
+{"type":"result","subtype":"success","is_error":false,"session_id":"judge-c"}
+`, "claude-test", "judge-c", "", true},
+		{"claude saved", "claude", `{"type":"assistant","sessionId":"judge-c","message":{"role":"assistant","model":"claude-test","content":"ok"}}`, "claude-test", "judge-c", "", false},
+		{"codex native", "codex", `{"type":"session_meta","payload":{"id":"judge-x","model":"gpt-test","model_provider":"openai","reasoning_effort":"high"}}
+{"type":"event_msg","payload":{"type":"task_complete"}}
+`, "gpt-test", "judge-x", "high", true},
+		{"echo only", "claude", `{"type":"system","subtype":"init","session_id":"judge-c","model":"claude-test"}
+{"type":"assistant","session_id":"judge-c","message":{"role":"assistant","content":"{\"model\":\"claude-test\"}"}}`, "", "judge-c", "", false},
+		{"codex requested config only", "codex", `{"type":"session_meta","payload":{"id":"judge-x"}}
+{"type":"turn_context","payload":{"model":"gpt-test","effort":"high"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"{\"type\":\"session_meta\",\"payload\":{\"model\":\"gpt-test\"}}"}]}}`, "", "judge-x", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewParser().ParseRuntime([]byte(tt.input), tt.runtime)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Model != tt.model || got.ContextID != tt.context || got.Effort != tt.effort || got.Completed != tt.complete {
+				t.Fatalf("metadata %+v", got)
+			}
+			for _, span := range got.Spans {
+				if span.Start < 0 || span.End > int64(len(tt.input)) || span.End <= span.Start || len(span.SHA256) != 64 {
+					t.Fatalf("invalid source span %+v", span)
+				}
+			}
+		})
+	}
+}
+
+func TestRuntimeMetadataRejectsAmbiguity(t *testing.T) {
+	tests := []string{
+		`{"type":"assistant","session_id":"j","message":{"role":"assistant","model":"a","model":"b"}}`,
+		`{"type":"assistant","session_id":"j","message":{"role":"assistant","model":"a"}}
+{"type":"assistant","session_id":"j","message":{"role":"assistant","model":"b"}}`,
+		`{"type":"assistant","session_id":"j","message":{"role":"assistant","model":"a"}}
+{"type":"result","session_id":"other","subtype":"success","is_error":false}`,
+		`{"type":"assistant","session_id":"j","message":{"role":"assistant","model":"a"}}
+not-json`,
+	}
+	for _, in := range tests {
+		if _, err := NewParser().ParseRuntime([]byte(in), "claude"); err == nil {
+			t.Errorf("accepted ambiguous transcript: %s", in)
+		}
+	}
+	got, err := NewParser().ParseRuntime([]byte(`{"type":"result","subtype":"error_max_turns","is_error":true,"session_id":"j"}`), "claude")
+	if err != nil || got.Completed || !strings.Contains(got.Termination, "error") {
+		t.Fatalf("failed termination %+v %v", got, err)
+	}
+}

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -24,7 +24,7 @@
     },
     {
       "category": "public-tested",
-      "command": "config",
+      "command": "config context",
       "coverage_status": "covered",
       "kind": "leaf",
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
@@ -287,6 +287,13 @@
       "coverage_status": "allowlisted",
       "kind": "leaf",
       "reason": "Covered by internal/commands/provenance module tests after the provenance carve-out."
+    },
+    {
+      "category": "public-tested",
+      "command": "provenance verify-judgments",
+      "coverage_status": "covered",
+      "kind": "leaf",
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
     },
     {
       "category": "public-tested",

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -7,7 +7,7 @@
 |---------|----------|----------|--------|
 | `ao capabilities` | `public-tested` | `allowlisted` | Covered by capability contract tests. |
 | `ao completion` | `public-tested` | `allowlisted` | Framework completion root has focused generation tests. |
-| `ao config` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao config context` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao demo` | `manual-only` | `allowlisted` | Interactive demonstration requires a TTY. |
 | `ao doctor capabilities` | `public-stateful-fixture-needed` | `allowlisted` | Inspects local installation state. |
 | `ao doctor diff` | `public-stateful-fixture-needed` | `allowlisted` | Compares local installation state. |
@@ -45,6 +45,7 @@
 | `ao provenance store-verdict` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance trace` | `public-tested` | `allowlisted` | Covered by internal/commands/provenance module tests after the provenance carve-out. |
 | `ao provenance verify` | `public-tested` | `allowlisted` | Covered by internal/commands/provenance module tests after the provenance carve-out. |
+| `ao provenance verify-judgments` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance verify-manifest` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance verify-subject` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance verify-verdict` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=18 sub=52 all=70"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=18 sub=54 all=72"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,5} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "18" || "$sub_count" != "52" || "$all_count" != "70" ]]; then
+if [[ "$top_count" != "18" || "$sub_count" != "54" || "$all_count" != "72" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,5} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 70 ]]; then
+if [[ "${#commands[@]}" -ne 72 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/images/gemini/skills/agent-native/SKILL.md
+++ b/images/gemini/skills/agent-native/SKILL.md
@@ -97,3 +97,7 @@ adapters. Use them only when the caller selected that execution shape. A
 single local agent pays no factory coordination cost. Model identity, when
 recorded, is a declared runtime fact like context identity — see
 [references/model-dispatch.md](references/model-dispatch.md).
+
+[Native judgment receipts](references/judgment-receipts.md) defines exact private
+receipt references and the independent profile/subject/acceptance checks for
+caller-required model diversity. Missing native identity never satisfies a leg.

--- a/images/gemini/skills/agent-native/references/judgment-receipts.md
+++ b/images/gemini/skills/agent-native/references/judgment-receipts.md
@@ -1,0 +1,120 @@
+# Native judgment receipt references
+
+A consumer can check caller-selected judge profiles with
+`ao provenance verify-judgments`. This is a mechanical reader over the existing
+`verdict.v2` contract; Validate remains the semantic author. It neither launches
+judges nor chooses a strategy, provider, retry, budget or delivery transition.
+
+Before dispatch or source retrieval, the caller resolves task, source owner,
+model/provider and destination authorization. Required diversity cannot grant
+access to a denied provider. The native runtime must enforce that policy before
+transmission; a local verifier cannot retract an unauthorized dispatch. Pass the
+independently authorized providers separately from the required profile file.
+The generic reader does not resolve configuration; callers supply its inputs.
+
+## Independent inputs
+
+Freeze the expected subject manifest, immutable acceptance file, author context,
+required profiles and authorized provider list outside the candidate's control.
+Every required leg must concern that exact subject **and** acceptance. Two valid
+PASS verdicts over the same bytes for different purposes are not interchangeable.
+For example, factual support cannot stand in for permission to disclose a page.
+
+The required profile file is a strict JSON object:
+
+```json
+{"profiles":[{"id":"other-family","runtime":"claude","model":"claude-example","family":"anthropic","effort":""}]}
+```
+
+Use an exact model ID, not an alias that can silently resolve to another model.
+Supported runtime/family pairs are `codex`/`openai` and `claude`/`anthropic`.
+Profile IDs must be distinct. An empty effort imposes no actual-effort requirement.
+A nonempty effort requires that exact effort in runtime reporting; a requested
+option alone does not prove actual effort. Missing native reporting remains an
+honest limitation, even when the model and context can be verified.
+
+## Receipt in existing evidence_refs
+
+The caller/runtime records one immutable receipt in protected non-Git evidence
+storage. A verdict cites it through an ordinary top-level `evidence_refs` string:
+
+```text
+judgment-receipt:/absolute/private/evidence/receipt.json#sha256=<SHA256-of-exact-receipt-bytes>
+```
+
+No model, provider, effort or receipt fields are added to `verdict.v2`. Its own
+content-addressed artifact remains unchanged, including FAIL, NOT_PROVEN,
+findings, omissions and freshness attestation. There is no receipt-to-verdict
+backreference or digest cycle: the verdict binds the receipt's bytes.
+
+The receipt's strict version-1 shape is:
+
+```json
+{
+  "version": "1",
+  "requested": {"id":"other-family","runtime":"claude","model":"claude-example","family":"anthropic","effort":""},
+  "subject_manifest_digest": "<expected-subject-manifest-digest>",
+  "acceptance_digest": "<SHA256-of-exact-expected-acceptance-bytes>",
+  "author_context_id": "<observed-author-context>",
+  "transcript": {"path":"/absolute/private/evidence/native.jsonl","start":0,"end":1234,"sha256":"<SHA256-of-exact-selected-native-bytes>"},
+  "exit_code": 0,
+  "timed_out": false,
+  "truncated": false,
+  "cleanup_verified": true,
+  "omissions": []
+}
+```
+
+Capture the complete invocation span, including native identity and terminal
+events. `start` and `end` are zero-based, end-exclusive byte offsets; both must
+be native JSONL line boundaries (the file end may lack a trailing newline).
+Hash the exact span, preserving CRLF, whitespace and final-newline presence.
+Never select only a favorable response from a run that changed model/context or
+terminated unsuccessfully. Record withheld/unread required input, incomplete
+output and every other omission. Nonempty omissions cannot satisfy the leg.
+Raw thinking content is not needed in reports; metadata span references suffice.
+
+The verifier reopens the transcript and parses native envelope fields. It never
+trusts a receipt-authored actual-model string, requested profile echo or JSON
+inside assistant/tool text. Claude `assistant.message.model` plus native
+`session_id`/`sessionId` supplies the reported identity; `system.init.model`
+is a requested configuration echo. Codex `session_meta.payload.model`,
+`model_provider`, `id` and optional `reasoning_effort` supply metadata when
+present. `turn_context` configuration and model self-description do not establish
+actual identity. Codex versions without native model reporting remain
+`identity_unverified`; do not guess their model from a command or filename.
+
+Successful native termination requires Claude `result` with `subtype: success`
+and `is_error: false`, or Codex `event_msg` with `payload.type: task_complete`.
+A saved content-only transcript without a terminal event cannot establish
+completion. Exit zero alone, a timed-out partial result or a clean process tree
+cannot replace the native terminal event. Native fields attest available runtime
+reporting; they do not cryptographically prove provider weights, an untampered
+recorder, complete source coverage or context isolation. Caller/runtime freshness
+attestation remains necessary alongside observed distinct context identities.
+
+## Verify required coverage
+
+```sh
+ao provenance verify-judgments \
+  --root "$SUBJECT_ROOT" --manifest "$MANIFEST" --intent "$EXPECTED_INTENT" \
+  --author-context-id "$AUTHOR_CONTEXT" --evidence-root "$EVIDENCE_ROOT" \
+  --required-profiles "$REQUIRED_PROFILES" --allowed-provider anthropic \
+  --verdict "$VERDICT"
+```
+
+Repeat `--verdict` for supplied legs and `--allowed-provider` for independently
+authorized providers. The existing private non-Git evidence root confines
+candidate-selected receipt, transcript and verdict reads. Files must be private
+regular files; paths cannot escape the root through symlinks. Reads are bounded
+to 16 MiB per file. Malformed/duplicate JSON, altered receipt or transcript bytes,
+invalid spans and unsupported helper versions fail closed before being relied on.
+
+The result lists each required leg, the unchanged supplied verdict, parsed native
+facts and exact source spans, and any mismatches or missing coverage. Unknown
+identity, wrong model/family/required effort, stale subject, wrong acceptance,
+reused author/peer context, timeout, truncation or unverified cleanup leaves
+`satisfied: false` with exit 1. An unavailable required leg remains missing;
+never swap it for another family or remove it without caller authority.
+Exit 0 and `satisfied: true` establish mechanical matching of the supplied PASS
+legs, not a new semantic judgment or a majority vote. Preserve disagreement.

--- a/images/gemini/skills/agent-native/references/model-dispatch.md
+++ b/images/gemini/skills/agent-native/references/model-dispatch.md
@@ -117,7 +117,16 @@ For a caller-selected Fable profile, the native command is:
 claude --print --model claude-fable-5-1 --effort xhigh
 ```
 
-This is the command supplied to a native bounded invocation, not a standalone
+This is one caller-selected profile, not a mandatory model pin. Select another
+authorized capable Claude profile when requested. For native model evidence,
+request `--output-format stream-json --verbose`; preserve assistant-envelope
+model/context fields and the terminal result, not just rendered text. Inspect the
+installed CLI contract before choosing flags. An authorized public/toy read can
+use native safe-mode/restricted controls with tools, customizations, MCP and
+session persistence disabled when the installed runtime supports them. Those
+controls and cleared toy bytes do not establish restricted-source isolation.
+
+The command is supplied to a native bounded invocation, not a standalone
 unbounded shell recipe. Before starting it, the native runtime must:
 
 1. Freeze exact authorized input and subject/acceptance identities; declare
@@ -149,8 +158,12 @@ shipped runner, or relax specialist provider-name guards.
 A successful prompt send proves transport, not engagement. Output bytes, exit
 zero, a terminated process and clean cleanup prove only those facts. Only fresh
 Validate can judge acceptance and persist `verdict.v2` when requested. Keep
-model/context identities in evidence references and freshness attestation notes;
-no verdict schema change is required and these attestations are not
+model/context identities in [native judgment receipt references](judgment-receipts.md)
+and freshness attestation notes. `ao provenance verify-judgments` compares all
+caller-required profiles with exact native transcript spans, independently
+supplied subject and acceptance, actual termination and omissions. Requested
+profile echo or unknown native identity cannot satisfy required diversity.
+No verdict schema change is required, and these attestations are not
 cryptographic proof of independence.
 
 Both required legs must pass the same exact subject for convergence. A split

--- a/images/gemini/skills/bootstrap/SKILL.md
+++ b/images/gemini/skills/bootstrap/SKILL.md
@@ -82,6 +82,12 @@ the local evidence and verdict directories (`.agents/ao/**`). `ao session
 bootstrap` is a read-only session command that reports which local orientation
 files are present. This skill invokes neither.
 
+For selected CDLC, the caller resolves existing external storage through the
+[context-routing reference](references/context-routing.md). Bootstrap never
+creates a consumer project config or replacement knowledge/withdrawal source.
+New CDLC proof uses the explicitly selected external evidence root; the local
+verdict-directory recipe above applies to caller-requested standalone proof.
+
 ## Non-goals
 
 - installing or invoking `ao`, `br`, `bd`, NTM, Agent Mail, or another runtime;
@@ -101,3 +107,4 @@ failed writes, and validation observations. Do not include a next action.
 - [Product](../product/SKILL.md)
 - [Documentation](../doc/SKILL.md)
 - [Examples](references/examples.md)
+- [External context routes](references/context-routing.md)

--- a/images/gemini/skills/bootstrap/references/context-routing.md
+++ b/images/gemini/skills/bootstrap/references/context-routing.md
@@ -1,0 +1,169 @@
+# Explicit external context routes
+
+The caller selects CDLC storage in an existing home config or an explicitly
+selected file. Bootstrap creates neither a project config nor a bundle, staging
+directory, evidence directory or maintenance anchor by default. Existing project
+configuration remains readable. This reference describes the caller's separate
+read-only `ao config context` operation; it does not add a Bootstrap setup step.
+
+## Configuration and identity
+
+`context` has no defaults and never consumes `paths.learnings_dir`. Every key
+below is a string. Existing precedence applies: invocation overrides,
+`AGENTOPS_CONTEXT_<UPPERCASE_KEY>`, project `.agents/ao/config.yaml`, home
+`~/.agents/ao/config.yaml`. `AGENTOPS_CONFIG` / `--config` selects **only** that
+file, excluding ambient home and project files. Missing explicit files and
+malformed/unreadable route configuration fail closed. No command writes config.
+
+```yaml
+context:
+  source_id: /srv/fixture/native/.beads
+  project_id: fixture-native-project-id
+  owner_scope: fixture-personal
+  bundle_id: fixture-bundle-id
+  bundle_root: /srv/fixture/knowledge
+  evidence_root: /srv/fixture/evidence
+  staging_root: /srv/fixture/staging
+  access_policy_ref: /srv/fixture/policy.json
+  owner_policy_ref: /srv/fixture/owner-policy.md
+  task_policy_ref: /srv/fixture/task-policy.md
+  model_policy_ref: /srv/fixture/model-policy.md
+  destination_policy_ref: /srv/fixture/destination-policy.md
+  maintenance_work_ref: fixture-maintenance-anchor
+```
+
+These are synthetic locators, not installation defaults. `source_id` names the
+canonical `beads_dir` returned by the selected native `bd context --json`;
+`project_id` is its native project identity. `owner_scope` is independently
+supplied by the caller, never inferred from the repository basename. Clones,
+worktrees, personal, employer and customer contexts do not merge implicitly.
+All roots and policy files must already exist. Policy roots name canonical
+absolute paths; an alias in the policy cannot silently retarget permission.
+
+The independently selected access-policy JSON has these required fields:
+
+```json
+{
+  "schema_version": 1,
+  "source_id": "/srv/fixture/native/.beads",
+  "project_id": "fixture-native-project-id",
+  "owner_scope": "fixture-personal",
+  "task_ref": "fixture-task",
+  "model_ref": "fixture-provider/model",
+  "destination_ref": "fixture-private-destination",
+  "bundle_id": "fixture-bundle-id",
+  "bundle_root": "/srv/fixture/knowledge",
+  "evidence_root": "/srv/fixture/evidence",
+  "staging_root": "/srv/fixture/staging",
+  "owner_policy_ref": "/srv/fixture/owner-policy.md",
+  "task_policy_ref": "/srv/fixture/task-policy.md",
+  "model_policy_ref": "/srv/fixture/model-policy.md",
+  "destination_policy_ref": "/srv/fixture/destination-policy.md",
+  "maintenance_work_ref": "fixture-maintenance-anchor"
+}
+```
+
+Unknown, duplicate, missing or incompatible policy fields are errors. The
+selected policy and supplied purpose are checked before private anchor comments
+are read. The individual policy references must resolve to existing regular
+files; this command selects and checks their locators, not their prose or native
+permission enforcement. It always reports `access_enforcement: not_attested`.
+T39 owns measured native enforcement; this route result grants no new access,
+model transmission, disclosure or Git ingestion permission.
+
+Both evidence and staging must be external to the bundle, the explicitly named
+consumer checkout, each other, ordinary/bare/linked Git repositories and active
+Git storage bindings. Filesystem identities and symlink resolution prevent
+aliases from bypassing these boundaries. As with the shared evidence helper,
+ancestry cannot discover an unmarked directory referenced as external storage
+by an unrelated repository. Declare those known external roots through the
+active Git bindings before use; the check is not a global reverse-reference
+inventory or protection against concurrent hostile path replacement.
+
+## Read-only lookup and recovery
+
+```sh
+ao config context \
+  --source-id /srv/fixture/native/.beads \
+  --project-id fixture-native-project-id \
+  --owner-scope fixture-personal \
+  --task-ref fixture-task \
+  --model-ref fixture-provider/model \
+  --destination-ref fixture-private-destination \
+  --consumer-root /srv/fixture/consumer \
+  --native-directory /srv/fixture/native
+```
+
+The result reports canonical paths, each field's configuration source, native
+comment count and typed anchor facts. `--field evidence_root`, `--field
+staging_root` or `--field bundle_root` emits one checked path. The caller passes
+that result explicitly to its existing consumer, for example the evidence
+root to `ao provenance snapshot-intent --source <intent-file> --evidence-root
+<resolved-root> --exclude-git-root <consumer> --exclude-git-root <bundle>`.
+The generic evidence helper retains its own final path checks and caller-owned
+standalone proof placement. Lookup itself writes no files, indexes or objects.
+
+Before relying on a route, the owner stores its permitted recovery locators in
+the **same existing native maintenance anchor** as a JSON comment:
+
+```json
+{"type":"context.route.v1","fact_id":"route-stable-id","route":{"source_id":"...","project_id":"...","owner_scope":"...","bundle_id":"...","bundle_root":"...","evidence_root":"...","staging_root":"...","access_policy_ref":"...","owner_policy_ref":"...","task_policy_ref":"...","model_policy_ref":"...","destination_policy_ref":"...","maintenance_work_ref":"..."}}
+```
+
+The `route` object contains the complete selected configuration above, with real
+permitted locators supplied by its owner. The owner uses native
+`bd comments add ANCHOR -f FILE --json`, then directly reads it back. The config
+command never appends comments. Multiple incompatible route facts fail closed;
+timestamps do not choose a winner.
+
+After config loss, supply the same invocation purpose plus `--recover
+--access-policy-ref <existing-policy> --maintenance-work-ref <known-anchor>`.
+The selected policy independently binds that anchor. Recovery fills only
+missing route values from its comment; conflicting owner, source or destination
+values fail. It returns the same bundle and maintenance parent without writing
+replacement config, initializing an empty bundle or creating another anchor.
+Loss of the policy or anchor is unavailable, not permission to start over.
+
+## Native withdrawal and resolution facts
+
+BD 1.2.2 is the presently checked compatibility contract. Its `context` schema is
+1, and native comment `id` and `issue_id` are strings. Lookup first verifies the
+native project/source identity and anchor existence with `show --json`, then
+reads **`bd --readonly comments ANCHOR --json`** directly. It never uses
+`show --include-comments` or child listings to infer absence. Native process,
+missing-anchor, malformed JSON and output-limit errors propagate. The complete
+response limit is 16 MiB; exceeding it is unavailable, never a successful
+truncated read. Other BD versions require renewed native conformance.
+
+Withdrawal comment text:
+
+```json
+{"type":"context.withdrawal.v1","fact_id":"withdrawal-stable-id","bundle_id":"fixture-bundle-id","page_id":"page-id","page_digest":"<64 lowercase SHA256 hex characters>","counterevidence":["<permitted exact source locator>"]}
+```
+
+Resolution comment text:
+
+```json
+{"type":"context.resolution.v1","fact_id":"resolution-stable-id","bundle_id":"fixture-bundle-id","page_id":"page-id","page_digest":"<withdrawn SHA256>","resolves_fact_id":"withdrawal-stable-id","review_ref":"<exact fresh resolution/correction review>","review_digest":"<review SHA256>","successor_digest":"<explicitly covered successor SHA256>"}
+```
+
+A parser success is a fact-shape check, never semantic readmission. T14/T18
+consumers must keep missing, ambiguous or unverified resolution pending. Only a
+matching exact fresh resolution/correction review can cover the withdrawal and
+its named successor. New page bytes, unrelated commits, timestamps, closed or
+deleted investigation children, and knowledge-bundle Git rollback do not clear
+an anchor fact. Native BD/Dolt restoration requires separate reconciliation;
+retain the anchor outside ordinary work retention/GC.
+
+Optional investigation metadata uses flat native keys such as
+`ao.context.bundle_id` and `ao.context.fact_id`, not nested JSON. A native scoped
+query for a closed investigation is `bd --readonly list --all --status closed
+--parent ANCHOR --metadata-field ao.context.fact_id=FACT --limit 0 --json`.
+This query locates work; it never replaces the direct anchor read.
+
+The opt-in installed fixture
+`AO_TEST_BD_NATIVE=1 go test ./internal/commands/config -run TestContextInstalledBDRecovery -count=1 -v`
+creates only synthetic temporary native state. It checks 57 direct comments
+(including a withdrawal after comment 50), a closed investigation, same-anchor
+recovery after deleting only fixture home config, real evidence-root consumption,
+unchanged consumer and knowledge Git bytes, and missing-anchor/source errors.

--- a/images/gemini/skills/codex-exec/SKILL.md
+++ b/images/gemini/skills/codex-exec/SKILL.md
@@ -125,3 +125,11 @@ report. The validator context ID must be distinct from the author's before a
 validator, record model identities per
 the `agent-native` model-dispatch recipe and match the sandbox to
 declared effects.
+
+For caller-required model identity, preserve native session metadata and terminal
+events as well as rendered output. The [judgment receipt convention](../agent-native/references/judgment-receipts.md)
+binds exact transcript byte spans and their SHA-256 through existing
+`evidence_refs`; the consumer supplies expected profiles, subject and acceptance
+independently. A requested model flag, Codex `turn_context` configuration, stdout
+marker or model self-description does not prove actual model identity. Missing
+native reporting stays `identity_unverified` and cannot satisfy a required leg.

--- a/registry.json
+++ b/registry.json
@@ -768,7 +768,7 @@
         "has_skill_md": true,
         "name": "agent-native",
         "path": "skills/agent-native/",
-        "reference_count": 1,
+        "reference_count": 2,
         "tier": "meta"
       },
       {
@@ -826,7 +826,7 @@
         "has_skill_md": true,
         "name": "bootstrap",
         "path": "skills/bootstrap/",
-        "reference_count": 1,
+        "reference_count": 2,
         "tier": "session"
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -375,8 +375,8 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "0a76ac9a1c8e1e9f8a57b943090f70e7e1fd251e9d1aece89b2bd2af08b6a6cb",
-      "generated_hash": "53c18f88fdd399e3de7ec09443cc735bceef878b6d2ec47dd4f763a716d7306c"
+      "source_hash": "82db24856239d7489842a400d273dae6192b8795f908c27884a829336105cd23",
+      "generated_hash": "e17fcecf436bbaab6b863e83a8c94cbc32ff18dfa8a14078e27d949f14ef7f7e"
     },
     {
       "name": "agy-native",
@@ -399,8 +399,8 @@
     {
       "name": "bootstrap",
       "source_skill": "skills/bootstrap",
-      "source_hash": "7bbb26e91b90929ead429d47181151f04c9925936d82b74abaac2c3545f3180d",
-      "generated_hash": "214989d49b68a47d00099e191e567431370be0a0f9ea73b10e83d23ac5ca8277"
+      "source_hash": "2f3a78e812689e4e07de1e8e613a20ed92b0ee9a0b7e547936f8d789e2d4b4ee",
+      "generated_hash": "f81660a56cba892511335859357e95b96ff48a7b0f73b56cfb0d1cc2b9b14657"
     },
     {
       "name": "cass",
@@ -423,8 +423,8 @@
     {
       "name": "codex-exec",
       "source_skill": "skills/codex-exec",
-      "source_hash": "8c84752797e7ffd9405eab523edb0c820d4c047384b9ad9b133f7c26ff1a4a9a",
-      "generated_hash": "0db2993854002bd005ddf1de805bd47f8cf8d857014eebe6b5aba4d9e320b461"
+      "source_hash": "9cdb3302e82aba2b7a8075f469092b6df17d89b56f3053808e08216115d986e3",
+      "generated_hash": "515002e8834b78bb54a52f748aefb2fa199c63b796d57fc8fba3c0539f029e39"
     },
     {
       "name": "converter",

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "0a76ac9a1c8e1e9f8a57b943090f70e7e1fd251e9d1aece89b2bd2af08b6a6cb",
-  "generated_hash": "53c18f88fdd399e3de7ec09443cc735bceef878b6d2ec47dd4f763a716d7306c"
+  "source_hash": "82db24856239d7489842a400d273dae6192b8795f908c27884a829336105cd23",
+  "generated_hash": "e17fcecf436bbaab6b863e83a8c94cbc32ff18dfa8a14078e27d949f14ef7f7e"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -75,3 +75,7 @@ adapters. Use them only when the caller selected that execution shape. A
 single local agent pays no factory coordination cost. Model identity, when
 recorded, is a declared runtime fact like context identity — see
 [references/model-dispatch.md](references/model-dispatch.md).
+
+[Native judgment receipts](references/judgment-receipts.md) defines exact private
+receipt references and the independent profile/subject/acceptance checks for
+caller-required model diversity. Missing native identity never satisfies a leg.

--- a/skills-codex/agent-native/references/judgment-receipts.md
+++ b/skills-codex/agent-native/references/judgment-receipts.md
@@ -1,0 +1,120 @@
+# Native judgment receipt references
+
+A consumer can check caller-selected judge profiles with
+`ao provenance verify-judgments`. This is a mechanical reader over the existing
+`verdict.v2` contract; Validate remains the semantic author. It neither launches
+judges nor chooses a strategy, provider, retry, budget or delivery transition.
+
+Before dispatch or source retrieval, the caller resolves task, source owner,
+model/provider and destination authorization. Required diversity cannot grant
+access to a denied provider. The native runtime must enforce that policy before
+transmission; a local verifier cannot retract an unauthorized dispatch. Pass the
+independently authorized providers separately from the required profile file.
+The generic reader does not resolve configuration; callers supply its inputs.
+
+## Independent inputs
+
+Freeze the expected subject manifest, immutable acceptance file, author context,
+required profiles and authorized provider list outside the candidate's control.
+Every required leg must concern that exact subject **and** acceptance. Two valid
+PASS verdicts over the same bytes for different purposes are not interchangeable.
+For example, factual support cannot stand in for permission to disclose a page.
+
+The required profile file is a strict JSON object:
+
+```json
+{"profiles":[{"id":"other-family","runtime":"claude","model":"claude-example","family":"anthropic","effort":""}]}
+```
+
+Use an exact model ID, not an alias that can silently resolve to another model.
+Supported runtime/family pairs are `codex`/`openai` and `claude`/`anthropic`.
+Profile IDs must be distinct. An empty effort imposes no actual-effort requirement.
+A nonempty effort requires that exact effort in runtime reporting; a requested
+option alone does not prove actual effort. Missing native reporting remains an
+honest limitation, even when the model and context can be verified.
+
+## Receipt in existing evidence_refs
+
+The caller/runtime records one immutable receipt in protected non-Git evidence
+storage. A verdict cites it through an ordinary top-level `evidence_refs` string:
+
+```text
+judgment-receipt:/absolute/private/evidence/receipt.json#sha256=<SHA256-of-exact-receipt-bytes>
+```
+
+No model, provider, effort or receipt fields are added to `verdict.v2`. Its own
+content-addressed artifact remains unchanged, including FAIL, NOT_PROVEN,
+findings, omissions and freshness attestation. There is no receipt-to-verdict
+backreference or digest cycle: the verdict binds the receipt's bytes.
+
+The receipt's strict version-1 shape is:
+
+```json
+{
+  "version": "1",
+  "requested": {"id":"other-family","runtime":"claude","model":"claude-example","family":"anthropic","effort":""},
+  "subject_manifest_digest": "<expected-subject-manifest-digest>",
+  "acceptance_digest": "<SHA256-of-exact-expected-acceptance-bytes>",
+  "author_context_id": "<observed-author-context>",
+  "transcript": {"path":"/absolute/private/evidence/native.jsonl","start":0,"end":1234,"sha256":"<SHA256-of-exact-selected-native-bytes>"},
+  "exit_code": 0,
+  "timed_out": false,
+  "truncated": false,
+  "cleanup_verified": true,
+  "omissions": []
+}
+```
+
+Capture the complete invocation span, including native identity and terminal
+events. `start` and `end` are zero-based, end-exclusive byte offsets; both must
+be native JSONL line boundaries (the file end may lack a trailing newline).
+Hash the exact span, preserving CRLF, whitespace and final-newline presence.
+Never select only a favorable response from a run that changed model/context or
+terminated unsuccessfully. Record withheld/unread required input, incomplete
+output and every other omission. Nonempty omissions cannot satisfy the leg.
+Raw thinking content is not needed in reports; metadata span references suffice.
+
+The verifier reopens the transcript and parses native envelope fields. It never
+trusts a receipt-authored actual-model string, requested profile echo or JSON
+inside assistant/tool text. Claude `assistant.message.model` plus native
+`session_id`/`sessionId` supplies the reported identity; `system.init.model`
+is a requested configuration echo. Codex `session_meta.payload.model`,
+`model_provider`, `id` and optional `reasoning_effort` supply metadata when
+present. `turn_context` configuration and model self-description do not establish
+actual identity. Codex versions without native model reporting remain
+`identity_unverified`; do not guess their model from a command or filename.
+
+Successful native termination requires Claude `result` with `subtype: success`
+and `is_error: false`, or Codex `event_msg` with `payload.type: task_complete`.
+A saved content-only transcript without a terminal event cannot establish
+completion. Exit zero alone, a timed-out partial result or a clean process tree
+cannot replace the native terminal event. Native fields attest available runtime
+reporting; they do not cryptographically prove provider weights, an untampered
+recorder, complete source coverage or context isolation. Caller/runtime freshness
+attestation remains necessary alongside observed distinct context identities.
+
+## Verify required coverage
+
+```sh
+ao provenance verify-judgments \
+  --root "$SUBJECT_ROOT" --manifest "$MANIFEST" --intent "$EXPECTED_INTENT" \
+  --author-context-id "$AUTHOR_CONTEXT" --evidence-root "$EVIDENCE_ROOT" \
+  --required-profiles "$REQUIRED_PROFILES" --allowed-provider anthropic \
+  --verdict "$VERDICT"
+```
+
+Repeat `--verdict` for supplied legs and `--allowed-provider` for independently
+authorized providers. The existing private non-Git evidence root confines
+candidate-selected receipt, transcript and verdict reads. Files must be private
+regular files; paths cannot escape the root through symlinks. Reads are bounded
+to 16 MiB per file. Malformed/duplicate JSON, altered receipt or transcript bytes,
+invalid spans and unsupported helper versions fail closed before being relied on.
+
+The result lists each required leg, the unchanged supplied verdict, parsed native
+facts and exact source spans, and any mismatches or missing coverage. Unknown
+identity, wrong model/family/required effort, stale subject, wrong acceptance,
+reused author/peer context, timeout, truncation or unverified cleanup leaves
+`satisfied: false` with exit 1. An unavailable required leg remains missing;
+never swap it for another family or remove it without caller authority.
+Exit 0 and `satisfied: true` establish mechanical matching of the supplied PASS
+legs, not a new semantic judgment or a majority vote. Preserve disagreement.

--- a/skills-codex/agent-native/references/model-dispatch.md
+++ b/skills-codex/agent-native/references/model-dispatch.md
@@ -117,7 +117,16 @@ For a caller-selected Fable profile, the native command is:
 claude --print --model claude-fable-5-1 --effort xhigh
 ```
 
-This is the command supplied to a native bounded invocation, not a standalone
+This is one caller-selected profile, not a mandatory model pin. Select another
+authorized capable Claude profile when requested. For native model evidence,
+request `--output-format stream-json --verbose`; preserve assistant-envelope
+model/context fields and the terminal result, not just rendered text. Inspect the
+installed CLI contract before choosing flags. An authorized public/toy read can
+use native safe-mode/restricted controls with tools, customizations, MCP and
+session persistence disabled when the installed runtime supports them. Those
+controls and cleared toy bytes do not establish restricted-source isolation.
+
+The command is supplied to a native bounded invocation, not a standalone
 unbounded shell recipe. Before starting it, the native runtime must:
 
 1. Freeze exact authorized input and subject/acceptance identities; declare
@@ -149,8 +158,12 @@ shipped runner, or relax specialist provider-name guards.
 A successful prompt send proves transport, not engagement. Output bytes, exit
 zero, a terminated process and clean cleanup prove only those facts. Only fresh
 Validate can judge acceptance and persist `verdict.v2` when requested. Keep
-model/context identities in evidence references and freshness attestation notes;
-no verdict schema change is required and these attestations are not
+model/context identities in [native judgment receipt references](judgment-receipts.md)
+and freshness attestation notes. `ao provenance verify-judgments` compares all
+caller-required profiles with exact native transcript spans, independently
+supplied subject and acceptance, actual termination and omissions. Requested
+profile echo or unknown native identity cannot satisfy required diversity.
+No verdict schema change is required, and these attestations are not
 cryptographic proof of independence.
 
 Both required legs must pass the same exact subject for convergence. A split

--- a/skills-codex/bootstrap/.agentops-generated.json
+++ b/skills-codex/bootstrap/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/bootstrap",
   "layout": "modular",
-  "source_hash": "7bbb26e91b90929ead429d47181151f04c9925936d82b74abaac2c3545f3180d",
-  "generated_hash": "214989d49b68a47d00099e191e567431370be0a0f9ea73b10e83d23ac5ca8277"
+  "source_hash": "2f3a78e812689e4e07de1e8e613a20ed92b0ee9a0b7e547936f8d789e2d4b4ee",
+  "generated_hash": "f81660a56cba892511335859357e95b96ff48a7b0f73b56cfb0d1cc2b9b14657"
 }

--- a/skills-codex/bootstrap/SKILL.md
+++ b/skills-codex/bootstrap/SKILL.md
@@ -57,6 +57,12 @@ the local evidence and verdict directories (`.agents/ao/**`). `ao session
 bootstrap` is a read-only session command that reports which local orientation
 files are present. This skill invokes neither.
 
+For selected CDLC, the caller resolves existing external storage through the
+[context-routing reference](references/context-routing.md). Bootstrap never
+creates a consumer project config or replacement knowledge/withdrawal source.
+New CDLC proof uses the explicitly selected external evidence root; the local
+verdict-directory recipe above applies to caller-requested standalone proof.
+
 ## Non-goals
 
 - installing or invoking `ao`, `br`, `bd`, NTM, Agent Mail, or another runtime;
@@ -76,3 +82,4 @@ failed writes, and validation observations. Do not include a next action.
 - [Product](../product/SKILL.md)
 - [Documentation](../doc/SKILL.md)
 - [Examples](references/examples.md)
+- [External context routes](references/context-routing.md)

--- a/skills-codex/bootstrap/references/context-routing.md
+++ b/skills-codex/bootstrap/references/context-routing.md
@@ -1,0 +1,169 @@
+# Explicit external context routes
+
+The caller selects CDLC storage in an existing home config or an explicitly
+selected file. Bootstrap creates neither a project config nor a bundle, staging
+directory, evidence directory or maintenance anchor by default. Existing project
+configuration remains readable. This reference describes the caller's separate
+read-only `ao config context` operation; it does not add a Bootstrap setup step.
+
+## Configuration and identity
+
+`context` has no defaults and never consumes `paths.learnings_dir`. Every key
+below is a string. Existing precedence applies: invocation overrides,
+`AGENTOPS_CONTEXT_<UPPERCASE_KEY>`, project `.agents/ao/config.yaml`, home
+`~/.agents/ao/config.yaml`. `AGENTOPS_CONFIG` / `--config` selects **only** that
+file, excluding ambient home and project files. Missing explicit files and
+malformed/unreadable route configuration fail closed. No command writes config.
+
+```yaml
+context:
+  source_id: /srv/fixture/native/.beads
+  project_id: fixture-native-project-id
+  owner_scope: fixture-personal
+  bundle_id: fixture-bundle-id
+  bundle_root: /srv/fixture/knowledge
+  evidence_root: /srv/fixture/evidence
+  staging_root: /srv/fixture/staging
+  access_policy_ref: /srv/fixture/policy.json
+  owner_policy_ref: /srv/fixture/owner-policy.md
+  task_policy_ref: /srv/fixture/task-policy.md
+  model_policy_ref: /srv/fixture/model-policy.md
+  destination_policy_ref: /srv/fixture/destination-policy.md
+  maintenance_work_ref: fixture-maintenance-anchor
+```
+
+These are synthetic locators, not installation defaults. `source_id` names the
+canonical `beads_dir` returned by the selected native `bd context --json`;
+`project_id` is its native project identity. `owner_scope` is independently
+supplied by the caller, never inferred from the repository basename. Clones,
+worktrees, personal, employer and customer contexts do not merge implicitly.
+All roots and policy files must already exist. Policy roots name canonical
+absolute paths; an alias in the policy cannot silently retarget permission.
+
+The independently selected access-policy JSON has these required fields:
+
+```json
+{
+  "schema_version": 1,
+  "source_id": "/srv/fixture/native/.beads",
+  "project_id": "fixture-native-project-id",
+  "owner_scope": "fixture-personal",
+  "task_ref": "fixture-task",
+  "model_ref": "fixture-provider/model",
+  "destination_ref": "fixture-private-destination",
+  "bundle_id": "fixture-bundle-id",
+  "bundle_root": "/srv/fixture/knowledge",
+  "evidence_root": "/srv/fixture/evidence",
+  "staging_root": "/srv/fixture/staging",
+  "owner_policy_ref": "/srv/fixture/owner-policy.md",
+  "task_policy_ref": "/srv/fixture/task-policy.md",
+  "model_policy_ref": "/srv/fixture/model-policy.md",
+  "destination_policy_ref": "/srv/fixture/destination-policy.md",
+  "maintenance_work_ref": "fixture-maintenance-anchor"
+}
+```
+
+Unknown, duplicate, missing or incompatible policy fields are errors. The
+selected policy and supplied purpose are checked before private anchor comments
+are read. The individual policy references must resolve to existing regular
+files; this command selects and checks their locators, not their prose or native
+permission enforcement. It always reports `access_enforcement: not_attested`.
+T39 owns measured native enforcement; this route result grants no new access,
+model transmission, disclosure or Git ingestion permission.
+
+Both evidence and staging must be external to the bundle, the explicitly named
+consumer checkout, each other, ordinary/bare/linked Git repositories and active
+Git storage bindings. Filesystem identities and symlink resolution prevent
+aliases from bypassing these boundaries. As with the shared evidence helper,
+ancestry cannot discover an unmarked directory referenced as external storage
+by an unrelated repository. Declare those known external roots through the
+active Git bindings before use; the check is not a global reverse-reference
+inventory or protection against concurrent hostile path replacement.
+
+## Read-only lookup and recovery
+
+```sh
+ao config context \
+  --source-id /srv/fixture/native/.beads \
+  --project-id fixture-native-project-id \
+  --owner-scope fixture-personal \
+  --task-ref fixture-task \
+  --model-ref fixture-provider/model \
+  --destination-ref fixture-private-destination \
+  --consumer-root /srv/fixture/consumer \
+  --native-directory /srv/fixture/native
+```
+
+The result reports canonical paths, each field's configuration source, native
+comment count and typed anchor facts. `--field evidence_root`, `--field
+staging_root` or `--field bundle_root` emits one checked path. The caller passes
+that result explicitly to its existing consumer, for example the evidence
+root to `ao provenance snapshot-intent --source <intent-file> --evidence-root
+<resolved-root> --exclude-git-root <consumer> --exclude-git-root <bundle>`.
+The generic evidence helper retains its own final path checks and caller-owned
+standalone proof placement. Lookup itself writes no files, indexes or objects.
+
+Before relying on a route, the owner stores its permitted recovery locators in
+the **same existing native maintenance anchor** as a JSON comment:
+
+```json
+{"type":"context.route.v1","fact_id":"route-stable-id","route":{"source_id":"...","project_id":"...","owner_scope":"...","bundle_id":"...","bundle_root":"...","evidence_root":"...","staging_root":"...","access_policy_ref":"...","owner_policy_ref":"...","task_policy_ref":"...","model_policy_ref":"...","destination_policy_ref":"...","maintenance_work_ref":"..."}}
+```
+
+The `route` object contains the complete selected configuration above, with real
+permitted locators supplied by its owner. The owner uses native
+`bd comments add ANCHOR -f FILE --json`, then directly reads it back. The config
+command never appends comments. Multiple incompatible route facts fail closed;
+timestamps do not choose a winner.
+
+After config loss, supply the same invocation purpose plus `--recover
+--access-policy-ref <existing-policy> --maintenance-work-ref <known-anchor>`.
+The selected policy independently binds that anchor. Recovery fills only
+missing route values from its comment; conflicting owner, source or destination
+values fail. It returns the same bundle and maintenance parent without writing
+replacement config, initializing an empty bundle or creating another anchor.
+Loss of the policy or anchor is unavailable, not permission to start over.
+
+## Native withdrawal and resolution facts
+
+BD 1.2.2 is the presently checked compatibility contract. Its `context` schema is
+1, and native comment `id` and `issue_id` are strings. Lookup first verifies the
+native project/source identity and anchor existence with `show --json`, then
+reads **`bd --readonly comments ANCHOR --json`** directly. It never uses
+`show --include-comments` or child listings to infer absence. Native process,
+missing-anchor, malformed JSON and output-limit errors propagate. The complete
+response limit is 16 MiB; exceeding it is unavailable, never a successful
+truncated read. Other BD versions require renewed native conformance.
+
+Withdrawal comment text:
+
+```json
+{"type":"context.withdrawal.v1","fact_id":"withdrawal-stable-id","bundle_id":"fixture-bundle-id","page_id":"page-id","page_digest":"<64 lowercase SHA256 hex characters>","counterevidence":["<permitted exact source locator>"]}
+```
+
+Resolution comment text:
+
+```json
+{"type":"context.resolution.v1","fact_id":"resolution-stable-id","bundle_id":"fixture-bundle-id","page_id":"page-id","page_digest":"<withdrawn SHA256>","resolves_fact_id":"withdrawal-stable-id","review_ref":"<exact fresh resolution/correction review>","review_digest":"<review SHA256>","successor_digest":"<explicitly covered successor SHA256>"}
+```
+
+A parser success is a fact-shape check, never semantic readmission. T14/T18
+consumers must keep missing, ambiguous or unverified resolution pending. Only a
+matching exact fresh resolution/correction review can cover the withdrawal and
+its named successor. New page bytes, unrelated commits, timestamps, closed or
+deleted investigation children, and knowledge-bundle Git rollback do not clear
+an anchor fact. Native BD/Dolt restoration requires separate reconciliation;
+retain the anchor outside ordinary work retention/GC.
+
+Optional investigation metadata uses flat native keys such as
+`ao.context.bundle_id` and `ao.context.fact_id`, not nested JSON. A native scoped
+query for a closed investigation is `bd --readonly list --all --status closed
+--parent ANCHOR --metadata-field ao.context.fact_id=FACT --limit 0 --json`.
+This query locates work; it never replaces the direct anchor read.
+
+The opt-in installed fixture
+`AO_TEST_BD_NATIVE=1 go test ./internal/commands/config -run TestContextInstalledBDRecovery -count=1 -v`
+creates only synthetic temporary native state. It checks 57 direct comments
+(including a withdrawal after comment 50), a closed investigation, same-anchor
+recovery after deleting only fixture home config, real evidence-root consumption,
+unchanged consumer and knowledge Git bytes, and missing-anchor/source errors.

--- a/skills-codex/codex-exec/.agentops-generated.json
+++ b/skills-codex/codex-exec/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/codex-exec",
   "layout": "modular",
-  "source_hash": "8c84752797e7ffd9405eab523edb0c820d4c047384b9ad9b133f7c26ff1a4a9a",
-  "generated_hash": "0db2993854002bd005ddf1de805bd47f8cf8d857014eebe6b5aba4d9e320b461"
+  "source_hash": "9cdb3302e82aba2b7a8075f469092b6df17d89b56f3053808e08216115d986e3",
+  "generated_hash": "515002e8834b78bb54a52f748aefb2fa199c63b796d57fc8fba3c0539f029e39"
 }

--- a/skills-codex/codex-exec/SKILL.md
+++ b/skills-codex/codex-exec/SKILL.md
@@ -97,3 +97,11 @@ report. The validator context ID must be distinct from the author's before a
 validator, record model identities per
 the `agent-native` model-dispatch recipe and match the sandbox to
 declared effects.
+
+For caller-required model identity, preserve native session metadata and terminal
+events as well as rendered output. The [judgment receipt convention](../agent-native/references/judgment-receipts.md)
+binds exact transcript byte spans and their SHA-256 through existing
+`evidence_refs`; the consumer supplies expected profiles, subject and acceptance
+independently. A requested model flag, Codex `turn_context` configuration, stdout
+marker or model self-description does not prove actual model identity. Missing
+native reporting stays `identity_unverified` and cannot satisfy a required leg.

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -97,3 +97,7 @@ adapters. Use them only when the caller selected that execution shape. A
 single local agent pays no factory coordination cost. Model identity, when
 recorded, is a declared runtime fact like context identity — see
 [references/model-dispatch.md](references/model-dispatch.md).
+
+[Native judgment receipts](references/judgment-receipts.md) defines exact private
+receipt references and the independent profile/subject/acceptance checks for
+caller-required model diversity. Missing native identity never satisfies a leg.

--- a/skills/agent-native/references/judgment-receipts.md
+++ b/skills/agent-native/references/judgment-receipts.md
@@ -1,0 +1,120 @@
+# Native judgment receipt references
+
+A consumer can check caller-selected judge profiles with
+`ao provenance verify-judgments`. This is a mechanical reader over the existing
+`verdict.v2` contract; Validate remains the semantic author. It neither launches
+judges nor chooses a strategy, provider, retry, budget or delivery transition.
+
+Before dispatch or source retrieval, the caller resolves task, source owner,
+model/provider and destination authorization. Required diversity cannot grant
+access to a denied provider. The native runtime must enforce that policy before
+transmission; a local verifier cannot retract an unauthorized dispatch. Pass the
+independently authorized providers separately from the required profile file.
+The generic reader does not resolve configuration; callers supply its inputs.
+
+## Independent inputs
+
+Freeze the expected subject manifest, immutable acceptance file, author context,
+required profiles and authorized provider list outside the candidate's control.
+Every required leg must concern that exact subject **and** acceptance. Two valid
+PASS verdicts over the same bytes for different purposes are not interchangeable.
+For example, factual support cannot stand in for permission to disclose a page.
+
+The required profile file is a strict JSON object:
+
+```json
+{"profiles":[{"id":"other-family","runtime":"claude","model":"claude-example","family":"anthropic","effort":""}]}
+```
+
+Use an exact model ID, not an alias that can silently resolve to another model.
+Supported runtime/family pairs are `codex`/`openai` and `claude`/`anthropic`.
+Profile IDs must be distinct. An empty effort imposes no actual-effort requirement.
+A nonempty effort requires that exact effort in runtime reporting; a requested
+option alone does not prove actual effort. Missing native reporting remains an
+honest limitation, even when the model and context can be verified.
+
+## Receipt in existing evidence_refs
+
+The caller/runtime records one immutable receipt in protected non-Git evidence
+storage. A verdict cites it through an ordinary top-level `evidence_refs` string:
+
+```text
+judgment-receipt:/absolute/private/evidence/receipt.json#sha256=<SHA256-of-exact-receipt-bytes>
+```
+
+No model, provider, effort or receipt fields are added to `verdict.v2`. Its own
+content-addressed artifact remains unchanged, including FAIL, NOT_PROVEN,
+findings, omissions and freshness attestation. There is no receipt-to-verdict
+backreference or digest cycle: the verdict binds the receipt's bytes.
+
+The receipt's strict version-1 shape is:
+
+```json
+{
+  "version": "1",
+  "requested": {"id":"other-family","runtime":"claude","model":"claude-example","family":"anthropic","effort":""},
+  "subject_manifest_digest": "<expected-subject-manifest-digest>",
+  "acceptance_digest": "<SHA256-of-exact-expected-acceptance-bytes>",
+  "author_context_id": "<observed-author-context>",
+  "transcript": {"path":"/absolute/private/evidence/native.jsonl","start":0,"end":1234,"sha256":"<SHA256-of-exact-selected-native-bytes>"},
+  "exit_code": 0,
+  "timed_out": false,
+  "truncated": false,
+  "cleanup_verified": true,
+  "omissions": []
+}
+```
+
+Capture the complete invocation span, including native identity and terminal
+events. `start` and `end` are zero-based, end-exclusive byte offsets; both must
+be native JSONL line boundaries (the file end may lack a trailing newline).
+Hash the exact span, preserving CRLF, whitespace and final-newline presence.
+Never select only a favorable response from a run that changed model/context or
+terminated unsuccessfully. Record withheld/unread required input, incomplete
+output and every other omission. Nonempty omissions cannot satisfy the leg.
+Raw thinking content is not needed in reports; metadata span references suffice.
+
+The verifier reopens the transcript and parses native envelope fields. It never
+trusts a receipt-authored actual-model string, requested profile echo or JSON
+inside assistant/tool text. Claude `assistant.message.model` plus native
+`session_id`/`sessionId` supplies the reported identity; `system.init.model`
+is a requested configuration echo. Codex `session_meta.payload.model`,
+`model_provider`, `id` and optional `reasoning_effort` supply metadata when
+present. `turn_context` configuration and model self-description do not establish
+actual identity. Codex versions without native model reporting remain
+`identity_unverified`; do not guess their model from a command or filename.
+
+Successful native termination requires Claude `result` with `subtype: success`
+and `is_error: false`, or Codex `event_msg` with `payload.type: task_complete`.
+A saved content-only transcript without a terminal event cannot establish
+completion. Exit zero alone, a timed-out partial result or a clean process tree
+cannot replace the native terminal event. Native fields attest available runtime
+reporting; they do not cryptographically prove provider weights, an untampered
+recorder, complete source coverage or context isolation. Caller/runtime freshness
+attestation remains necessary alongside observed distinct context identities.
+
+## Verify required coverage
+
+```sh
+ao provenance verify-judgments \
+  --root "$SUBJECT_ROOT" --manifest "$MANIFEST" --intent "$EXPECTED_INTENT" \
+  --author-context-id "$AUTHOR_CONTEXT" --evidence-root "$EVIDENCE_ROOT" \
+  --required-profiles "$REQUIRED_PROFILES" --allowed-provider anthropic \
+  --verdict "$VERDICT"
+```
+
+Repeat `--verdict` for supplied legs and `--allowed-provider` for independently
+authorized providers. The existing private non-Git evidence root confines
+candidate-selected receipt, transcript and verdict reads. Files must be private
+regular files; paths cannot escape the root through symlinks. Reads are bounded
+to 16 MiB per file. Malformed/duplicate JSON, altered receipt or transcript bytes,
+invalid spans and unsupported helper versions fail closed before being relied on.
+
+The result lists each required leg, the unchanged supplied verdict, parsed native
+facts and exact source spans, and any mismatches or missing coverage. Unknown
+identity, wrong model/family/required effort, stale subject, wrong acceptance,
+reused author/peer context, timeout, truncation or unverified cleanup leaves
+`satisfied: false` with exit 1. An unavailable required leg remains missing;
+never swap it for another family or remove it without caller authority.
+Exit 0 and `satisfied: true` establish mechanical matching of the supplied PASS
+legs, not a new semantic judgment or a majority vote. Preserve disagreement.

--- a/skills/agent-native/references/model-dispatch.md
+++ b/skills/agent-native/references/model-dispatch.md
@@ -117,7 +117,16 @@ For a caller-selected Fable profile, the native command is:
 claude --print --model claude-fable-5-1 --effort xhigh
 ```
 
-This is the command supplied to a native bounded invocation, not a standalone
+This is one caller-selected profile, not a mandatory model pin. Select another
+authorized capable Claude profile when requested. For native model evidence,
+request `--output-format stream-json --verbose`; preserve assistant-envelope
+model/context fields and the terminal result, not just rendered text. Inspect the
+installed CLI contract before choosing flags. An authorized public/toy read can
+use native safe-mode/restricted controls with tools, customizations, MCP and
+session persistence disabled when the installed runtime supports them. Those
+controls and cleared toy bytes do not establish restricted-source isolation.
+
+The command is supplied to a native bounded invocation, not a standalone
 unbounded shell recipe. Before starting it, the native runtime must:
 
 1. Freeze exact authorized input and subject/acceptance identities; declare
@@ -149,8 +158,12 @@ shipped runner, or relax specialist provider-name guards.
 A successful prompt send proves transport, not engagement. Output bytes, exit
 zero, a terminated process and clean cleanup prove only those facts. Only fresh
 Validate can judge acceptance and persist `verdict.v2` when requested. Keep
-model/context identities in evidence references and freshness attestation notes;
-no verdict schema change is required and these attestations are not
+model/context identities in [native judgment receipt references](judgment-receipts.md)
+and freshness attestation notes. `ao provenance verify-judgments` compares all
+caller-required profiles with exact native transcript spans, independently
+supplied subject and acceptance, actual termination and omissions. Requested
+profile echo or unknown native identity cannot satisfy required diversity.
+No verdict schema change is required, and these attestations are not
 cryptographic proof of independence.
 
 Both required legs must pass the same exact subject for convergence. A split

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -82,6 +82,12 @@ the local evidence and verdict directories (`.agents/ao/**`). `ao session
 bootstrap` is a read-only session command that reports which local orientation
 files are present. This skill invokes neither.
 
+For selected CDLC, the caller resolves existing external storage through the
+[context-routing reference](references/context-routing.md). Bootstrap never
+creates a consumer project config or replacement knowledge/withdrawal source.
+New CDLC proof uses the explicitly selected external evidence root; the local
+verdict-directory recipe above applies to caller-requested standalone proof.
+
 ## Non-goals
 
 - installing or invoking `ao`, `br`, `bd`, NTM, Agent Mail, or another runtime;
@@ -101,3 +107,4 @@ failed writes, and validation observations. Do not include a next action.
 - [Product](../product/SKILL.md)
 - [Documentation](../doc/SKILL.md)
 - [Examples](references/examples.md)
+- [External context routes](references/context-routing.md)

--- a/skills/bootstrap/references/context-routing.md
+++ b/skills/bootstrap/references/context-routing.md
@@ -1,0 +1,169 @@
+# Explicit external context routes
+
+The caller selects CDLC storage in an existing home config or an explicitly
+selected file. Bootstrap creates neither a project config nor a bundle, staging
+directory, evidence directory or maintenance anchor by default. Existing project
+configuration remains readable. This reference describes the caller's separate
+read-only `ao config context` operation; it does not add a Bootstrap setup step.
+
+## Configuration and identity
+
+`context` has no defaults and never consumes `paths.learnings_dir`. Every key
+below is a string. Existing precedence applies: invocation overrides,
+`AGENTOPS_CONTEXT_<UPPERCASE_KEY>`, project `.agents/ao/config.yaml`, home
+`~/.agents/ao/config.yaml`. `AGENTOPS_CONFIG` / `--config` selects **only** that
+file, excluding ambient home and project files. Missing explicit files and
+malformed/unreadable route configuration fail closed. No command writes config.
+
+```yaml
+context:
+  source_id: /srv/fixture/native/.beads
+  project_id: fixture-native-project-id
+  owner_scope: fixture-personal
+  bundle_id: fixture-bundle-id
+  bundle_root: /srv/fixture/knowledge
+  evidence_root: /srv/fixture/evidence
+  staging_root: /srv/fixture/staging
+  access_policy_ref: /srv/fixture/policy.json
+  owner_policy_ref: /srv/fixture/owner-policy.md
+  task_policy_ref: /srv/fixture/task-policy.md
+  model_policy_ref: /srv/fixture/model-policy.md
+  destination_policy_ref: /srv/fixture/destination-policy.md
+  maintenance_work_ref: fixture-maintenance-anchor
+```
+
+These are synthetic locators, not installation defaults. `source_id` names the
+canonical `beads_dir` returned by the selected native `bd context --json`;
+`project_id` is its native project identity. `owner_scope` is independently
+supplied by the caller, never inferred from the repository basename. Clones,
+worktrees, personal, employer and customer contexts do not merge implicitly.
+All roots and policy files must already exist. Policy roots name canonical
+absolute paths; an alias in the policy cannot silently retarget permission.
+
+The independently selected access-policy JSON has these required fields:
+
+```json
+{
+  "schema_version": 1,
+  "source_id": "/srv/fixture/native/.beads",
+  "project_id": "fixture-native-project-id",
+  "owner_scope": "fixture-personal",
+  "task_ref": "fixture-task",
+  "model_ref": "fixture-provider/model",
+  "destination_ref": "fixture-private-destination",
+  "bundle_id": "fixture-bundle-id",
+  "bundle_root": "/srv/fixture/knowledge",
+  "evidence_root": "/srv/fixture/evidence",
+  "staging_root": "/srv/fixture/staging",
+  "owner_policy_ref": "/srv/fixture/owner-policy.md",
+  "task_policy_ref": "/srv/fixture/task-policy.md",
+  "model_policy_ref": "/srv/fixture/model-policy.md",
+  "destination_policy_ref": "/srv/fixture/destination-policy.md",
+  "maintenance_work_ref": "fixture-maintenance-anchor"
+}
+```
+
+Unknown, duplicate, missing or incompatible policy fields are errors. The
+selected policy and supplied purpose are checked before private anchor comments
+are read. The individual policy references must resolve to existing regular
+files; this command selects and checks their locators, not their prose or native
+permission enforcement. It always reports `access_enforcement: not_attested`.
+T39 owns measured native enforcement; this route result grants no new access,
+model transmission, disclosure or Git ingestion permission.
+
+Both evidence and staging must be external to the bundle, the explicitly named
+consumer checkout, each other, ordinary/bare/linked Git repositories and active
+Git storage bindings. Filesystem identities and symlink resolution prevent
+aliases from bypassing these boundaries. As with the shared evidence helper,
+ancestry cannot discover an unmarked directory referenced as external storage
+by an unrelated repository. Declare those known external roots through the
+active Git bindings before use; the check is not a global reverse-reference
+inventory or protection against concurrent hostile path replacement.
+
+## Read-only lookup and recovery
+
+```sh
+ao config context \
+  --source-id /srv/fixture/native/.beads \
+  --project-id fixture-native-project-id \
+  --owner-scope fixture-personal \
+  --task-ref fixture-task \
+  --model-ref fixture-provider/model \
+  --destination-ref fixture-private-destination \
+  --consumer-root /srv/fixture/consumer \
+  --native-directory /srv/fixture/native
+```
+
+The result reports canonical paths, each field's configuration source, native
+comment count and typed anchor facts. `--field evidence_root`, `--field
+staging_root` or `--field bundle_root` emits one checked path. The caller passes
+that result explicitly to its existing consumer, for example the evidence
+root to `ao provenance snapshot-intent --source <intent-file> --evidence-root
+<resolved-root> --exclude-git-root <consumer> --exclude-git-root <bundle>`.
+The generic evidence helper retains its own final path checks and caller-owned
+standalone proof placement. Lookup itself writes no files, indexes or objects.
+
+Before relying on a route, the owner stores its permitted recovery locators in
+the **same existing native maintenance anchor** as a JSON comment:
+
+```json
+{"type":"context.route.v1","fact_id":"route-stable-id","route":{"source_id":"...","project_id":"...","owner_scope":"...","bundle_id":"...","bundle_root":"...","evidence_root":"...","staging_root":"...","access_policy_ref":"...","owner_policy_ref":"...","task_policy_ref":"...","model_policy_ref":"...","destination_policy_ref":"...","maintenance_work_ref":"..."}}
+```
+
+The `route` object contains the complete selected configuration above, with real
+permitted locators supplied by its owner. The owner uses native
+`bd comments add ANCHOR -f FILE --json`, then directly reads it back. The config
+command never appends comments. Multiple incompatible route facts fail closed;
+timestamps do not choose a winner.
+
+After config loss, supply the same invocation purpose plus `--recover
+--access-policy-ref <existing-policy> --maintenance-work-ref <known-anchor>`.
+The selected policy independently binds that anchor. Recovery fills only
+missing route values from its comment; conflicting owner, source or destination
+values fail. It returns the same bundle and maintenance parent without writing
+replacement config, initializing an empty bundle or creating another anchor.
+Loss of the policy or anchor is unavailable, not permission to start over.
+
+## Native withdrawal and resolution facts
+
+BD 1.2.2 is the presently checked compatibility contract. Its `context` schema is
+1, and native comment `id` and `issue_id` are strings. Lookup first verifies the
+native project/source identity and anchor existence with `show --json`, then
+reads **`bd --readonly comments ANCHOR --json`** directly. It never uses
+`show --include-comments` or child listings to infer absence. Native process,
+missing-anchor, malformed JSON and output-limit errors propagate. The complete
+response limit is 16 MiB; exceeding it is unavailable, never a successful
+truncated read. Other BD versions require renewed native conformance.
+
+Withdrawal comment text:
+
+```json
+{"type":"context.withdrawal.v1","fact_id":"withdrawal-stable-id","bundle_id":"fixture-bundle-id","page_id":"page-id","page_digest":"<64 lowercase SHA256 hex characters>","counterevidence":["<permitted exact source locator>"]}
+```
+
+Resolution comment text:
+
+```json
+{"type":"context.resolution.v1","fact_id":"resolution-stable-id","bundle_id":"fixture-bundle-id","page_id":"page-id","page_digest":"<withdrawn SHA256>","resolves_fact_id":"withdrawal-stable-id","review_ref":"<exact fresh resolution/correction review>","review_digest":"<review SHA256>","successor_digest":"<explicitly covered successor SHA256>"}
+```
+
+A parser success is a fact-shape check, never semantic readmission. T14/T18
+consumers must keep missing, ambiguous or unverified resolution pending. Only a
+matching exact fresh resolution/correction review can cover the withdrawal and
+its named successor. New page bytes, unrelated commits, timestamps, closed or
+deleted investigation children, and knowledge-bundle Git rollback do not clear
+an anchor fact. Native BD/Dolt restoration requires separate reconciliation;
+retain the anchor outside ordinary work retention/GC.
+
+Optional investigation metadata uses flat native keys such as
+`ao.context.bundle_id` and `ao.context.fact_id`, not nested JSON. A native scoped
+query for a closed investigation is `bd --readonly list --all --status closed
+--parent ANCHOR --metadata-field ao.context.fact_id=FACT --limit 0 --json`.
+This query locates work; it never replaces the direct anchor read.
+
+The opt-in installed fixture
+`AO_TEST_BD_NATIVE=1 go test ./internal/commands/config -run TestContextInstalledBDRecovery -count=1 -v`
+creates only synthetic temporary native state. It checks 57 direct comments
+(including a withdrawal after comment 50), a closed investigation, same-anchor
+recovery after deleting only fixture home config, real evidence-root consumption,
+unchanged consumer and knowledge Git bytes, and missing-anchor/source errors.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -107,7 +107,7 @@
         "runtime-evidence",
         "worker-handoff"
       ],
-      "references_count": 1,
+      "references_count": 2,
       "tier": "meta",
       "user_invocable": true
     },
@@ -254,7 +254,7 @@
         "code-complete"
       ],
       "produces": [],
-      "references_count": 1,
+      "references_count": 2,
       "tier": "session",
       "user_invocable": true
     },

--- a/skills/codex-exec/SKILL.md
+++ b/skills/codex-exec/SKILL.md
@@ -125,3 +125,11 @@ report. The validator context ID must be distinct from the author's before a
 validator, record model identities per
 the `agent-native` model-dispatch recipe and match the sandbox to
 declared effects.
+
+For caller-required model identity, preserve native session metadata and terminal
+events as well as rendered output. The [judgment receipt convention](../agent-native/references/judgment-receipts.md)
+binds exact transcript byte spans and their SHA-256 through existing
+`evidence_refs`; the consumer supplies expected profiles, subject and acceptance
+independently. A requested model flag, Codex `turn_context` configuration, stdout
+marker or model self-description does not prove actual model identity. Missing
+native reporting stays `identity_unverified` and cannot satisfy a required leg.

--- a/tests/scripts/codex-exec-lib.bats
+++ b/tests/scripts/codex-exec-lib.bats
@@ -576,23 +576,42 @@ FAKE
   [ ! -e "$TMP/codex-argv" ]
 }
 
+@test "bounds: preparation expiry prevents launch without renewing the caller deadline" {
+  stub_argv_recorder
+  run timeout --kill-after=1 5 bash -c '
+    . "'"$LIB"'"
+    # Preparation consumes the same deadline as the eventual reviewer.
+    codex_exec_timeout_bin() { sleep .4; printf "%s" "'"$REAL_TIMEOUT"'"; }
+    CODEX_EXEC_TIMEOUT=.3 CODEX_EXEC_PROMPT_ARG=x codex_exec_guarded
+  '
+  [ "$status" -eq 124 ]
+  [[ "$output" == *"deadline expired before launch"* ]]
+  [ ! -e "$TMP/codex-argv" ]
+}
+
 @test "bounds: TERM resistant reviewer and child are killed with partial evidence" {
   cat > "$TMP/bin/codex" <<'FAKE'
 #!/usr/bin/env bash
 trap '' TERM
 echo $$ > "$TMPDIR/reviewer-pid"
 bash -c 'trap "" TERM; echo $$ > "$TMPDIR/child-pid"; exec sleep 30' &
+while [ ! -s "$TMPDIR/child-pid" ]; do sleep .01; done
 printf 'partial result\n'
 wait
 FAKE
   chmod +x "$TMP/bin/codex"
   start=$SECONDS
-  run timeout --kill-after=1 5 bash -c '. "'"$LIB"'"; CODEX_EXEC_TIMEOUT=.3 CODEX_EXEC_PROMPT_ARG=x codex_exec_guarded'
+  # This fixture must reach the running-reviewer branch. A .3s budget can be
+  # consumed by capability probing alone; the preceding case proves that path.
+  run timeout --kill-after=1 5 bash -c '. "'"$LIB"'"; CODEX_EXEC_TIMEOUT=2 CODEX_EXEC_PROMPT_ARG=x codex_exec_guarded'
   [ "$status" -eq 124 ]
   [ $((SECONDS - start)) -lt 4 ]
+  [ -s "$TMP/reviewer-pid" ]
+  [ -s "$TMP/child-pid" ]
   assert_stopped "$(cat "$TMP/reviewer-pid")"
   assert_stopped "$(cat "$TMP/child-pid")"
   [[ "$output" == *"partial result"* ]]
+  [[ "$output" == *"deadline expired; owned process group stopped"* ]]
 }
 
 @test "bounds: clean parent exit with children is degraded even when cleanup succeeds" {


### PR DESCRIPTION
Add explicit, recoverable private context routing through `ao config context`, binding native source, owner, task, model and destination to existing policy and external storage. Recovery reads the original Beads maintenance anchor; configuration reports native access enforcement as unattested.

Add `ao provenance verify-judgments` to check required review profiles against exact native transcript receipts, independent subject and acceptance, distinct contexts, completion and permitted providers. Requested identity and unreported effort do not count as runtime evidence. The verdict schema is unchanged.

Repair the existing cleanup test: a 0.3-second budget could expire during preparation before either fixture process started. A separate controlled-delay test now proves preparation cannot renew that deadline. The running-cleanup case requires parent/child readiness, preserved partial output, the postlaunch cleanup result and both processes stopped within its existing four-second bound. Production timeout behavior is unchanged.

Validation: fresh author-distinct review passed the exact 55-path final subject and all T05/T21 acceptance. The complete local Bats run passed (1,333 passed, two existing skips), as did Go build/vet/test/race, all 72 full-mode gates, the aggregate and generated-output checks. Ubuntu/Windows CI, security and both installation jobs passed on the final commit. The final evidence scan found no new orphaned bindings; 73 historical bindings remain preserved. Earlier failed results and private evidence remain outside the PR.
