### PR TITLE
Add bounded source reads and pinned OKF profile checks

### DIFF
--- a/cli/cmd/ao/default_spine_test.go
+++ b/cli/cmd/ao/default_spine_test.go
@@ -23,7 +23,7 @@ var approvedDefaultChildren = map[string]map[string]bool{
 		"drift": true, "export": true, "history": true, "measure": true,
 		"meta": true, "render": true, "scenarios": true, "validate": true,
 	},
-	"session": {"bootstrap": true, "handoff": true, "prune-agents": true, "rehydrate": true},
+	"session": {"bootstrap": true, "handoff": true, "prune-agents": true, "read-source": true, "rehydrate": true},
 	"skills": {
 		"check": true, "consumers": true, "find": true, "graph": true,
 		"link": true, "list": true, "producers": true, "resolve": true,

--- a/cli/cmd/ao/session_composition.go
+++ b/cli/cmd/ao/session_composition.go
@@ -17,10 +17,9 @@ func init() {
 // newSessionCommand wires the session command module and attaches the optional
 // `ao session handoff` writer, which is a separate command (defined in
 // handoff.go) that shares this parent. The module owns the session parent plus
-// its bootstrap, rehydrate, and prune-agents subcommands and delegates all
-// filesystem effects to internal/sessionapp. The session family attaches no
-// CommandContract to the command tree, preserving its pre-migration
-// capabilities surface.
+// its bootstrap, rehydrate, prune-agents and read-source subcommands. The
+// module attaches its family and read-source contracts and delegates effects
+// to the session and source-reading application packages.
 func newSessionCommand() *cobra.Command {
 	command := sessioncommands.NewModule(clicontract.HostOptions{
 		OutputMode: GetOutput,

--- a/cli/cmd/ao/source_okf_composition_test.go
+++ b/cli/cmd/ao/source_okf_composition_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSourceReadAndOKFComposedBoundary(t *testing.T) {
+	bin := aoBinary(t)
+	base, consumer := t.TempDir(), t.TempDir()
+	page := "---\ntype: observation\ntitle: PRIVATE_INPUT_CANARY\ndescription: A synthetic observation.\nstatus: draft\nsources:\n  - resource: synthetic:episode\nknowledge_use: maintained-reference\napplicability: One synthetic episode.\nclaim: The fixture has complete metadata.\nlimitations: No real-world claim.\nconsumer: Profile checker test.\nretirement_condition: When the profile changes.\n---\n"
+	valid, missingStatus := filepath.Join(base, "valid.md"), filepath.Join(base, "missing-status.md")
+	for name, contents := range map[string]string{valid: page, missingStatus: strings.Replace(page, "status: draft\n", "", 1)} {
+		if err := os.WriteFile(name, []byte(contents), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		exit       int
+		stderr     string
+		structured bool
+		valid      bool
+	}{
+		// ao session read-source must deny missing policy before opening a source or invoking BD.
+		{"source-denied", []string{"session", "read-source", "--file", filepath.Join(base, "missing-private-source"), "--start-byte", "0", "--max-bytes", "1"}, 1, "explicit access policy is required", false, false},
+		{"source-output-profile", []string{"-o", "yaml", "session", "read-source", "--file", valid, "--start-byte", "0", "--max-bytes", "1"}, 1, "supports JSON only", false, false},
+		// ao provenance check-okf checks structure without echoing or admitting candidate content.
+		{"okf-valid", []string{"provenance", "check-okf", "--file", valid}, 0, "", true, true},
+		{"okf-missing-status", []string{"provenance", "check-okf", "--file", missingStatus, "--json"}, 1, "structural findings", true, false},
+		{"okf-unsupported-profile", []string{"provenance", "check-okf", "--file", filepath.Join(base, "missing-private.md"), "--profile", "unknown"}, 1, "unsupported profile", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, bin, tc.args...)
+			cmd.Dir = consumer
+			for _, entry := range os.Environ() {
+				if !strings.HasPrefix(entry, "PATH=") {
+					cmd.Env = append(cmd.Env, entry)
+				}
+			}
+			cmd.Env = append(cmd.Env, "PATH=")
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			err := cmd.Run()
+			code := 0
+			if err != nil {
+				var exit *exec.ExitError
+				if !errors.As(err, &exit) {
+					t.Fatal(err)
+				}
+				code = exit.ExitCode()
+			}
+			if code != tc.exit || !strings.Contains(stderr.String(), tc.stderr) {
+				t.Fatalf("exit %d, want %d; stderr=%s", code, tc.exit, &stderr)
+			}
+			if strings.Contains(stdout.String()+stderr.String(), "PRIVATE_INPUT_CANARY") {
+				t.Fatal("candidate content echoed by structural or denied-read path")
+			}
+			if tc.structured {
+				var report struct {
+					Valid     bool   `json:"structurally_valid"`
+					Digest    string `json:"content_sha256"`
+					Assurance string `json:"assurance"`
+				}
+				if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+					t.Fatal(err)
+				}
+				if report.Valid != tc.valid || report.Assurance == "" || len(report.Digest) != 64 {
+					t.Fatalf("incomplete structural report: %+v", report)
+				}
+				if tc.valid && report.Digest != fmt.Sprintf("%x", sha256.Sum256([]byte(page))) {
+					t.Fatal("report is not bound to exact input bytes")
+				}
+			} else if stdout.Len() != 0 {
+				t.Fatalf("preflight emitted content: %s", &stdout)
+			}
+			entries, err := os.ReadDir(consumer)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("consumer mutated: %v %v", entries, err)
+			}
+		})
+	}
+}
+
+func TestSourceReadAndOKFCapabilities(t *testing.T) {
+	for _, tc := range []struct{ path, id, args, output, effects string }{
+		{"ao session", "ao.session", "arbitrary", "text", "filesystem,process,environment"},
+		{"ao session read-source", "ao.session.read-source", "none", "structured", "filesystem,process,environment"},
+		{"ao provenance check-okf", "ao.provenance.check-okf", "no-args", "structured", "filesystem"},
+	} {
+		entry := capabilityEntry(t, tc.path)
+		if entry.ID != tc.id || entry.Args != tc.args || entry.Output != tc.output || entry.Effects != tc.effects || entry.ExitCodes["0"] != "success" || entry.ExitCodes["1"] != "failure" {
+			t.Errorf("%s: %+v", tc.path, entry)
+		}
+	}
+}

--- a/cli/docs/COMMANDS.md
+++ b/cli/docs/COMMANDS.md
@@ -535,6 +535,37 @@ ao session prune-agents [flags]
       --quiet     Suppress per-path output and print only the summary
 ```
 
+#### `ao session read-source`
+
+Read one explicit regular source file under independently selected T05 context
+
+```
+ao session read-source [flags]
+```
+
+**Flags:**
+
+```
+      --access-policy-ref string      Independently selected T05 access policy JSON (required)
+      --allow-oversize                Explicitly bypass serialized profile size bound; host delivery remains unverified
+      --consumer-root string          Existing consumer checkout for T05 route verification (required)
+      --destination-ref string        Expected destination identity (required)
+      --expect-file-identity string   Expected prior file_before.identity, for replacement checks across calls
+      --expect-prefix-sha256 string   Expected SHA-256 of all bytes before through-byte
+      --file string                   Exact absolute source file path (required)
+  -h, --help                          help for read-source
+      --json                          Emit JSON (also the default; no text-only coverage view)
+      --max-bytes int                 Positive maximum returned source bytes (required)
+      --model-ref string              Expected model/provider identity (required)
+      --native-directory string       Explicit directory for native BD source verification (required)
+      --owner-scope string            Independently expected owner scope (required)
+      --project-id string             Expected native project identity (required)
+      --source-id string              Expected canonical native beads_dir (required)
+      --start-byte int                First byte of the returned half-open range (required)
+      --task-ref string               Expected caller task identity (required)
+      --through-byte int              Frozen exclusive prefix boundary, paired with expect-prefix-sha256
+```
+
 #### `ao session rehydrate`
 
 Read a handoff without consuming it, claiming work, or choosing a next action.
@@ -639,6 +670,23 @@ ao provenance add <from-id> <to-id> [flags]
       --to-type string      Target node type (for example decision, artifact, or observation) (default "artifact")
       --trust-tier string   Trust tier (authored|inferred|mined) (default "authored")
       --ts string           Override the UTC RFC3339 timestamp (defaults to now)
+```
+
+#### `ao provenance check-okf`
+
+Check one explicitly selected Markdown concept against agentops-okf-v0.2/v1,
+
+```
+ao provenance check-okf [flags]
+```
+
+**Flags:**
+
+```
+      --file string      Explicit Markdown concept file (required; at most 1 MiB)
+  -h, --help             help for check-okf
+      --json             Emit JSON (the default)
+      --profile string   Exact supported structural profile version (default "agentops-okf-v0.2/v1")
 ```
 
 #### `ao provenance digest`

--- a/cli/internal/commands/provenance/module.go
+++ b/cli/internal/commands/provenance/module.go
@@ -143,6 +143,7 @@ judgment. See each leaf for evidence helper version and mutation conditions.`,
 	root.AddCommand(m.evidenceCommands()...)
 	root.AddCommand(m.evidenceOrphansCommand())
 	root.AddCommand(m.verifyJudgmentsCommand())
+	root.AddCommand(m.checkOKFCommand())
 	if err := clicontract.Attach(root, m.Contract()); err != nil {
 		panic(err)
 	}

--- a/cli/internal/commands/provenance/module_test.go
+++ b/cli/internal/commands/provenance/module_test.go
@@ -57,7 +57,7 @@ func TestModuleConstructsCommandTree(t *testing.T) {
 	}
 	want := map[string]bool{
 		"add": true, "list": true, "export": true, "show": true,
-		"position": true, "trace": true, "verify": true, "mine-session": true,
+		"position": true, "trace": true, "verify": true, "mine-session": true, "check-okf": true,
 		"snapshot-intent": true, "manifest": true, "verify-manifest": true, "digest": true, "store-verdict": true, "verify-verdict": true, "verify-subject": true, "evidence-orphans": true, "verify-judgments": true,
 	}
 	got := map[string]bool{}

--- a/cli/internal/commands/provenance/okf.go
+++ b/cli/internal/commands/provenance/okf.go
@@ -1,0 +1,71 @@
+package provenance
+
+import (
+	"fmt"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"github.com/boshu2/agentops/cli/internal/okfprofile"
+	"github.com/spf13/cobra"
+)
+
+func (m *Module) checkOKFCommand() *cobra.Command {
+	var file, profile string
+	var localJSON bool
+	cmd := &cobra.Command{
+		Use: "check-okf", Short: "Check the pinned AgentOps OKF page profile without granting semantic approval", Args: cobra.NoArgs,
+		SilenceUsage: true,
+		Long: `Check one explicitly selected Markdown concept against agentops-okf-v0.2/v1,
+pinned to OKF v0.2 SPEC commit ad30107c31c06aec8a7d5636e0d1058118604e6f.
+Unknown profiles fail before any file read. Optional agentops_profile and
+okf_version page declarations must match the selected pin. Missing status is
+invalid; it never inherits stable. No page label grants clearance or admission.
+
+Require type, title, description, explicit status, nonempty sources entries,
+knowledge_use (maintained-reference or promotion-candidate), applicability,
+claim or action, limitations, consumer, and retirement_condition. These five
+text obligations may be string metadata or named Markdown ATX sections. Check standard
+generated/verified actor and timestamp shapes without treating actor strings
+as independent-review evidence. Other producer keys and unknown types are allowed.
+
+Reads only --file, a regular .md concept of at most 1 MiB with at most 64 KiB
+frontmatter. Rejects index.md/log.md, file symlinks, malformed/duplicate YAML,
+aliases/merge inheritance and excessive nesting. Sources and links are opaque:
+no source fetching, bundle search, Git, configuration lookup, memory write,
+network, external process or semantic judgment. Native runtime authorization
+must precede this read; the checker does not enforce owner/destination policy.
+
+JSON by default, --json or -o json; -o yaml emits the same fields. The report
+contains the exact input SHA-256, structural findings and the explicit assurance
+boundary, without echoing page text or source locators. --dry-run is also read-only.
+Exit 0 means the selected structure is valid. Exit 1 means findings, unsupported
+profile, invalid input, read failure or output failure. Neither exit establishes
+truth, disclosure permission, independent review, applicability or usefulness.`,
+	}
+	cmd.Flags().StringVar(&file, "file", "", "Explicit Markdown concept file (required; at most 1 MiB)")
+	_ = cmd.MarkFlagRequired("file")
+	cmd.Flags().StringVar(&profile, "profile", okfprofile.Profile, "Exact supported structural profile version")
+	cmd.Flags().BoolVar(&localJSON, "json", false, "Emit JSON (the default)")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		result, err := okfprofile.CheckFile(file, profile)
+		if err != nil {
+			return err
+		}
+		if _, err := m.emitStructured(cmd.OutOrStdout(), true, result); err != nil {
+			return err
+		}
+		if !result.StructurallyValid {
+			return fmt.Errorf("OKF page profile has structural findings")
+		}
+		return nil
+	}
+	contract := m.Contract()
+	contract.ID = "ao.provenance.check-okf"
+	contract.Args = clicontract.ArgsPolicy{Name: "no-args", Validate: cobra.NoArgs}
+	contract.Output = clicontract.OutputStructured
+	contract.Effects = clicontract.EffectFilesystem
+	contract.ExitClasses = map[int]clicontract.ExitClass{0: clicontract.ExitSuccess, 1: clicontract.ExitFailure}
+	if err := clicontract.Attach(cmd, contract); err != nil {
+		panic(err)
+	}
+	return cmd
+}

--- a/cli/internal/commands/provenance/okf_test.go
+++ b/cli/internal/commands/provenance/okf_test.go
@@ -1,0 +1,137 @@
+package provenance
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"github.com/boshu2/agentops/cli/internal/okfprofile"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckOKFCLIReadOnlyAndNoSourceFetch(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls.Add(1) }))
+	defer server.Close()
+	fixture, err := os.ReadFile("../../okfprofile/testdata/maintained-reference.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(strings.Replace(string(fixture), "https://example.invalid/declared-source", server.URL+"/source-locator-canary", 1))
+	dir := t.TempDir()
+	file := filepath.Join(dir, "input.md")
+	if err := os.WriteFile(file, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"", "json", "yaml"} {
+		t.Run("format-"+mode, func(t *testing.T) {
+			cmd := NewModule(clicontract.HostOptions{OutputMode: func() string { return mode }, DryRun: func() bool { return true }}).Command()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"check-okf", "--file", file})
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			var result map[string]any
+			if mode == "yaml" {
+				err = yaml.Unmarshal(out.Bytes(), &result)
+			} else {
+				err = json.Unmarshal(out.Bytes(), &result)
+			}
+			if err != nil || result["structurally_valid"] != true || result["assurance"] != okfprofile.Assurance {
+				t.Fatalf("result: %v %v", result, err)
+			}
+			if _, exists := result["verdict"]; exists {
+				t.Fatal("structural checker emitted semantic verdict")
+			}
+			if strings.Contains(out.String(), "source-locator-canary") || strings.Contains(out.String(), "human:example") || strings.Contains(out.String(), "Synthetic request behavior") {
+				t.Fatal("candidate text echoed")
+			}
+		})
+	}
+	if calls.Load() != 0 {
+		t.Fatal("checker fetched a source")
+	}
+	after, err := os.ReadFile(file)
+	if err != nil || !bytes.Equal(after, payload) {
+		t.Fatal("checker changed candidate")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("unexpected file effects: %v %v", entries, err)
+	}
+}
+
+func TestCheckOKFCLIFindingsAndInvalidRequests(t *testing.T) {
+	fixture, err := os.ReadFile("../../okfprofile/testdata/maintained-reference.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(t.TempDir(), "input.md")
+	if err := os.WriteFile(file, []byte(strings.Replace(string(fixture), "status: stable\n", "", 1)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		report bool
+	}{
+		{"missing status", []string{"--file", file}, true},
+		{"missing file flag", nil, false},
+		{"unknown profile before read", []string{"--file", "not-present.md", "--profile", "future/2"}, false},
+		{"empty profile", []string{"--file", file, "--profile", ""}, false},
+		{"positional argument", []string{"--file", file, "unexpected"}, false},
+		{"unavailable file", []string{"--file", "not-present.md"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := execProv(t, "must-not-resolve-ledger", append([]string{"check-okf"}, tc.args...)...)
+			if err == nil {
+				t.Fatal("invalid request succeeded")
+			}
+			if tc.report {
+				var result okfprofile.Result
+				if err := json.Unmarshal([]byte(out), &result); err != nil {
+					t.Fatal(err)
+				}
+				if result.StructurallyValid || len(result.Issues) != 1 || result.Issues[0].Field != "status" {
+					t.Fatalf("missing explicit status: %+v", result)
+				}
+			} else if out != "" {
+				t.Fatalf("invalid operation emitted misleading report: %s", out)
+			}
+		})
+	}
+	if err := os.WriteFile(file, []byte("---\ntype: [private-content-canary\n---\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := execProv(t, "unused", "check-okf", "--file", file)
+	if err == nil || strings.Contains(out+err.Error(), "private-content-canary") {
+		t.Fatal("parser error exposed content or succeeded")
+	}
+}
+
+func TestCheckOKFCapabilityContract(t *testing.T) {
+	cmd := NewModule(clicontract.HostOptions{}).Command()
+	leaf, _, err := cmd.Find([]string{"check-okf"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract, ok := clicontract.ContractFor(leaf)
+	if !ok || contract.ID != "ao.provenance.check-okf" || contract.Effects != clicontract.EffectFilesystem || contract.Output != clicontract.OutputStructured || contract.Args.Name != "no-args" {
+		t.Fatalf("incorrect contract: %+v", contract)
+	}
+	if len(contract.ExitClasses) != 2 || contract.ExitClasses[0] != clicontract.ExitSuccess || contract.ExitClasses[1] != clicontract.ExitFailure {
+		t.Fatalf("incorrect exits: %+v", contract.ExitClasses)
+	}
+	if leaf.Flags().Lookup("profile").DefValue != okfprofile.Profile {
+		t.Fatal("profile default does not match implementation pin")
+	}
+}

--- a/cli/internal/commands/session/module.go
+++ b/cli/internal/commands/session/module.go
@@ -1,7 +1,7 @@
 // Package session owns Cobra presentation for the `ao session` commands
-// (bootstrap, rehydrate, and prune-agents). The module builds its command tree with
+// (bootstrap, rehydrate, prune-agents, and read-source). The module builds its command tree with
 // constructor-scoped flag state and delegates every filesystem effect to
-// internal/sessionapp, so this package performs no direct effect. The optional
+// internal/sessionapp and internal/sourceread, so this package performs no direct effect. The optional
 // `ao session handoff` writer is attached by the cmd/ao composition; it is a
 // separate command that shares this parent.
 package session
@@ -42,15 +42,15 @@ func (m Module) outputMode() string {
 // caller-authored handoff, and its explicitly selected prune-agents command can
 // apply retention mutations (dry-run by default). It emits text (JSON under the
 // read commands' --json flags) and exits 0 on success or 1 on a filesystem
-// failure. The session family attached no capabilities contract before the
-// carve-out, so the composition does not attach this one either.
+// failure. The source reader additionally reads caller configuration and native
+// BD through its existing read-only gateway; leaf contracts state exact effects.
 func (Module) Contract() clicontract.CommandContract {
 	return clicontract.CommandContract{
 		ID:       "ao.session",
 		Profiles: clicontract.ProfileDefault | clicontract.ProfileLegacy | clicontract.ProfileCombined,
 		Args:     clicontract.ArgsPolicy{Name: "arbitrary", Validate: cobra.ArbitraryArgs},
 		Output:   clicontract.OutputText,
-		Effects:  clicontract.EffectFilesystem,
+		Effects:  clicontract.EffectFilesystem | clicontract.EffectEnvironment | clicontract.EffectProcess,
 		ExitClasses: map[int]clicontract.ExitClass{
 			0: clicontract.ExitSuccess,
 			1: clicontract.ExitFailure,
@@ -59,7 +59,7 @@ func (Module) Contract() clicontract.CommandContract {
 }
 
 // Command builds the `ao session` command. The RunE closures delegate entirely
-// to internal/sessionapp so this module performs no direct filesystem effect.
+// to application packages so this module performs no direct filesystem effect.
 func (m Module) Command() *cobra.Command {
 	root := &cobra.Command{
 		Use:     "session",
@@ -69,6 +69,10 @@ func (m Module) Command() *cobra.Command {
 	root.AddCommand(m.bootstrapCommand())
 	root.AddCommand(m.rehydrateCommand())
 	root.AddCommand(m.pruneAgentsCommand())
+	root.AddCommand(m.readSourceCommand())
+	if err := clicontract.Attach(root, m.Contract()); err != nil {
+		panic(err)
+	}
 	return root
 }
 

--- a/cli/internal/commands/session/read_source.go
+++ b/cli/internal/commands/session/read_source.go
@@ -1,0 +1,79 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+	"github.com/boshu2/agentops/cli/internal/sourceread"
+	"github.com/spf13/cobra"
+)
+
+func (m Module) readSourceCommand() *cobra.Command {
+	var options sourceread.Options
+	var through int64
+	var jsonOut bool
+	command := &cobra.Command{
+		Use: "read-source", Short: "Read authorized bounded source bytes with integrity facts",
+		Long: `Read one explicit regular source file under independently selected T05 context
+policy. Native BD 1.2.2 context and maintenance-anchor reads must succeed before
+source bytes open. The selected task_policy_ref must contain source-read-policy.v1
+with exact file permissions and a measured output profile. Missing, mismatched,
+unavailable or malformed policy denies the read. Restricted sources remain
+unavailable until native access enforcement is implemented; current policy checks
+support only explicitly synthetic or already-cleared sources.
+
+--start-byte and positive --max-bytes are required. The half-open result includes
+raw base64 bytes, a separately labelled text view, full-prefix/span SHA-256,
+file observations and next offset. --through-byte and --expect-prefix-sha256
+must be paired for a frozen continuation; appends after that boundary are allowed.
+Use --expect-file-identity from a previous file_before.identity to detect
+replacement between invocations, including replacement with identical bytes.
+
+Output is one compact source-read.v1 JSON document, including its trailing newline.
+The selected profile bounds the actual serialized output before any bytes emit.
+--allow-oversize explicitly bypasses only that size bound. Every result remains
+host-delivery-unverified, semantically unprocessed and complete_reading=false:
+emitted stdout cannot prove host delivery, absence of tool-result truncation,
+or model comprehension. YAML is unavailable because this profile measures JSON.
+No source, policy, tracker or evidence file is written; --dry-run changes nothing.
+Exit 0 means JSON was written; exit 1 means denied access, invalid bounds,
+integrity failure, unavailable source/profile, oversized output or output failure.`,
+		Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			command.SilenceUsage = true
+			if m.outputMode() == "yaml" {
+				return fmt.Errorf("read-source: measured serialization supports JSON only")
+			}
+			if !command.Flags().Changed("start-byte") || !command.Flags().Changed("max-bytes") {
+				return fmt.Errorf("read-source: explicit start-byte and max-bytes are required")
+			}
+			if command.Flags().Changed("through-byte") {
+				options.ThroughByte = &through
+			}
+			return sourceread.Run(command.Context(), options, command.OutOrStdout())
+		},
+	}
+	f := command.Flags()
+	f.StringVar(&options.File, "file", "", "Exact absolute source file path (required)")
+	f.StringVar(&options.Context.Overrides.AccessPolicyRef, "access-policy-ref", "", "Independently selected T05 access policy JSON (required)")
+	f.StringVar(&options.Context.SourceID, "source-id", "", "Expected canonical native beads_dir (required)")
+	f.StringVar(&options.Context.ProjectID, "project-id", "", "Expected native project identity (required)")
+	f.StringVar(&options.Context.OwnerScope, "owner-scope", "", "Independently expected owner scope (required)")
+	f.StringVar(&options.Context.TaskRef, "task-ref", "", "Expected caller task identity (required)")
+	f.StringVar(&options.Context.ModelRef, "model-ref", "", "Expected model/provider identity (required)")
+	f.StringVar(&options.Context.DestinationRef, "destination-ref", "", "Expected destination identity (required)")
+	f.StringVar(&options.Context.ConsumerRoot, "consumer-root", "", "Existing consumer checkout for T05 route verification (required)")
+	f.StringVar(&options.Context.NativeDirectory, "native-directory", "", "Explicit directory for native BD source verification (required)")
+	f.Int64Var(&options.StartByte, "start-byte", 0, "First byte of the returned half-open range (required)")
+	f.Int64Var(&options.MaxBytes, "max-bytes", 0, "Positive maximum returned source bytes (required)")
+	f.Int64Var(&through, "through-byte", 0, "Frozen exclusive prefix boundary, paired with expect-prefix-sha256")
+	f.StringVar(&options.ExpectPrefixSHA256, "expect-prefix-sha256", "", "Expected SHA-256 of all bytes before through-byte")
+	f.StringVar(&options.ExpectFileIdentity, "expect-file-identity", "", "Expected prior file_before.identity, for replacement checks across calls")
+	f.BoolVar(&options.AllowOversize, "allow-oversize", false, "Explicitly bypass serialized profile size bound; host delivery remains unverified")
+	f.BoolVar(&jsonOut, "json", false, "Emit JSON (also the default; no text-only coverage view)")
+	contract := clicontract.CommandContract{ID: "ao.session.read-source", Profiles: clicontract.ProfileDefault | clicontract.ProfileLegacy | clicontract.ProfileCombined, Args: clicontract.ArgsPolicy{Name: "none", Validate: cobra.NoArgs}, Output: clicontract.OutputStructured, Effects: clicontract.EffectFilesystem | clicontract.EffectEnvironment | clicontract.EffectProcess, ExitClasses: map[int]clicontract.ExitClass{0: clicontract.ExitSuccess, 1: clicontract.ExitFailure}}
+	if err := clicontract.Attach(command, contract); err != nil {
+		panic(err)
+	}
+	return command
+}

--- a/cli/internal/commands/session/read_source_test.go
+++ b/cli/internal/commands/session/read_source_test.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/clicontract"
+)
+
+func TestReadSourceMissingContextAndBounds(t *testing.T) {
+	for _, args := range [][]string{{"read-source"}, {"read-source", "--file", "/denied", "--start-byte", "0"}, {"read-source", "--file", "/denied", "--start-byte", "0", "--max-bytes", "1", "--json"}, {"read-source", "--file", "/denied", "--start-byte", "-1", "--max-bytes", "1"}, {"read-source", "unexpected"}} {
+		root := NewModule(clicontract.HostOptions{}).Command()
+		var out bytes.Buffer
+		root.SetOut(&out)
+		root.SetErr(&out)
+		root.SetArgs(args)
+		if err := root.Execute(); err == nil {
+			t.Fatalf("invalid input succeeded: %v", args)
+		}
+		if strings.Contains(out.String(), "bytes_base64") {
+			t.Fatal("denied source emitted content")
+		}
+	}
+}
+func TestReadSourceRejectsUnmeasuredYAML(t *testing.T) {
+	root := NewModule(clicontract.HostOptions{OutputMode: func() string { return "yaml" }}).Command()
+	root.SetArgs([]string{"read-source", "--start-byte", "0", "--max-bytes", "1"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "JSON only") {
+		t.Fatalf("yaml result: %v", err)
+	}
+}

--- a/cli/internal/okfprofile/file.go
+++ b/cli/internal/okfprofile/file.go
@@ -11,7 +11,7 @@ import (
 // CheckFile reads only the explicitly named regular concept file. It does not
 // discover a bundle, consult configuration, resolve sources or write receipts.
 // Authorization and OS confinement belong to the invoking native runtime.
-func CheckFile(path, profile string) (Result, error) {
+func CheckFile(path, profile string) (result Result, err error) {
 	if err := checkProfile(profile); err != nil {
 		return Result{}, err
 	}
@@ -26,7 +26,12 @@ func CheckFile(path, profile string) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("cannot open input directory")
 	}
-	defer root.Close()
+	defer func() {
+		if closeErr := root.Close(); err == nil && closeErr != nil {
+			result = Result{}
+			err = fmt.Errorf("cannot close input directory")
+		}
+	}()
 	before, err := root.Lstat(base)
 	if err != nil {
 		return Result{}, fmt.Errorf("cannot inspect input file")
@@ -41,7 +46,12 @@ func CheckFile(path, profile string) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("cannot open input file")
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); err == nil && closeErr != nil {
+			result = Result{}
+			err = fmt.Errorf("cannot close input file")
+		}
+	}()
 	opened, err := file.Stat()
 	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
 		return Result{}, fmt.Errorf("input changed while opening")

--- a/cli/internal/okfprofile/file.go
+++ b/cli/internal/okfprofile/file.go
@@ -1,0 +1,61 @@
+package okfprofile
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CheckFile reads only the explicitly named regular concept file. It does not
+// discover a bundle, consult configuration, resolve sources or write receipts.
+// Authorization and OS confinement belong to the invoking native runtime.
+func CheckFile(path, profile string) (Result, error) {
+	if err := checkProfile(profile); err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(path) == "" || filepath.Ext(path) != ".md" {
+		return Result{}, fmt.Errorf("--file must name a Markdown concept file")
+	}
+	base := filepath.Base(path)
+	if base == "index.md" || base == "log.md" {
+		return Result{}, fmt.Errorf("reserved index.md and log.md are not concept pages")
+	}
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		return Result{}, fmt.Errorf("cannot open input directory")
+	}
+	defer root.Close()
+	before, err := root.Lstat(base)
+	if err != nil {
+		return Result{}, fmt.Errorf("cannot inspect input file")
+	}
+	if !before.Mode().IsRegular() {
+		return Result{}, fmt.Errorf("input must be a regular file, not a symlink or special file")
+	}
+	if before.Size() > MaxPageBytes {
+		return Result{}, fmt.Errorf("input exceeds 1 MiB read bound")
+	}
+	file, err := root.Open(base)
+	if err != nil {
+		return Result{}, fmt.Errorf("cannot open input file")
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return Result{}, fmt.Errorf("input changed while opening")
+	}
+	payload, err := io.ReadAll(io.LimitReader(file, MaxPageBytes+1))
+	if err != nil {
+		return Result{}, fmt.Errorf("cannot read input file")
+	}
+	if len(payload) > MaxPageBytes {
+		return Result{}, fmt.Errorf("input exceeds 1 MiB read bound")
+	}
+	after, err := file.Stat()
+	if err != nil || opened.Size() != after.Size() || !opened.ModTime().Equal(after.ModTime()) {
+		return Result{}, fmt.Errorf("input changed while reading")
+	}
+	return Check(payload, profile)
+}

--- a/cli/internal/okfprofile/file_test.go
+++ b/cli/internal/okfprofile/file_test.go
@@ -1,0 +1,64 @@
+package okfprofile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckFileBoundedAndReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "observation.md")
+	payload := []byte(observation)
+	if err := os.WriteFile(path, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := CheckFile(path, Profile)
+	if err != nil || !result.StructurallyValid {
+		t.Fatalf("check: %+v %v", result, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(payload, after) {
+		t.Fatal("checker altered input")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("checker created output: %v %v", entries, err)
+	}
+
+	link := filepath.Join(dir, "link.md")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CheckFile(link, Profile); err == nil {
+		t.Fatal("file symlink accepted")
+	}
+	if _, err := CheckFile(filepath.Join(dir, "missing.md"), "future/2"); err == nil || !strings.Contains(err.Error(), "unsupported profile") {
+		t.Fatalf("version not checked before input: %v", err)
+	}
+
+	for _, name := range []string{"index.md", "log.md", "page.txt"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, payload, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := CheckFile(path, Profile); err == nil {
+			t.Fatalf("non-concept %s accepted", name)
+		}
+	}
+	if err := os.Truncate(path, MaxPageBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CheckFile(path, Profile); err == nil || !strings.Contains(err.Error(), "read bound") {
+		t.Fatalf("oversized input: %v", err)
+	}
+}
+
+func TestCheckFileErrorDoesNotEchoLocator(t *testing.T) {
+	_, err := CheckFile(filepath.Join(t.TempDir(), "private-owner-canary", "page.md"), Profile)
+	if err == nil || strings.Contains(err.Error(), "private-owner-canary") {
+		t.Fatalf("locator echoed: %v", err)
+	}
+}

--- a/cli/internal/okfprofile/profile.go
+++ b/cli/internal/okfprofile/profile.go
@@ -6,6 +6,7 @@ package okfprofile
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -257,7 +258,7 @@ func frontmatter(payload []byte) (map[string]*yaml.Node, string, string) {
 		return nil, "", "invalid_yaml"
 	}
 	var extra yaml.Node
-	if decoder.Decode(&extra) != io.EOF {
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
 		return nil, "", "multiple_yaml_documents"
 	}
 	if len(doc.Content) != 1 || doc.Content[0].Kind != yaml.MappingNode {

--- a/cli/internal/okfprofile/profile.go
+++ b/cli/internal/okfprofile/profile.go
@@ -1,0 +1,421 @@
+// Package okfprofile checks the explicitly selected AgentOps page profile of
+// pinned OKF v0.2. It establishes structure, never factual support, permission,
+// applicability, independent review, admission, or usefulness.
+package okfprofile
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	Profile             = "agentops-okf-v0.2/v1"
+	OKFVersion          = "0.2"
+	SpecCommit          = "ad30107c31c06aec8a7d5636e0d1058118604e6f"
+	MaxPageBytes        = 1 << 20
+	MaxFrontmatterBytes = 64 << 10
+	Assurance           = "Structure only; factual support, destination disclosure, independent review, current applicability and demonstrated usefulness are not established."
+)
+
+// Issue contains fixed field names and codes, never candidate text or locators.
+type Issue struct {
+	Field string `json:"field"`
+	Code  string `json:"code"`
+}
+
+type Result struct {
+	Profile           string  `json:"profile"`
+	OKFVersion        string  `json:"okf_version"`
+	SpecCommit        string  `json:"spec_commit"`
+	ContentSHA256     string  `json:"content_sha256,omitempty"`
+	StructurallyValid bool    `json:"structurally_valid"`
+	Issues            []Issue `json:"issues"`
+	Assurance         string  `json:"assurance"`
+}
+
+func checkProfile(profile string) error {
+	if profile != Profile {
+		return fmt.Errorf("unsupported profile; supported profile is %s", Profile)
+	}
+	return nil
+}
+
+// Check validates one page without resolving any source, link or other file.
+// The caller's profile selection is checked before inspecting candidate bytes.
+// A structural rejection is a Result; an unsupported operation is an error.
+func Check(payload []byte, profile string) (Result, error) {
+	result := Result{Profile: Profile, OKFVersion: OKFVersion, SpecCommit: SpecCommit, Issues: []Issue{}, Assurance: Assurance}
+	if err := checkProfile(profile); err != nil {
+		return result, err
+	}
+	if len(payload) > MaxPageBytes {
+		result.add("page", "exceeds_1_mib")
+		return result, nil
+	}
+	result.ContentSHA256 = fmt.Sprintf("%x", sha256.Sum256(payload))
+	if !utf8.Valid(payload) {
+		result.add("page", "invalid_utf8")
+		return result, nil
+	}
+	metadata, body, code := frontmatter(payload)
+	if code != "" {
+		result.add("frontmatter", code)
+		return result, nil
+	}
+
+	result.metadata(metadata)
+	result.requiredText(metadata, bodySections(body))
+	result.StructurallyValid = len(result.Issues) == 0
+	return result, nil
+}
+
+func (result *Result) metadata(metadata map[string]*yaml.Node) {
+	for _, key := range []string{"type", "title", "description"} {
+		result.requireString(metadata[key], key)
+	}
+	result.requireEnum(metadata["status"], "status", "draft", "stable", "deprecated")
+	result.requireEnum(metadata["knowledge_use"], "knowledge_use", "maintained-reference", "promotion-candidate")
+	if n := metadata["agentops_profile"]; n != nil {
+		result.requireEnum(n, "agentops_profile", Profile)
+	}
+	if n := metadata["okf_version"]; n != nil {
+		result.requireEnum(n, "okf_version", OKFVersion)
+	}
+	result.sources(metadata["sources"])
+	if n := metadata["generated"]; n != nil {
+		result.actorEvent(n, "generated", false)
+	}
+	if n := metadata["verified"]; n != nil {
+		items := n.Content
+		if n.Kind == yaml.MappingNode {
+			items = []*yaml.Node{n}
+		} else if n.Kind != yaml.SequenceNode {
+			result.add("verified", "expected_mapping_or_list")
+			items = nil
+		}
+		for i, item := range items {
+			result.actorEvent(item, fmt.Sprintf("verified[%d]", i), true)
+		}
+	}
+	if n := metadata["stale_after"]; n != nil {
+		result.timestamp(n, "stale_after")
+	}
+
+}
+
+func (result *Result) requiredText(metadata map[string]*yaml.Node, sections map[string]bool) {
+	for _, key := range []string{"applicability", "limitations", "consumer", "retirement_condition"} {
+		if n := metadata[key]; n != nil {
+			result.requireString(n, key)
+		} else if !sections[key] {
+			result.add(key, "required_nonempty_text")
+		}
+	}
+	claim := false
+	for _, key := range []string{"claim", "action"} {
+		if n := metadata[key]; n != nil {
+			claim = result.requireString(n, key) || claim
+		} else {
+			claim = sections[key] || claim
+		}
+	}
+	if !claim {
+		result.add("claim/action", "required_nonempty_text")
+	}
+}
+
+func (r *Result) add(field, code string) {
+	r.Issues = append(r.Issues, Issue{Field: field, Code: code})
+}
+
+func stringValue(n *yaml.Node) (string, bool) {
+	if n == nil || n.Kind != yaml.ScalarNode || n.Tag != "!!str" || strings.TrimSpace(n.Value) == "" {
+		return "", false
+	}
+	return n.Value, true
+}
+
+func (r *Result) requireString(n *yaml.Node, field string) bool {
+	_, ok := stringValue(n)
+	if !ok {
+		r.add(field, "required_nonempty_string")
+	}
+	return ok
+}
+
+func (r *Result) requireEnum(n *yaml.Node, field string, values ...string) {
+	value, ok := stringValue(n)
+	if !ok {
+		r.add(field, "required_explicit_value")
+		return
+	}
+	for _, allowed := range values {
+		if value == allowed {
+			return
+		}
+	}
+	r.add(field, "unsupported_value")
+}
+
+func mapping(n *yaml.Node) map[string]*yaml.Node {
+	fields := map[string]*yaml.Node{}
+	if n != nil && n.Kind == yaml.MappingNode {
+		for i := 0; i < len(n.Content); i += 2 {
+			fields[n.Content[i].Value] = n.Content[i+1]
+		}
+	}
+	return fields
+}
+
+func (r *Result) sources(n *yaml.Node) {
+	if n == nil || n.Kind != yaml.SequenceNode || len(n.Content) == 0 {
+		r.add("sources", "required_nonempty_list")
+		return
+	}
+	ids := map[string]bool{}
+	for i, entry := range n.Content {
+		field := fmt.Sprintf("sources[%d]", i)
+		if entry.Kind != yaml.MappingNode {
+			r.add(field, "expected_mapping")
+			continue
+		}
+		fields := mapping(entry)
+		r.requireString(fields["resource"], field+".resource")
+		for _, key := range []string{"id", "title", "author"} {
+			if item := fields[key]; item != nil {
+				r.requireString(item, field+"."+key)
+			}
+		}
+		if id, ok := stringValue(fields["id"]); ok {
+			if ids[id] {
+				r.add(field+".id", "duplicate_source_id")
+			}
+			ids[id] = true
+		}
+		if n := fields["last_modified"]; n != nil {
+			r.timestamp(n, field+".last_modified")
+		}
+	}
+}
+
+func (r *Result) actorEvent(n *yaml.Node, field string, requireTime bool) {
+	if n.Kind != yaml.MappingNode {
+		r.add(field, "expected_mapping")
+		return
+	}
+	fields := mapping(n)
+	actor, ok := stringValue(fields["by"])
+	if !ok {
+		r.add(field+".by", "required_actor")
+	} else if !validActor(actor) {
+		r.add(field+".by", "invalid_actor_convention")
+	}
+	if fields["at"] != nil || requireTime {
+		r.timestamp(fields["at"], field+".at")
+	}
+}
+
+func validActor(actor string) bool {
+	if strings.IndexFunc(actor, unicode.IsSpace) >= 0 {
+		return false
+	}
+	for _, prefix := range []string{"human:", "process:"} {
+		if strings.HasPrefix(actor, prefix) {
+			return len(actor) > len(prefix)
+		}
+	}
+	producer, version, ok := strings.Cut(actor, "/")
+	return ok && producer != "" && version != ""
+}
+
+func (r *Result) timestamp(n *yaml.Node, field string) {
+	if n == nil || n.Kind != yaml.ScalarNode || (n.Tag != "!!str" && n.Tag != "!!timestamp") {
+		r.add(field, "expected_datetime_with_offset")
+		return
+	}
+	if _, err := time.Parse(time.RFC3339, n.Value); err != nil {
+		r.add(field, "expected_datetime_with_offset")
+	}
+}
+
+func frontmatter(payload []byte) (map[string]*yaml.Node, string, string) {
+	header, body, code := splitFrontmatter(payload)
+	if code != "" {
+		return nil, "", code
+	}
+	var doc yaml.Node
+	decoder := yaml.NewDecoder(bytes.NewReader(header))
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, "", "invalid_yaml"
+	}
+	var extra yaml.Node
+	if decoder.Decode(&extra) != io.EOF {
+		return nil, "", "multiple_yaml_documents"
+	}
+	if len(doc.Content) != 1 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, "", "expected_mapping"
+	}
+	count := 0
+	if !unambiguousYAML(doc.Content[0], 0, &count) {
+		return nil, "", "ambiguous_or_excessive_yaml"
+	}
+	return mapping(doc.Content[0]), strings.ReplaceAll(string(body), "\r\n", "\n"), ""
+}
+
+func splitFrontmatter(payload []byte) ([]byte, []byte, string) {
+	opening := bytes.IndexByte(payload, '\n')
+	if opening < 0 || string(bytes.TrimSuffix(payload[:opening], []byte{'\r'})) != "---" {
+		return nil, nil, "missing_opening_delimiter"
+	}
+	start := opening + 1
+	for position := start; position < len(payload); {
+		if position > MaxFrontmatterBytes {
+			return nil, nil, "exceeds_64_kib"
+		}
+		length := bytes.IndexByte(payload[position:], '\n')
+		if length < 0 {
+			length = len(payload) - position
+		}
+		end := position + length
+		if string(bytes.TrimSuffix(payload[position:end], []byte{'\r'})) == "---" {
+			body := payload[end:]
+			return payload[start:position], bytes.TrimPrefix(body, []byte{'\n'}), ""
+		}
+		position = end + 1
+	}
+	return nil, nil, "missing_closing_delimiter"
+}
+
+// Explicit keys prevent aliases, merge inheritance and duplicate keys from
+// concealing missing metadata. Bound nesting and node count without expansion.
+func unambiguousYAML(n *yaml.Node, depth int, count *int) bool {
+	*count++
+	if depth > 32 || *count > 8192 || n.Kind == yaml.AliasNode {
+		return false
+	}
+	if n.Kind == yaml.MappingNode {
+		seen := map[string]bool{}
+		for i := 0; i < len(n.Content); i += 2 {
+			key := n.Content[i]
+			if key.Kind != yaml.ScalarNode || key.Tag != "!!str" || seen[key.Value] {
+				return false
+			}
+			seen[key.Value] = true
+		}
+	}
+	for _, child := range n.Content {
+		if !unambiguousYAML(child, depth+1, count) {
+			return false
+		}
+	}
+	return true
+}
+
+// bodySections recognizes ordinary ATX headings outside comments and code
+// examples. It checks presence of content, not the meaning of that content.
+func bodySections(body string) map[string]bool {
+	sections := map[string]bool{}
+	current, level := "", 0
+	fence := markdownFence{}
+	comment := false
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimLeft(raw, " ")
+		indent := len(raw) - len(line)
+		if fence.marker == 0 {
+			line = stripComments(line, &comment)
+		}
+		if indent <= 3 && fence.delimiter(line) {
+			continue
+		}
+		if fence.marker == 0 && indent <= 3 {
+			if key, n := atxHeading(line); n != 0 {
+				switch key {
+				case "applicability", "claim", "action", "limitations", "consumer", "retirement_condition":
+					current, level = key, n
+				default:
+					if n <= level {
+						current, level = "", 0
+					}
+				}
+				continue
+			}
+		}
+		if current != "" && len(bytes.TrimSpace([]byte(line))) > 0 {
+			sections[current] = true
+		}
+	}
+	return sections
+}
+
+type markdownFence struct {
+	marker byte
+	length int
+}
+
+func (f *markdownFence) delimiter(line string) bool {
+	line = strings.TrimSpace(line)
+	if len(line) < 3 || (line[0] != '`' && line[0] != '~') {
+		return false
+	}
+	n := 0
+	for n < len(line) && line[n] == line[0] {
+		n++
+	}
+	if n < 3 {
+		return false
+	}
+	if f.marker == 0 {
+		f.marker, f.length = line[0], n
+		return true
+	}
+	if line[0] == f.marker && n >= f.length && strings.TrimSpace(line[n:]) == "" {
+		f.marker, f.length = 0, 0
+		return true
+	}
+	return false
+}
+
+func atxHeading(line string) (string, int) {
+	n := 0
+	for n < len(line) && line[n] == '#' {
+		n++
+	}
+	if n == 0 || n > 6 || (n < len(line) && line[n] != ' ' && line[n] != '\t') {
+		return "", 0
+	}
+	title := strings.TrimSpace(line[n:])
+	withoutClosing := strings.TrimRight(title, "#")
+	if strings.HasSuffix(withoutClosing, " ") || strings.HasSuffix(withoutClosing, "\t") {
+		title = strings.TrimSpace(withoutClosing)
+	}
+	return strings.ReplaceAll(strings.ToLower(title), " ", "_"), n
+}
+
+func stripComments(line string, inComment *bool) string {
+	var out strings.Builder
+	for line != "" {
+		if *inComment {
+			_, rest, found := strings.Cut(line, "-->")
+			if !found {
+				break
+			}
+			line, *inComment = rest, false
+		} else {
+			before, rest, found := strings.Cut(line, "<!--")
+			out.WriteString(before)
+			if !found {
+				break
+			}
+			line, *inComment = rest, true
+		}
+	}
+	return out.String()
+}

--- a/cli/internal/okfprofile/profile_test.go
+++ b/cli/internal/okfprofile/profile_test.go
@@ -1,0 +1,145 @@
+package okfprofile
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// All examples are synthetic; no private source text belongs in this corpus.
+const observation = `---
+type: Observation
+title: Synthetic timeout observation
+description: One synthetic request succeeded after a bounded retry.
+status: draft
+knowledge_use: promotion-candidate
+sources:
+  - id: episode
+    resource: references/synthetic-episode.md
+generated: {by: example/1, at: 2026-09-08T12:00:00Z}
+---
+
+## Applicability
+The synthetic one-request experiment only.
+## Claim
+The second request succeeded.[^episode]
+## Limitations
+One observation does not establish a general retry policy.
+## Consumer
+The caller reviewing the synthetic request experiment.
+## Retirement condition
+Review when the request behavior changes; retire if the source is withdrawn.
+
+[^episode]: Synthetic episode.
+`
+
+func TestProfileExamples(t *testing.T) {
+	for _, tc := range []struct {
+		name, before, after, issue string
+	}{
+		{name: "narrow observation"},
+		{"maintained reference", "knowledge_use: promotion-candidate", "knowledge_use: maintained-reference", ""},
+		{"unknown concept type", "type: Observation", "type: Locally defined kind", ""},
+		{"bare verifier", "status: draft", "status: stable\nverified: {by: human:example, at: 2026-09-08T13:00:00-04:00}", ""},
+		{"verifier list", "status: draft", "status: deprecated\nverified:\n  - {by: process:example, at: 2026-09-08T13:00:00Z}\n  - {by: human:example, at: 2026-09-08T14:00:00Z}", ""},
+		{"generated time optional", ", at: 2026-09-08T12:00:00Z", "", ""},
+		{"source scope descriptor", "references/synthetic-episode.md", "all synthetic requests in the declared experiment", ""},
+		{"unknown extensions", "status: draft", "status: draft\nowner_label: illustrative-only\ncustom: {nested: [one, two]}", ""},
+		{"no implicit stable", "status: draft\n", "", "status"},
+		{"empty status", "status: draft", "status:", "status"},
+		{"unsupported status", "status: draft", "status: approved", "status"},
+		{"missing sources", "sources:\n  - id: episode\n    resource: references/synthetic-episode.md\n", "", "sources"},
+		{"empty sources", "sources:\n  - id: episode\n    resource: references/synthetic-episode.md", "sources: []", "sources"},
+		{"source string is not entry", "  - id: episode\n    resource: references/synthetic-episode.md", "  - references/synthetic-episode.md", "sources[0]"},
+		{"missing source resource", "    resource: references/synthetic-episode.md\n", "", "sources[0].resource"},
+		{"missing applicability", "## Applicability\nThe synthetic one-request experiment only.\n", "", "applicability"},
+		{"empty claim", "The second request succeeded.[^episode]", "", "claim/action"},
+		{"missing limitations", "## Limitations\nOne observation does not establish a general retry policy.\n", "", "limitations"},
+		{"missing consumer", "## Consumer\nThe caller reviewing the synthetic request experiment.\n", "", "consumer"},
+		{"missing retirement", "## Retirement condition\nReview when the request behavior changes; retire if the source is withdrawn.\n", "", "retirement_condition"},
+		{"missing use", "knowledge_use: promotion-candidate\n", "", "knowledge_use"},
+		{"unknown use", "knowledge_use: promotion-candidate", "knowledge_use: universal-rule", "knowledge_use"},
+		{"unknown page profile", "status: draft", "status: draft\nagentops_profile: unknown/99", "agentops_profile"},
+		{"incompatible version", "status: draft", "status: draft\nokf_version: '0.1'", "okf_version"},
+		{"malformed YAML", "title: Synthetic timeout observation", "title: [secret-unclosed", "frontmatter"},
+		{"duplicate status", "status: draft", "status: draft\nstatus: stable", "frontmatter"},
+		{"duplicate nested field", "    resource: references/synthetic-episode.md", "    resource: references/synthetic-episode.md\n    resource: something", "frontmatter"},
+		{"no YAML alias inference", "status: draft", "status: &s draft\ncopy: *s", "frontmatter"},
+		{"string type enforced", "title: Synthetic timeout observation", "title: 42", "title"},
+		{"generated actor required", "generated: {by: example/1, at: 2026-09-08T12:00:00Z}", "generated: {at: 2026-09-08T12:00:00Z}", "generated.by"},
+		{"invalid actor", "by: example/1", "by: human:", "generated.by"},
+		{"missing verifier timestamp", "status: draft", "status: draft\nverified: {by: human:example}", "verified[0].at"},
+		{"no timezone", "2026-09-08T12:00:00Z", "2026-09-08T12:00:00", "generated.at"},
+		{"fenced headings are examples", "## Applicability\nThe synthetic one-request experiment only.", "~~~md\n## Applicability\nThe synthetic one-request experiment only.\n~~~", "applicability"},
+		{"commented headings are absent", "## Applicability\nThe synthetic one-request experiment only.", "<!--\n## Applicability\nThe synthetic one-request experiment only.\n-->", "applicability"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := []byte(strings.Replace(observation, tc.before, tc.after, 1))
+			result, err := Check(payload, Profile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.StructurallyValid != (tc.issue == "") {
+				t.Fatalf("valid=%v, issues=%+v", result.StructurallyValid, result.Issues)
+			}
+			if tc.issue != "" {
+				found := false
+				for _, issue := range result.Issues {
+					found = found || issue.Field == tc.issue
+				}
+				if !found {
+					t.Fatalf("missing %s: %+v", tc.issue, result.Issues)
+				}
+			}
+			if result.ContentSHA256 != fmt.Sprintf("%x", sha256.Sum256(payload)) {
+				t.Fatal("receipt is not bound to exact original bytes")
+			}
+		})
+	}
+}
+
+func TestProfileRequiredStringsAndMetadataSections(t *testing.T) {
+	for _, key := range []string{"type", "title", "description"} {
+		lines := strings.Split(observation, "\n")
+		for i, line := range lines {
+			if strings.HasPrefix(line, key+":") {
+				lines[i] = key + ": ''"
+			}
+		}
+		result, err := Check([]byte(strings.Join(lines, "\n")), Profile)
+		if err != nil || result.StructurallyValid {
+			t.Fatalf("empty %s accepted: %v", key, err)
+		}
+	}
+	page := strings.Split(observation, "\n---\n")[0] + `
+applicability: The one declared experiment.
+action: Read the referenced observation.
+limitations: No demonstrated general benefit.
+consumer: The caller of this experiment.
+retirement_condition: Retire when withdrawn.
+---
+`
+	result, err := Check([]byte(page), Profile)
+	if err != nil || !result.StructurallyValid {
+		t.Fatalf("metadata sections: %+v %v", result, err)
+	}
+}
+
+func TestProfileBoundsAndVersion(t *testing.T) {
+	if _, err := Check([]byte(observation), "unknown/1"); err == nil {
+		t.Fatal("unknown profile accepted")
+	}
+	for _, payload := range [][]byte{
+		[]byte(strings.Repeat("x", MaxPageBytes+1)),
+		[]byte("---\ncustom: " + strings.Repeat("x", MaxFrontmatterBytes) + "\n---\n"),
+		[]byte("---\ntype: [\xff]\n---\n"),
+		[]byte("---\ntype: Observation\n"),
+		[]byte("not frontmatter\n"),
+	} {
+		result, err := Check(payload, Profile)
+		if err != nil || result.StructurallyValid {
+			t.Fatalf("invalid bounded input accepted: %+v %v", result, err)
+		}
+	}
+}

--- a/cli/internal/okfprofile/testdata/maintained-reference.md
+++ b/cli/internal/okfprofile/testdata/maintained-reference.md
@@ -1,0 +1,37 @@
+---
+type: Reference
+title: Synthetic request behavior reference
+description: The synthetic example service returns a fixed success response.
+status: stable
+knowledge_use: maintained-reference
+sources:
+  - id: example
+    resource: https://example.invalid/declared-source
+    title: Synthetic source for the test fixture
+generated: {by: example/1, at: 2026-09-08T12:00:00Z}
+verified: {by: human:example, at: 2026-09-08T13:00:00Z}
+---
+
+## Applicability
+
+The caller's synthetic example service only.
+
+## Claim
+
+The synthetic example response is fixed.[^example]
+
+## Limitations
+
+This fixture demonstrates document structure. It establishes no actual service
+behavior, independent review, disclosure permission or demonstrated usefulness.
+
+## Consumer
+
+The profile checker's deterministic fixture tests.
+
+## Retirement condition
+
+Review when the selected profile changes; retire when the fixture has no test
+consumer.
+
+[^example]: Synthetic source; the checker must not fetch this URL.

--- a/cli/internal/sourceread/command_test.go
+++ b/cli/internal/sourceread/command_test.go
@@ -1,0 +1,125 @@
+package sourceread
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This fixture builds the actual composition root and invokes its production
+// policy/reader boundary. The native BD adapter reads synthetic native responses;
+// source bytes, source policy, config and output are real files/process streams.
+func TestSourceBuiltCommandBoundary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX native BD fixture")
+	}
+	f := newFixture(t, []byte("CLI_BYTE_CANARY\x00\xff€\n"))
+	f.policy.OutputProfile.MaxSerializedBytes = 2048
+	if ref := os.Getenv("AO_SOURCE_READ_OBSERVATION"); ref != "" {
+		data, err := os.ReadFile(ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.policy.OutputProfile.ID = "codex-exec-command-2048-v1"
+		f.policy.OutputProfile.ObservationRef = ref
+		f.policy.OutputProfile.ObservationSHA256 = digest(data)
+	}
+	f.savePolicy()
+	bin := filepath.Join(f.root, "ao")
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	build := exec.CommandContext(ctx, "go", "build", "-o", bin, "./cmd/ao")
+	build.Dir = filepath.Join("..", "..")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("source build: %v %s", err, out)
+	}
+	nativePath := filepath.Join(f.root, "native-context.json")
+	commentsPath := filepath.Join(f.root, "comments.json")
+	writeJSONFixture(t, nativePath, f.native.native)
+	writeJSONFixture(t, commentsPath, f.native.comments)
+	bd := filepath.Join(f.root, "bd")
+	script := `#!/bin/sh
+case "$5" in
+ context) cat "$AO_TEST_NATIVE_CONTEXT" ;;
+ show) printf '[{"id":"anchor"}]\n' ;;
+ comments) cat "$AO_TEST_NATIVE_COMMENTS" ;;
+ *) exit 42 ;;
+esac
+`
+	if err := os.WriteFile(bd, []byte(script), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", f.root+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("AO_TEST_NATIVE_CONTEXT", nativePath)
+	t.Setenv("AO_TEST_NATIVE_COMMENTS", commentsPath)
+	args := []string{"session", "read-source", "--file", f.options.File, "--access-policy-ref", f.route.AccessPolicyRef, "--source-id", f.options.Context.SourceID, "--project-id", "project", "--owner-scope", "owner", "--task-ref", "task", "--model-ref", "model", "--destination-ref", "destination", "--consumer-root", f.options.Context.ConsumerRoot, "--native-directory", f.options.Context.NativeDirectory, "--start-byte", "0", "--max-bytes", "1", "--json"}
+	run := func(args []string) ([]byte, string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, bin, args...)
+		var out, diagnostic bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &diagnostic
+		err := cmd.Run()
+		if ctx.Err() != nil {
+			t.Fatalf("reader boundary did not finish; may have opened denied FIFO: %v", ctx.Err())
+		}
+		return out.Bytes(), diagnostic.String(), err
+	}
+	out, diagnostic, err := run(args)
+	if err != nil {
+		t.Fatalf("command fixture: %v %s", err, diagnostic)
+	}
+	var result Result
+	if err = json.Unmarshal(out, &result); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(result.BytesBase64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "C" || len(out) > 2048 || result.SerializedBytes != int64(len(out)) || result.AccessEnforcement != "not_attested" || result.CompleteReading || result.HostDelivery != "host-delivery-unverified" {
+		t.Fatalf("bad command facts: %s", out)
+	}
+	t.Logf("source-built CLI emitted %d bytes within selected 2048-byte profile; host delivery remains unverified", len(out))
+	if evidence := os.Getenv("AO_SOURCE_READ_FIXTURE_OUTPUT"); evidence != "" {
+		if err := os.WriteFile(evidence, out, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A premature source open would block on this FIFO. Both absent caller
+	// context and mismatched task fail promptly without opening it or emitting.
+	fifo := filepath.Join(f.root, "denied-fifo")
+	if output, err := exec.Command("mkfifo", fifo).CombinedOutput(); err != nil {
+		t.Fatalf("FIFO fixture: %v %s", err, output)
+	}
+	denied := append([]string{}, args...)
+	denied[3] = fifo
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{{"missing-policy", []string{"session", "read-source", "--file", fifo, "--start-byte", "0", "--max-bytes", "1", "--json"}}, {"unlisted-source", denied}} {
+		out, diagnostic, err := run(tc.args)
+		if err == nil || len(out) != 0 || strings.Contains(diagnostic, "CLI_BYTE_CANARY") {
+			t.Fatalf("%s denial: %v stdout=%s stderr=%s", tc.name, err, out, diagnostic)
+		}
+	}
+	wrongTask := append([]string{}, denied...)
+	for i := range wrongTask {
+		if wrongTask[i] == "--task-ref" {
+			wrongTask[i+1] = "wrong"
+		}
+	}
+	out, diagnostic, err = run(wrongTask)
+	if err == nil || len(out) != 0 {
+		t.Fatalf("wrong task: %v %s %s", err, out, diagnostic)
+	}
+}

--- a/cli/internal/sourceread/identity_unix.go
+++ b/cli/internal/sourceread/identity_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package sourceread
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func nativeIdentity(_ *os.File, info os.FileInfo) string {
+	if native, ok := info.Sys().(*syscall.Stat_t); ok {
+		return fmt.Sprintf("%d:%d", native.Dev, native.Ino)
+	}
+	return "unavailable"
+}

--- a/cli/internal/sourceread/identity_windows.go
+++ b/cli/internal/sourceread/identity_windows.go
@@ -1,0 +1,15 @@
+package sourceread
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func nativeIdentity(f *os.File, _ os.FileInfo) string {
+	var native syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(f.Fd()), &native); err != nil {
+		return "unavailable"
+	}
+	return fmt.Sprintf("%d:%d:%d", native.VolumeSerialNumber, native.FileIndexHigh, native.FileIndexLow)
+}

--- a/cli/internal/sourceread/policy.go
+++ b/cli/internal/sourceread/policy.go
@@ -1,0 +1,189 @@
+// Package sourceread reads explicit, authorized byte spans without interpreting
+// transcript records or claiming host delivery or semantic processing.
+package sourceread
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	configadapter "github.com/boshu2/agentops/cli/internal/adapters/config"
+	"github.com/boshu2/agentops/cli/internal/config"
+	"github.com/boshu2/agentops/cli/internal/verdictcheck"
+)
+
+// OutputProfile is selected through independently supplied T05 policy, never
+// through a source record. Its receipt is a caller observation, not OS isolation
+// or evidence of this particular command's delivery to a model.
+type OutputProfile struct {
+	ID                 string `json:"id"`
+	ModelRef           string `json:"model_ref"`
+	DestinationRef     string `json:"destination_ref"`
+	MaxSerializedBytes int64  `json:"max_serialized_bytes"`
+	ObservationRef     string `json:"observation_ref"`
+	ObservationSHA256  string `json:"observation_sha256"`
+}
+
+type SourcePermission struct {
+	Path         string `json:"path"`
+	ContentScope string `json:"content_scope"`
+}
+
+// Policy is the source-read-policy.v1 document at the resolved TaskPolicyRef.
+// The T05 access policy and native maintenance fact select this document.
+type Policy struct {
+	SchemaVersion  string             `json:"schema_version"`
+	SourceID       string             `json:"source_id"`
+	ProjectID      string             `json:"project_id"`
+	OwnerScope     string             `json:"owner_scope"`
+	TaskRef        string             `json:"task_ref"`
+	ModelRef       string             `json:"model_ref"`
+	DestinationRef string             `json:"destination_ref"`
+	Files          []SourcePermission `json:"files"`
+	OutputProfile  OutputProfile      `json:"output_profile"`
+}
+
+type authorization struct {
+	route        config.ContextResult
+	policy       Policy
+	policyDigest string
+	permission   SourcePermission
+}
+
+// Service's only public dependency is the existing native configuration port.
+// Zero-value Service uses the production native BD gateway. Private operation
+// seams let tests observe source-open ordering and races without global hooks.
+type Service struct {
+	Gateway    config.ContextGateway
+	openSource func(string) (*os.File, error)
+	afterRead  func()
+}
+
+func (s Service) authorize(ctx context.Context, o Options) (authorization, error) {
+	var a authorization
+	if strings.TrimSpace(o.Context.Overrides.AccessPolicyRef) == "" {
+		return a, fmt.Errorf("read-source denied: explicit access policy is required")
+	}
+	gateway := s.Gateway
+	if gateway == nil {
+		gateway = configadapter.Gateway{}
+	}
+	result, err := config.ResolveContext(ctx, gateway, o.Context)
+	if err != nil {
+		return a, fmt.Errorf("read-source denied: context authorization failed")
+	}
+	data, err := readPolicyFile(result.Route.TaskPolicyRef)
+	if err != nil {
+		return a, fmt.Errorf("read-source denied: source policy unavailable")
+	}
+	var p Policy
+	if err = strictJSON(data, &p); err != nil {
+		return a, fmt.Errorf("read-source denied: malformed source policy")
+	}
+	if !policyMatches(p, o.Context) {
+		return a, fmt.Errorf("read-source denied: source policy identity mismatch")
+	}
+	permission, err := permittedFile(p.Files, o.File)
+	if err != nil {
+		return a, err
+	}
+	if err := checkProfile(p.OutputProfile, o.Context); err != nil {
+		return a, err
+	}
+	// Validate the selected file's canonical location before opening bytes.
+	canonical, err := filepath.EvalSymlinks(o.File)
+	if err != nil || canonical != o.File {
+		return a, fmt.Errorf("read-source denied: source canonical identity unavailable or changed")
+	}
+	return authorization{route: result, policy: p, policyDigest: digest(data), permission: permission}, nil
+}
+
+func policyMatches(p Policy, r config.ContextRequest) bool {
+	return p.SchemaVersion == "source-read-policy.v1" && p.SourceID == r.SourceID && p.ProjectID == r.ProjectID && p.OwnerScope == r.OwnerScope && p.TaskRef == r.TaskRef && p.ModelRef == r.ModelRef && p.DestinationRef == r.DestinationRef
+}
+
+func permittedFile(files []SourcePermission, path string) (SourcePermission, error) {
+	var permission SourcePermission
+	// Compare the caller's exact lexical path before touching its metadata.
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return permission, fmt.Errorf("read-source denied: file must be an exact absolute path")
+	}
+	seen := map[string]bool{}
+	for _, f := range files {
+		if !filepath.IsAbs(f.Path) || filepath.Clean(f.Path) != f.Path || seen[f.Path] {
+			return permission, fmt.Errorf("read-source denied: invalid source allowlist")
+		}
+		seen[f.Path] = true
+		if f.ContentScope != "synthetic" && f.ContentScope != "already-cleared" && f.ContentScope != "restricted" {
+			return permission, fmt.Errorf("read-source denied: unsupported content scope")
+		}
+		if f.Path == path {
+			permission = f
+		}
+	}
+	if permission.Path == "" {
+		return permission, fmt.Errorf("read-source denied: file is not authorized")
+	}
+	// T05 only selects policy today. No supplied string can assert the missing
+	// native T39 enforcement. Restricted processing remains unavailable.
+	if permission.ContentScope == "restricted" {
+		return permission, fmt.Errorf("read-source denied: restricted-source native enforcement is unavailable")
+	}
+	return permission, nil
+}
+
+func checkProfile(profile OutputProfile, r config.ContextRequest) error {
+	if strings.TrimSpace(profile.ID) == "" || profile.ModelRef != r.ModelRef || profile.DestinationRef != r.DestinationRef || profile.MaxSerializedBytes <= 0 || !verdictcheck.ValidDigest(profile.ObservationSHA256) {
+		return fmt.Errorf("read-source denied: measured output profile is missing or mismatched")
+	}
+	observation, err := readPolicyFile(profile.ObservationRef)
+	if err != nil || digest(observation) != profile.ObservationSHA256 {
+		return fmt.Errorf("read-source denied: output profile observation integrity failed")
+	}
+	return nil
+}
+
+func strictJSON(data []byte, v any) error {
+	if !utf8.Valid(data) {
+		return fmt.Errorf("policy is not UTF-8")
+	}
+	if _, err := verdictcheck.DecodeObject(data); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(v)
+}
+
+func readPolicyFile(path string) (data []byte, err error) {
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf("absolute policy path required")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errors.Join(err, f.Close()) }()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("regular policy file required")
+	}
+	// A parser resource bound, not a measured host-output profile.
+	data, err = io.ReadAll(io.LimitReader(f, (1<<20)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 1<<20 {
+		return nil, fmt.Errorf("policy exceeds parser resource bound")
+	}
+	return data, nil
+}
+func digest(data []byte) string { return fmt.Sprintf("%x", sha256.Sum256(data)) }

--- a/cli/internal/sourceread/read.go
+++ b/cli/internal/sourceread/read.go
@@ -1,0 +1,262 @@
+package sourceread
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/boshu2/agentops/cli/internal/config"
+	"github.com/boshu2/agentops/cli/internal/verdictcheck"
+)
+
+// Options carries finite caller-selected bounds. ThroughByte and the expected
+// prefix digest are paired to bind every continued read to one frozen prefix.
+type Options struct {
+	File               string
+	Context            config.ContextRequest
+	StartByte          int64
+	MaxBytes           int64
+	ThroughByte        *int64
+	ExpectPrefixSHA256 string
+	ExpectFileIdentity string
+	AllowOversize      bool
+}
+
+type Observation struct {
+	Identity   string `json:"identity"`
+	Size       int64  `json:"size"`
+	ModifiedNS int64  `json:"modified_unix_nano"`
+}
+
+type Result struct {
+	SchemaVersion           string        `json:"schema_version"`
+	File                    string        `json:"file"`
+	SourceID                string        `json:"source_id"`
+	ProjectID               string        `json:"project_id"`
+	OwnerScope              string        `json:"owner_scope"`
+	TaskRef                 string        `json:"task_ref"`
+	ModelRef                string        `json:"model_ref"`
+	DestinationRef          string        `json:"destination_ref"`
+	ContentScope            string        `json:"content_scope"`
+	AccessEnforcement       string        `json:"access_enforcement"`
+	PolicySHA256            string        `json:"source_policy_sha256"`
+	Before                  Observation   `json:"file_before"`
+	After                   Observation   `json:"file_after"`
+	FileIdentityExpectation string        `json:"file_identity_expectation"`
+	CapturedThrough         int64         `json:"captured_through"`
+	StartByte               int64         `json:"start_byte"`
+	EndByte                 int64         `json:"end_byte"`
+	NextByte                int64         `json:"next_byte"`
+	PrefixSHA256            string        `json:"prefix_sha256"`
+	SpanSHA256              string        `json:"span_sha256"`
+	BytesBase64             string        `json:"bytes_base64"`
+	TextView                string        `json:"text_view"`
+	TextViewEncoding        string        `json:"text_view_encoding"`
+	Profile                 OutputProfile `json:"output_profile"`
+	OversizeOverride        bool          `json:"oversize_override"`
+	ProfileBoundSatisfied   bool          `json:"profile_bound_satisfied"`
+	HostDelivery            string        `json:"host_delivery"`
+	SemanticProcessing      string        `json:"semantic_processing"`
+	CompleteReading         bool          `json:"complete_reading"`
+	SerializedBytes         int64         `json:"serialized_bytes"`
+}
+
+func validateOptions(o Options) error {
+	if o.StartByte < 0 || o.MaxBytes <= 0 {
+		return fmt.Errorf("read-source: start-byte must be nonnegative and max-bytes must be positive")
+	}
+	if o.File == "" {
+		return fmt.Errorf("read-source: file is required")
+	}
+	if (o.ThroughByte == nil) != (o.ExpectPrefixSHA256 == "") {
+		return fmt.Errorf("read-source: through-byte and expect-prefix-sha256 must be supplied together")
+	}
+	if o.ThroughByte != nil && (*o.ThroughByte < 0 || o.StartByte > *o.ThroughByte || !verdictcheck.ValidDigest(o.ExpectPrefixSHA256)) {
+		return fmt.Errorf("read-source: invalid frozen boundary or prefix digest")
+	}
+	return nil
+}
+
+// Run emits exactly one compact JSON result after authorization, integrity and
+// actual serialized-size checks. A successful write is only emitted output;
+// downstream host observation and semantic acknowledgements remain separate.
+func Run(ctx context.Context, o Options, out io.Writer) error { return (Service{}).Run(ctx, o, out) }
+func (s Service) Run(ctx context.Context, o Options, out io.Writer) error {
+	if err := validateOptions(o); err != nil {
+		return err
+	}
+	a, err := s.authorize(ctx, o)
+	if err != nil {
+		return err
+	}
+	// The base64 content alone cannot fit when max-bytes exceeds this bound.
+	// Reject before source open; do not allocate an arbitrarily large request.
+	if !o.AllowOversize && o.MaxBytes > a.policy.OutputProfile.MaxSerializedBytes {
+		return fmt.Errorf("read-source: requested bounds exceed selected serialized-output profile; reduce max-bytes or explicitly allow oversize")
+	}
+	result, err := s.read(ctx, o, a)
+	if err != nil {
+		return err
+	}
+	payload, err := serialize(&result)
+	if err != nil {
+		return err
+	}
+	if int64(len(payload)) > a.policy.OutputProfile.MaxSerializedBytes {
+		if !o.AllowOversize {
+			return fmt.Errorf("read-source: serialized output exceeds selected profile; no source bytes emitted")
+		}
+		result.ProfileBoundSatisfied = false
+		payload, err = serialize(&result)
+		if err != nil {
+			return err
+		}
+	}
+	n, err := out.Write(payload)
+	if err != nil || n != len(payload) {
+		return fmt.Errorf("read-source: output write incomplete; host delivery unverified")
+	}
+	return nil
+}
+
+func serialize(r *Result) ([]byte, error) {
+	// serialized_bytes includes its own digits and the one newline. Iterate to
+	// a fixed point; the decimal width can only grow finitely.
+	for {
+		b, err := json.Marshal(r)
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, '\n')
+		if r.SerializedBytes == int64(len(b)) {
+			return b, nil
+		}
+		r.SerializedBytes = int64(len(b))
+	}
+}
+
+func observe(f *os.File, info os.FileInfo) Observation {
+	return Observation{Identity: nativeIdentity(f, info), Size: info.Size(), ModifiedNS: info.ModTime().UnixNano()}
+}
+
+func (s Service) read(ctx context.Context, o Options, a authorization) (r Result, err error) {
+	f, before, err := s.openChecked(o)
+	if err != nil {
+		return r, err
+	}
+	defer func() { err = errors.Join(err, f.Close()) }()
+	through := before.Size()
+	if o.ThroughByte != nil {
+		through = *o.ThroughByte
+	}
+	if through > before.Size() || o.StartByte > through {
+		return r, fmt.Errorf("read-source: truncated source or start beyond captured boundary")
+	}
+	count := min(o.MaxBytes, through-o.StartByte)
+	prefix, span, err := readPrefix(ctx, f, through, o.StartByte, count)
+	if err != nil {
+		return r, err
+	}
+	if o.ExpectPrefixSHA256 != "" && prefix != o.ExpectPrefixSHA256 {
+		return r, fmt.Errorf("read-source: frozen prefix changed")
+	}
+	if s.afterRead != nil {
+		s.afterRead()
+	}
+	after, err := verifyRead(ctx, f, o.File, before, through, prefix)
+	if err != nil {
+		return r, err
+	}
+	text, textEncoding := textView(span)
+	expectation := "not-supplied; cross-invocation replacement not checked"
+	if o.ExpectFileIdentity != "" {
+		expectation = "matched"
+	}
+	req := o.Context
+	return Result{SchemaVersion: "source-read.v1", File: o.File, SourceID: req.SourceID, ProjectID: req.ProjectID, OwnerScope: req.OwnerScope, TaskRef: req.TaskRef, ModelRef: req.ModelRef, DestinationRef: req.DestinationRef, ContentScope: a.permission.ContentScope, AccessEnforcement: a.route.AccessEnforcement, PolicySHA256: a.policyDigest, Before: observe(f, before), After: observe(f, after), FileIdentityExpectation: expectation, CapturedThrough: through, StartByte: o.StartByte, EndByte: o.StartByte + count, NextByte: o.StartByte + count, PrefixSHA256: prefix, SpanSHA256: digest(span), BytesBase64: base64.StdEncoding.EncodeToString(span), TextView: text, TextViewEncoding: textEncoding, Profile: a.policy.OutputProfile, OversizeOverride: o.AllowOversize, ProfileBoundSatisfied: true, HostDelivery: "host-delivery-unverified", SemanticProcessing: "not-established", CompleteReading: false}, nil
+}
+
+func (s Service) openChecked(o Options) (*os.File, os.FileInfo, error) {
+	before, err := os.Lstat(o.File)
+	if err != nil || !before.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("read-source: source is unavailable or not a regular file")
+	}
+	open := s.openSource
+	if open == nil {
+		open = os.Open
+	}
+	f, err := open(o.File)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read-source: source open failed")
+	}
+	opened, err := f.Stat()
+	if err != nil || !os.SameFile(before, opened) {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("read-source: file replaced while opening")
+	}
+	identity := nativeIdentity(f, opened)
+	if o.ExpectFileIdentity != "" && (identity == "unavailable" || o.ExpectFileIdentity != identity) {
+		_ = f.Close()
+		return nil, nil, fmt.Errorf("read-source: file identity changed or unavailable")
+	}
+	return f, opened, nil
+}
+
+func verifyRead(ctx context.Context, f *os.File, path string, opened os.FileInfo, through int64, prefix string) (os.FileInfo, error) {
+	// Re-read the entire frozen prefix; appends beyond it are harmless while
+	// corrections inside it invalidate this result, even with identical calls.
+	check, _, err := readPrefix(ctx, f, through, 0, 0)
+	if err != nil || check != prefix {
+		return nil, fmt.Errorf("read-source: frozen prefix changed or short read during verification")
+	}
+	after, err := f.Stat()
+	if err != nil || after.Size() < through {
+		return nil, fmt.Errorf("read-source: source truncated during read")
+	}
+	pathInfo, err := os.Lstat(path)
+	if err != nil || !pathInfo.Mode().IsRegular() || !os.SameFile(opened, pathInfo) {
+		return nil, fmt.Errorf("read-source: source replaced during read")
+	}
+	return after, nil
+}
+
+func textView(span []byte) (string, string) {
+	textEncoding := "utf-8"
+	text := string(span)
+	if !utf8.Valid(span) {
+		text = strings.ToValidUTF8(text, "\uFFFD")
+		textEncoding = "utf-8-replacement-view; bytes_base64 is authoritative"
+	}
+	return text, textEncoding
+}
+
+func readPrefix(ctx context.Context, f *os.File, through, start, count int64) (string, []byte, error) {
+	h := sha256.New()
+	var span bytes.Buffer
+	buf := make([]byte, 32*1024)
+	for offset := int64(0); offset < through; {
+		if err := ctx.Err(); err != nil {
+			return "", nil, fmt.Errorf("read-source: source read canceled")
+		}
+		n := min(int64(len(buf)), through-offset)
+		got, err := f.ReadAt(buf[:n], offset)
+		if err != nil || int64(got) != n {
+			return "", nil, fmt.Errorf("read-source: short source read")
+		}
+		_, _ = h.Write(buf[:got])
+		lo, hi := max(offset, start), min(offset+n, start+count)
+		if hi > lo {
+			_, _ = span.Write(buf[lo-offset : hi-offset])
+		}
+		offset += n
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), span.Bytes(), nil
+}

--- a/cli/internal/sourceread/read_test.go
+++ b/cli/internal/sourceread/read_test.go
@@ -1,0 +1,423 @@
+package sourceread
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/config"
+)
+
+type nativeFixture struct {
+	native   config.NativeContext
+	comments []config.AnchorComment
+	err      error
+	reads    int
+}
+
+func (n *nativeFixture) NativeContext(context.Context, string) (config.NativeContext, error) {
+	return n.native, n.err
+}
+func (n *nativeFixture) AnchorComments(context.Context, string, string) ([]config.AnchorComment, error) {
+	n.reads++
+	return n.comments, n.err
+}
+
+type fixture struct {
+	t       *testing.T
+	service Service
+	options Options
+	policy  Policy
+	route   config.ContextConfig
+	native  *nativeFixture
+	root    string
+}
+
+func newFixture(t *testing.T, content []byte) *fixture {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := func(name string) string {
+		p := filepath.Join(root, name)
+		if err := os.Mkdir(p, 0700); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	source, consumer, bundle, evidence, stage := dir("native"), dir("consumer"), dir("bundle"), dir("evidence"), dir("stage")
+	r := config.ContextConfig{SourceID: source, ProjectID: "project", OwnerScope: "owner", BundleID: "bundle", BundleRoot: bundle, EvidenceRoot: evidence, StagingRoot: stage, AccessPolicyRef: filepath.Join(root, "access.json"), OwnerPolicyRef: filepath.Join(root, "owner.json"), TaskPolicyRef: filepath.Join(root, "task.json"), ModelPolicyRef: filepath.Join(root, "model.json"), DestinationPolicyRef: filepath.Join(root, "destination.json"), MaintenanceWorkRef: "anchor"}
+	for _, p := range []string{r.OwnerPolicyRef, r.ModelPolicyRef, r.DestinationPolicyRef} {
+		if err := os.WriteFile(p, []byte("{}"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	file := filepath.Join(root, "source.jsonl")
+	if err := os.WriteFile(file, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+	observation := filepath.Join(root, "observation.json")
+	observed := []byte(`{"fixture_only":true,"serialized_output_observation":"synthetic test"}`)
+	if err := os.WriteFile(observation, observed, 0600); err != nil {
+		t.Fatal(err)
+	}
+	p := Policy{SchemaVersion: "source-read-policy.v1", SourceID: source, ProjectID: "project", OwnerScope: "owner", TaskRef: "task", ModelRef: "model", DestinationRef: "destination", Files: []SourcePermission{{Path: file, ContentScope: "synthetic"}}, OutputProfile: OutputProfile{ID: "synthetic-fixture-only", ModelRef: "model", DestinationRef: "destination", MaxSerializedBytes: 4096, ObservationRef: observation, ObservationSHA256: digest(observed)}}
+	access := config.ContextPolicy{SchemaVersion: 1, SourceID: source, ProjectID: "project", OwnerScope: "owner", TaskRef: "task", ModelRef: "model", DestinationRef: "destination", BundleID: r.BundleID, BundleRoot: r.BundleRoot, EvidenceRoot: r.EvidenceRoot, StagingRoot: r.StagingRoot, OwnerPolicyRef: r.OwnerPolicyRef, TaskPolicyRef: r.TaskPolicyRef, ModelPolicyRef: r.ModelPolicyRef, DestinationPolicyRef: r.DestinationPolicyRef, MaintenanceWorkRef: r.MaintenanceWorkRef}
+	writeJSONFixture(t, r.AccessPolicyRef, access)
+	configPath := filepath.Join(root, "config.yaml")
+	writeJSONFixture(t, configPath, map[string]any{"context": r})
+	t.Setenv("AGENTOPS_CONFIG", configPath)
+	for _, k := range []string{"SOURCE_ID", "PROJECT_ID", "OWNER_SCOPE", "BUNDLE_ID", "BUNDLE_ROOT", "EVIDENCE_ROOT", "STAGING_ROOT", "ACCESS_POLICY_REF", "OWNER_POLICY_REF", "TASK_POLICY_REF", "MODEL_POLICY_REF", "DESTINATION_POLICY_REF", "MAINTENANCE_WORK_REF"} {
+		t.Setenv("AGENTOPS_CONTEXT_"+k, "")
+	}
+	fact, _ := json.Marshal(config.ContextFact{Type: "context.route.v1", FactID: "route", Route: &r})
+	native := &nativeFixture{native: config.NativeContext{BDVersion: "1.2.2", SchemaVersion: 1, Backend: "dolt", ProjectID: "project", BeadsDir: source}, comments: []config.AnchorComment{{ID: "1", IssueID: "anchor", Text: string(fact)}}}
+	f := &fixture{t: t, root: root, route: r, policy: p, native: native, service: Service{Gateway: native}, options: Options{File: file, StartByte: 0, MaxBytes: 16, Context: config.ContextRequest{SourceID: source, ProjectID: "project", OwnerScope: "owner", TaskRef: "task", ModelRef: "model", DestinationRef: "destination", ConsumerRoot: consumer, NativeDirectory: consumer, Overrides: config.ContextConfig{AccessPolicyRef: r.AccessPolicyRef}}}}
+	f.savePolicy()
+	return f
+}
+func writeJSONFixture(t *testing.T, p string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.WriteFile(p, b, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+func (f *fixture) savePolicy() { writeJSONFixture(f.t, f.route.TaskPolicyRef, f.policy) }
+func (f *fixture) run() (Result, []byte, error) {
+	var out bytes.Buffer
+	err := f.service.Run(context.Background(), f.options, &out)
+	var r Result
+	if err == nil {
+		if decErr := json.Unmarshal(out.Bytes(), &r); decErr != nil {
+			f.t.Fatal(decErr)
+		}
+	}
+	return r, out.Bytes(), err
+}
+func (f *fixture) success() Result {
+	f.t.Helper()
+	r, raw, err := f.run()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if r.SerializedBytes != int64(len(raw)) {
+		f.t.Fatalf("serialized size %d != %d", r.SerializedBytes, len(raw))
+	}
+	if r.HostDelivery != "host-delivery-unverified" || r.CompleteReading || r.SemanticProcessing != "not-established" {
+		f.t.Fatalf("unsupported coverage: %+v", r)
+	}
+	return r
+}
+func TestRawSpanAndFrozenAppend(t *testing.T) {
+	original := []byte("operator correction\n{\"tool\":\"same\"}\n\u2028\u2029\n")
+	f := newFixture(t, original)
+	f.options.StartByte = 3
+	f.options.MaxBytes = 11
+	r := f.success()
+	raw, err := base64.StdEncoding.DecodeString(r.BytesBase64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, original[3:14]) || r.StartByte != 3 || r.EndByte != 14 || r.NextByte != 14 || r.CapturedThrough != int64(len(original)) || r.PrefixSHA256 != digest(original) || r.SpanSHA256 != digest(original[3:14]) {
+		t.Fatalf("incorrect raw facts: %+v", r)
+	}
+	f.options.ThroughByte = &r.CapturedThrough
+	f.options.ExpectPrefixSHA256 = r.PrefixSHA256
+	f.options.ExpectFileIdentity = r.Before.Identity
+	file, err := os.OpenFile(f.options.File, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = file.WriteString("new tail"); err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+	appended := f.success()
+	if appended.PrefixSHA256 != r.PrefixSHA256 || appended.CapturedThrough != r.CapturedThrough || appended.After.Size <= r.After.Size {
+		t.Fatal("append changed frozen prefix")
+	}
+}
+func TestOperatorCorrectionBetweenIdenticalToolCalls(t *testing.T) {
+	a := []byte("{\"tool\":\"same\"}\n{\"user\":\"correct A\"}\n{\"tool\":\"same\"}\n")
+	f := newFixture(t, a)
+	r := f.success()
+	f.options.ThroughByte = &r.CapturedThrough
+	f.options.ExpectPrefixSHA256 = r.PrefixSHA256
+	b := bytes.Replace(a, []byte("correct A"), []byte("correct B"), 1)
+	if err := os.WriteFile(f.options.File, b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, raw, err := f.run()
+	if err == nil || !strings.Contains(err.Error(), "prefix changed") || len(raw) != 0 {
+		t.Fatalf("correction accepted: %v %s", err, raw)
+	}
+}
+func TestInvalidAndSplitUTF8RemainReversible(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		data       []byte
+		start, max int64
+	}{{"invalid", []byte{0xff, 0x00, 'x', 0xfe}, 0, 4}, {"split", []byte("A€B"), 2, 1}, {"separators", []byte("x\u2028y\u2029z\n"), 0, 20}} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t, tc.data)
+			f.options.StartByte = tc.start
+			f.options.MaxBytes = tc.max
+			r := f.success()
+			raw, err := base64.StdEncoding.DecodeString(r.BytesBase64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			end := min(int64(len(tc.data)), tc.start+tc.max)
+			if !bytes.Equal(raw, tc.data[tc.start:end]) {
+				t.Fatal("bytes repaired or lost")
+			}
+			if tc.name != "separators" && !strings.Contains(r.TextViewEncoding, "replacement-view") {
+				t.Fatal("unlabelled lossy text")
+			}
+		})
+	}
+}
+func TestBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		start, max int64
+		hash       string
+	}{{"zero", 0, 0, ""}, {"negative-max", 0, -1, ""}, {"negative-start", -1, 1, ""}, {"huge", 0, math.MaxInt64, ""}, {"unpaired-digest", 0, 1, strings.Repeat("0", 64)}, {"beyond-source", 99, 1, ""}} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t, []byte("abc"))
+			f.options.StartByte = tc.start
+			f.options.MaxBytes = tc.max
+			f.options.ExpectPrefixSHA256 = tc.hash
+			_, out, err := f.run()
+			if err == nil || len(out) > 0 {
+				t.Fatalf("invalid bounds emitted %s, %v", out, err)
+			}
+		})
+	}
+	t.Run("empty-source", func(t *testing.T) {
+		f := newFixture(t, nil)
+		r := f.success()
+		if r.CapturedThrough != 0 || r.EndByte != 0 || r.PrefixSHA256 != digest(nil) {
+			t.Fatal("empty source facts invalid")
+		}
+	})
+	t.Run("end-of-prefix", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		r := f.success()
+		f.options.StartByte = 3
+		f.options.ThroughByte = &r.CapturedThrough
+		f.options.ExpectPrefixSHA256 = r.PrefixSHA256
+		if f.success().BytesBase64 != "" {
+			t.Fatal("nonempty terminal span")
+		}
+	})
+}
+func TestSerializedProfileAndOversize(t *testing.T) {
+	f := newFixture(t, bytes.Repeat([]byte("\x00"), 1000))
+	f.options.MaxBytes = 1000
+	_, out, err := f.run()
+	if err == nil || !strings.Contains(err.Error(), "serialized output exceeds") || len(out) != 0 {
+		t.Fatalf("serialized overflow missed: %v (%d bytes)", err, len(out))
+	}
+	f.options.AllowOversize = true
+	r := f.success()
+	if r.ProfileBoundSatisfied || !r.OversizeOverride {
+		t.Fatal("oversize not disclosed")
+	}
+	f.options.MaxBytes = math.MaxInt64
+	r = f.success()
+	if r.EndByte != 1000 {
+		t.Fatal("oversize arithmetic overflow")
+	}
+	f.options.MaxBytes = 1
+	r = f.success()
+	if !r.OversizeOverride {
+		t.Fatal("explicit override lost")
+	}
+}
+func TestDeniedPolicyNeverOpensSource(t *testing.T) {
+	cases := map[string]func(*fixture){
+		"missing-access":       func(f *fixture) { f.options.Context.Overrides.AccessPolicyRef = "" },
+		"missing-owner":        func(f *fixture) { f.options.Context.OwnerScope = "" },
+		"wrong-source":         func(f *fixture) { f.options.Context.SourceID = "/other-native" },
+		"wrong-project":        func(f *fixture) { f.options.Context.ProjectID = "wrong" },
+		"wrong-task":           func(f *fixture) { f.options.Context.TaskRef = "wrong" },
+		"wrong-model":          func(f *fixture) { f.options.Context.ModelRef = "wrong" },
+		"wrong-destination":    func(f *fixture) { f.options.Context.DestinationRef = "wrong" },
+		"unlisted-file":        func(f *fixture) { f.policy.Files = nil; f.savePolicy() },
+		"restricted":           func(f *fixture) { f.policy.Files[0].ContentScope = "restricted"; f.savePolicy() },
+		"bad-profile":          func(f *fixture) { f.policy.OutputProfile.MaxSerializedBytes = 0; f.savePolicy() },
+		"observation-tampered": func(f *fixture) { os.WriteFile(f.policy.OutputProfile.ObservationRef, []byte("changed"), 0600) },
+		"policy-wrong-model":   func(f *fixture) { f.policy.ModelRef = "wrong"; f.savePolicy() },
+		"anchor-unavailable":   func(f *fixture) { f.native.err = fmt.Errorf("unavailable") },
+		"native-mismatch":      func(f *fixture) { f.native.native.ProjectID = "other" },
+		"bad-json": func(f *fixture) {
+			os.WriteFile(f.route.TaskPolicyRef, []byte(`{"schema_version":"source-read-policy.v1","schema_version":"source-read-policy.v1"}`), 0600)
+		},
+	}
+	for name, change := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t, []byte("DENIED_SOURCE_CANARY"))
+			opened := false
+			f.service.openSource = func(p string) (*os.File, error) { opened = true; return os.Open(p) }
+			change(f)
+			_, out, err := f.run()
+			if err == nil || opened || len(out) != 0 || strings.Contains(err.Error(), "DENIED_SOURCE_CANARY") {
+				t.Fatalf("denial leaked or opened: opened=%v err=%v out=%s", opened, err, out)
+			}
+		})
+	}
+}
+func TestReplacementAndShortReads(t *testing.T) {
+	t.Run("same-content-new-inode", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		r := f.success()
+		replacement := filepath.Join(f.root, "replacement")
+		os.WriteFile(replacement, []byte("abc"), 0600)
+		os.Rename(replacement, f.options.File)
+		f.options.ExpectFileIdentity = r.Before.Identity
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("replacement accepted")
+		}
+	})
+	t.Run("replace-at-open", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		f.service.openSource = func(p string) (*os.File, error) {
+			replacement := filepath.Join(f.root, "replacement")
+			os.WriteFile(replacement, []byte("abc"), 0600)
+			os.Rename(replacement, p)
+			return os.Open(p)
+		}
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("open replacement accepted")
+		}
+	})
+	t.Run("replace-during-read", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		f.service.afterRead = func() {
+			p := filepath.Join(f.root, "replacement")
+			os.WriteFile(p, []byte("abc"), 0600)
+			os.Rename(p, f.options.File)
+		}
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("read replacement accepted")
+		}
+	})
+	t.Run("short-read", func(t *testing.T) {
+		f := newFixture(t, []byte("abcdef"))
+		r := f.success()
+		f.options.ThroughByte = &r.CapturedThrough
+		f.options.ExpectPrefixSHA256 = r.PrefixSHA256
+		os.Truncate(f.options.File, 2)
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("truncated frozen source accepted")
+		}
+	})
+	t.Run("truncate-during-read", func(t *testing.T) {
+		f := newFixture(t, []byte("abcdef"))
+		f.service.afterRead = func() { os.Truncate(f.options.File, 2) }
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("concurrent truncate accepted")
+		}
+	})
+	t.Run("rewrite-during-read", func(t *testing.T) {
+		f := newFixture(t, []byte("abcdef"))
+		f.service.afterRead = func() { os.WriteFile(f.options.File, []byte("abcxef"), 0600) }
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("concurrent correction accepted")
+		}
+	})
+	t.Run("append-during-read", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		f.service.afterRead = func() {
+			h, _ := os.OpenFile(f.options.File, os.O_WRONLY|os.O_APPEND, 0600)
+			h.WriteString("new tail")
+			h.Close()
+		}
+		r := f.success()
+		if r.CapturedThrough != 3 {
+			t.Fatal("append enlarged denominator")
+		}
+	})
+	t.Run("symlink", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		p := filepath.Join(f.root, "link")
+		os.Symlink(f.options.File, p)
+		f.options.File = p
+		f.policy.Files[0].Path = p
+		f.savePolicy()
+		_, out, err := f.run()
+		if err == nil || len(out) > 0 {
+			t.Fatal("source alias accepted")
+		}
+	})
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) { return len(p) / 2, nil }
+func TestOutputShortWriteIsUnverified(t *testing.T) {
+	f := newFixture(t, []byte("abc"))
+	err := f.service.Run(context.Background(), f.options, shortWriter{})
+	if err == nil || !strings.Contains(err.Error(), "delivery unverified") {
+		t.Fatalf("short write: %v", err)
+	}
+}
+func TestCanceledReadEmitsNothing(t *testing.T) {
+	f := newFixture(t, []byte("abc"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var out bytes.Buffer
+	err := f.service.Run(ctx, f.options, &out)
+	if err == nil || out.Len() > 0 {
+		t.Fatal("canceled read emitted source")
+	}
+}
+
+func TestFrozenBoundArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		through  int64
+		expected string
+		start    int64
+	}{{"negative", -1, strings.Repeat("0", 64), 0}, {"missing-digest", 1, "", 0}, {"invalid-digest", 1, "NOT_A_SHA256", 0}, {"start-after-boundary", 1, strings.Repeat("0", 64), 2}, {"truncated", 4, digest([]byte("abcd")), 0}} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t, []byte("abc"))
+			f.options.ThroughByte = &tc.through
+			f.options.ExpectPrefixSHA256 = tc.expected
+			f.options.StartByte = tc.start
+			_, out, err := f.run()
+			if err == nil || len(out) > 0 {
+				t.Fatalf("frozen argument admitted: %v %s", err, out)
+			}
+		})
+	}
+	t.Run("zero-boundary", func(t *testing.T) {
+		f := newFixture(t, []byte("abc"))
+		zero := int64(0)
+		f.options.ThroughByte = &zero
+		f.options.ExpectPrefixSHA256 = digest(nil)
+		r := f.success()
+		if r.EndByte != 0 || r.PrefixSHA256 != digest(nil) {
+			t.Fatal("zero frozen boundary changed")
+		}
+	})
+}

--- a/docs/cli-surface.json
+++ b/docs/cli-surface.json
@@ -206,6 +206,13 @@
     },
     {
       "category": "public-tested",
+      "command": "provenance check-okf",
+      "coverage_status": "covered",
+      "kind": "leaf",
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+    },
+    {
+      "category": "public-tested",
       "command": "provenance digest",
       "coverage_status": "covered",
       "kind": "leaf",
@@ -347,6 +354,13 @@
     {
       "category": "public-tested",
       "command": "session prune-agents",
+      "coverage_status": "covered",
+      "kind": "leaf",
+      "reason": "Covered by release smoke tests, direct command tests, or command handler tests."
+    },
+    {
+      "category": "public-tested",
+      "command": "session read-source",
       "coverage_status": "covered",
       "kind": "leaf",
       "reason": "Covered by release smoke tests, direct command tests, or command handler tests."

--- a/docs/cli-surface.md
+++ b/docs/cli-surface.md
@@ -33,6 +33,7 @@
 | `ao help` | `internal-hidden` | `allowlisted` | Built-in Cobra help dispatcher with no application handler. |
 | `ao init` | `public-tested` | `allowlisted` | Covered by internal/commands/init module tests and internal/initapp tests after the init carve-out. |
 | `ao provenance add` | `public-tested` | `allowlisted` | Covered by internal/commands/provenance module tests after the provenance carve-out. |
+| `ao provenance check-okf` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance digest` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance evidence-orphans` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao provenance export` | `public-tested` | `allowlisted` | Covered by internal/commands/provenance module tests after the provenance carve-out. |
@@ -54,6 +55,7 @@
 | `ao session bootstrap` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao session handoff` | `public-tested` | `allowlisted` | Covered by handoff artifact tests. |
 | `ao session prune-agents` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
+| `ao session read-source` | `public-tested` | `covered` | Covered by release smoke tests, direct command tests, or command handler tests. |
 | `ao session rehydrate` | `public-tested` | `allowlisted` | Covered by rehydrate artifact tests. |
 | `ao skills check` | `public-tested` | `allowlisted` | Covered by internal/commands/skills module tests after the skills carve-out. |
 | `ao skills consumers` | `public-tested` | `allowlisted` | Covered by internal/commands/skills module tests after the skills carve-out. |

--- a/evals/agentops-core/cli-command-surface-matrix.json
+++ b/evals/agentops-core/cli-command-surface-matrix.json
@@ -41,7 +41,7 @@
       },
       "expectations": [
         {"type": "exit_code", "value": 0},
-        {"type": "stdout_contains", "value": "cli-command-headings: top=18 sub=54 all=72"},
+        {"type": "stdout_contains", "value": "cli-command-headings: top=18 sub=56 all=74"},
         {"type": "stdout_contains", "value": "cli-help-matrix-ok"}
       ],
       "dimensions": ["correctness", "runtime_compatibility", "artifact_quality"],

--- a/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
+++ b/evals/agentops-core/fixtures/cli-command-surface-smoke.sh
@@ -17,7 +17,7 @@ top_count="$(rg -c '^### `ao ' "$DOCS_PATH")"
 sub_count="$(rg -c '^#### `ao ' "$DOCS_PATH")"
 all_count="$(rg -c '^#{3,5} `ao ' "$DOCS_PATH")"
 
-if [[ "$top_count" != "18" || "$sub_count" != "54" || "$all_count" != "72" ]]; then
+if [[ "$top_count" != "18" || "$sub_count" != "56" || "$all_count" != "74" ]]; then
   printf 'unexpected command heading counts: top=%s sub=%s all=%s\n' "$top_count" "$sub_count" "$all_count" >&2
   exit 1
 fi
@@ -25,7 +25,7 @@ fi
 # shellcheck disable=SC2016 # literal backticks delimit generated Markdown command headings.
 mapfile -t commands < <(rg '^#{3,5} `ao ' "$DOCS_PATH" | sed -E 's/^.*`([^`]+)`.*/\1/')
 
-if [[ "${#commands[@]}" -ne 72 ]]; then
+if [[ "${#commands[@]}" -ne 74 ]]; then
   printf 'unexpected command matrix size: %s\n' "${#commands[@]}" >&2
   exit 1
 fi

--- a/images/gemini/skills/cass/SKILL.md
+++ b/images/gemini/skills/cass/SKILL.md
@@ -241,6 +241,7 @@ Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.bead
 | jq patterns | [PATTERNS.md](references/PATTERNS.md) |
 | Pitfalls & fixes | [PITFALLS.md](references/PITFALLS.md) |
 | Session file formats | [SESSION_FORMATS.md](references/SESSION_FORMATS.md) |
+| Bounded authorized source-byte reads | [RAW_SOURCE_READS.md](references/RAW_SOURCE_READS.md) |
 | Remote sources, multi-machine search | [REMOTE_SOURCES.md](references/REMOTE_SOURCES.md) |
 | Semantic / hybrid / models | [SEMANTIC_AND_HYBRID.md](references/SEMANTIC_AND_HYBRID.md) |
 | Token / tool / model analytics | [ANALYTICS.md](references/ANALYTICS.md) |

--- a/images/gemini/skills/cass/references/RAW_SOURCE_READS.md
+++ b/images/gemini/skills/cass/references/RAW_SOURCE_READS.md
@@ -1,0 +1,113 @@
+# Bounded raw source reads
+
+CASS search, `view` and `expand` locate excerpts. `ao session read-source`
+returns explicit raw bytes after checking caller-selected policy; it does not
+parse records or replace the existing `ao provenance mine-session` tool-call
+contract. Raw bytes include prose, operator corrections, malformed records and
+Unicode line/paragraph separators. If a later consumer parses JSONL, split on
+the byte `\n`, not Unicode line boundaries, and retain rejected records in raw
+coverage accounting.
+
+## Select access before opening bytes
+
+The caller independently supplies the expected native source/project, owner,
+task, model and destination. Existing T05 configuration and its native BD 1.2.2
+maintenance anchor must resolve successfully. The access-policy reference is an
+identity, not permission by its presence. Missing or mismatched context denies
+the read; no source content is included in the error.
+
+The resolved `task_policy_ref` selects a `source-read-policy.v1` JSON document.
+It binds the same source/project/owner/task/model/destination to exact canonical
+file permissions and a measured output profile. The caller, not the source
+record or a knowledge candidate, owns this document. For example, replacing
+these illustrative identities and paths with the independently authorized ones:
+
+```json
+{
+  "schema_version": "source-read-policy.v1",
+  "source_id": "/native/tracker/.beads",
+  "project_id": "native-project-id",
+  "owner_scope": "selected-owner",
+  "task_ref": "selected-task",
+  "model_ref": "selected-model",
+  "destination_ref": "selected-destination",
+  "files": [
+    {"path": "/authorized/source.jsonl", "content_scope": "already-cleared"}
+  ],
+  "output_profile": {
+    "id": "caller-selected-measured-profile",
+    "model_ref": "selected-model",
+    "destination_ref": "selected-destination",
+    "max_serialized_bytes": 2048,
+    "observation_ref": "/protected/host-output-observation.json",
+    "observation_sha256": "replace-with-the-actual-64-character-lowercase-sha256"
+  }
+}
+```
+
+The example size is illustrative, not a default or a universal safe limit.
+Select a limit measured on the actual native tool-result surface and preserve
+its observation bytes/digest. The reader verifies the selected observation's
+integrity; it does not attest its truth or observe host delivery. Policy and
+observation documents have a separate 1 MiB parser resource bound. No source
+locator, task, model, destination or profile has an inferred public default.
+
+Allowed `content_scope` values are `synthetic`, `already-cleared` and `restricted`.
+Current T05 reports `access_enforcement: not_attested`; restricted source reads
+are therefore unavailable. The first two scopes support explicitly authorized
+mechanism checks only. A policy label, file permission or worktree cannot supply
+the native runtime/OS and egress enforcement owned by T39.
+
+## Read and continue the same frozen prefix
+
+```sh
+ao session read-source \
+  --file /authorized/source.jsonl \
+  --access-policy-ref /protected/access-policy.json \
+  --source-id /native/tracker/.beads --project-id native-project-id \
+  --owner-scope selected-owner --task-ref selected-task \
+  --model-ref selected-model --destination-ref selected-destination \
+  --consumer-root /consumer/checkout --native-directory /native/workspace \
+  --start-byte 0 --max-bytes 64 --json
+```
+
+The first invocation freezes the observed file size as `captured_through`.
+Continue with `--start-byte` equal to `next_byte`, and pair
+`--through-byte` with `--expect-prefix-sha256` from that result. The expected
+hash covers **all bytes in `[0, captured_through)`**, not just the previous
+span. Appends after that boundary are allowed. Any changed prefix, including
+only an operator correction between identical tool calls, invalidates it.
+
+Pass the previous `file_before.identity` as `--expect-file-identity` to check
+replacement across invocations, even when a new file has identical contents.
+Without that expectation, the response explicitly says cross-invocation
+replacement was not checked. Within each invocation the reader compares the
+opened file identity with the path before/after reading, rejects short reads,
+and hashes the frozen prefix again to detect concurrent changes. These are
+observations, not an atomic snapshot or a lock against a malicious concurrent
+writer. Native files remain authoritative; no new source/state store is created.
+
+## Interpret output honestly
+
+`source-read.v1` is one compact JSON document, including a trailing newline.
+`start_byte`, `end_byte` and `next_byte` identify the returned half-open span.
+`prefix_sha256` hashes the entire frozen prefix; `span_sha256` hashes exactly
+the returned bytes. `bytes_base64` is reversible and authoritative. `text_view`
+is separately labelled with `text_view_encoding`; invalid or split UTF-8 uses
+a replacement view and must never replace the raw bytes for integrity.
+
+The reader checks the **actual serialized document length**, including metadata,
+base64 expansion, text escapes and newline. Oversize output emits no source
+bytes unless the caller explicitly sets `--allow-oversize`; that override is
+recorded and never establishes complete reading. `profile_bound_satisfied`
+reports the size comparison, not delivery. JSON is the measured output format;
+YAML is rejected rather than silently bypassing its size contract.
+
+Every result reports `host_delivery: host-delivery-unverified`,
+`semantic_processing: not-established` and `complete_reading: false`.
+`serialized_bytes` records emitted document size, not what a tool wrapper
+actually delivered. Preserve the native transcript's actual result and any
+truncation/omission markers. Even a successful producer and an observed final
+sentinel cannot prove the omitted middle was delivered or processed. T09 owns
+later identity-bound coverage/acknowledgement verification; a head-and-tail
+read still leaves the middle unread.

--- a/images/gemini/skills/cass/references/SESSION_FORMATS.md
+++ b/images/gemini/skills/cass/references/SESSION_FORMATS.md
@@ -7,6 +7,7 @@
 ## Contents
 
 - [Work-to-session associations](#work-to-session-associations)
+- [Bounded raw source reads](RAW_SOURCE_READS.md)
 - [Quick Detection](#quick-detection)
 - [Claude Code Format](#claude-code-format)
 - [Codex CLI Format](#codex-cli-format)
@@ -72,6 +73,11 @@ prove bytes were emitted, delivered to the host or semantically processed.
 Head/tail excerpts leave the middle unread; new tails or children belong to a
 later observation, not a rewritten completed denominator. T09 owns the later
 coverage verifier; no coverage command or acceptance claim is introduced here.
+
+For byte-preserving reads of explicitly authorized sources, follow
+[bounded raw source reads](RAW_SOURCE_READS.md). The source reader checks native
+policy before opening bytes and reports frozen prefix/span digests, reversible
+content and delivery limits; emitted stdout does not establish full reading.
 
 ## Quick Detection
 

--- a/images/gemini/skills/learn/SKILL.md
+++ b/images/gemini/skills/learn/SKILL.md
@@ -76,6 +76,14 @@ Knowledge is revisable. Preserve evidence and provenance when retracting an
 unsupported or stale belief; artifact accumulation is not a monotonic increase
 in truth or utility. Negative, null, and contradictory results remain visible.
 
+When the caller selects an OKF page for an observation or maintained reference,
+follow the [pinned page profile](references/okf-page-profile.md) and run
+`ao provenance check-okf --file <concept.md>` before exact-content review.
+The command checks structure only: it cannot establish factual support,
+destination disclosure, independent review or usefulness, and it neither
+admits pages nor promotes rules. This optional representation does not broaden
+Learn's verdict-only input or authorize a new storage destination.
+
 A repeated finding class may support a check proposal only when causal evidence
 identifies a preventable defect and a concrete consumer needs that check. Name
 the exact behavior the check would refuse and why existing checks missed it;

--- a/images/gemini/skills/learn/SKILL.md
+++ b/images/gemini/skills/learn/SKILL.md
@@ -80,7 +80,8 @@ When the caller selects an OKF page for an observation or maintained reference,
 follow the [pinned page profile](references/okf-page-profile.md) and run
 `ao provenance check-okf --file <concept.md>` before exact-content review.
 The command checks structure only: it cannot establish factual support,
-destination disclosure, independent review or usefulness, and it neither
+permission to disclose to the destination, independent review or usefulness,
+and it neither
 admits pages nor promotes rules. This optional representation does not broaden
 Learn's verdict-only input or authorize a new storage destination.
 

--- a/images/gemini/skills/learn/references/okf-page-profile.md
+++ b/images/gemini/skills/learn/references/okf-page-profile.md
@@ -1,0 +1,117 @@
+# Selected OKF page profile
+
+Use `ao provenance check-okf --file <concept.md>` to check the structure of one
+caller-selected page. The default and only supported `--profile` is
+`agentops-okf-v0.2/v1`, pinned to [OKF v0.2 SPEC at
+ad30107c31c06aec8a7d5636e0d1058118604e6f](https://github.com/GoogleCloudPlatform/open-knowledge-format/blob/ad30107c31c06aec8a7d5636e0d1058118604e6f/SPEC.md).
+This is a stricter AgentOps authoring profile of ordinary UTF-8 Markdown and
+YAML frontmatter, not a new knowledge syntax or a full bundle conformance test.
+Upstream OKF makes most metadata optional; this selected profile requires the
+fields below. `learning.coherence` does not establish this profile's validity.
+
+The concrete consumer is the caller preparing a maintained reference or an
+advisory candidate before exact-content review. The check catches missing or
+malformed metadata; it does not decide whether prose is meaningful or supported.
+Review this profile when its upstream pin or accepted caller contract changes;
+retire it if no selected maintenance invocation consumes it.
+
+## Required structure
+
+The file begins with a `---` line, one YAML mapping, and a closing `---` line.
+LF and CRLF line endings are accepted and the result hashes the original bytes.
+
+| Field | Mechanical requirement |
+|---|---|
+| `type`, `title`, `description` | Nonempty strings. Unknown descriptive type values are accepted. |
+| `status` | Explicit `draft`, `stable`, or `deprecated`. Omission never inherits upstream's implicit `stable`. |
+| `sources` | Nonempty list of mappings, each with a nonempty string `resource`. Optional IDs are unique strings. Resources may be URLs, relative paths, or source scope descriptions. |
+| `knowledge_use` | Producer metadata: `maintained-reference` or `promotion-candidate`. Neither value promotes a rule. |
+| `applicability` | Nonempty string metadata or an `Applicability` section. |
+| `claim` or `action` | At least one nonempty string or corresponding `Claim`/`Action` section. |
+| `limitations` | Nonempty string metadata or a `Limitations` section. |
+| `consumer` | Nonempty string metadata or a `Consumer` section naming the concrete user or invocation. |
+| `retirement_condition` | Nonempty string metadata or a `Retirement condition` section describing when to review or withdraw the page. |
+
+Named sections use standard ATX headings (`#` through `######`, case insensitive).
+Headings inside fenced code or HTML comments do not supply required sections.
+If a corresponding metadata key is present, it must itself be a nonempty string;
+a body section cannot conceal malformed metadata. The checker confirms text is
+present, not that it describes a useful consumer, valid claim or sufficient limit.
+
+`agentops_profile`, if included as producer metadata, must match the selected
+profile. A repeated `okf_version`, if present, must be the string `"0.2"`.
+OKF's standard bundle version declaration lives in the root `index.md`; this
+single-page check does not discover or read that file. The invoking caller
+selects the pinned profile explicitly or uses the documented default. Unknown
+or incompatible selections fail; no best-effort version fallback is applied.
+
+Other producer keys are accepted without granting them authority. YAML duplicate
+keys, aliases, merge inheritance, non-string mapping keys, nesting beyond 32
+levels and more than 8,192 nodes are rejected to keep metadata explicit and
+bounded. These are profile restrictions, not claims that all such YAML is
+malformed under upstream OKF.
+
+## Generated and verified metadata
+
+Optional `generated` is a mapping with a required actor `by`; `at` is optional.
+Optional `verified` accepts either one `{by, at}` mapping or a list of those
+mappings. A present verification event requires both fields. Actors follow
+`producer/version`, `human:id`, or `process:id`; strings alone establish no
+independent process or factual review. Datetimes in these fields, `stale_after`
+and `sources[].last_modified` use RFC3339 with an explicit UTC offset. An empty
+verification list records no events and is accepted without a trust claim.
+
+The checker does not execute computation or attestation fields, resolve source
+links, evaluate stale dates, classify trust tiers, or prove any other optional
+OKF family. Unknown extension values remain uninterpreted. Broken or unavailable
+source targets need separate authorized review; structural success proves only
+that their declared references have the required shape.
+
+## Three separate decisions
+
+Factual support, permission to disclose to the exact destination, and observed
+usefulness remain distinct. A true page can be confidential; a permitted page
+can be unused or harmful. Page status, owner/access labels and actor strings
+cannot grant clearance, admission or semantic approval.
+
+Prepare the final bytes, including any intended metadata, before independent
+review. Reuse the existing exact-content manifest and `verdict.v2` mechanism;
+keep matching factual-support and destination-disclosure judgments outside the
+page under the caller's independently supplied expected acceptance. A batch may
+cover every changed page and claim in one bounded review. Adding a stamp after
+review changes the content digest and requires a new matching judgment.
+
+Default retrieval still requires matching independent evidence-backed review
+and current applicability. This structural command does not implement retrieval
+or admission. Drafts and review outputs stay in caller-selected protected non-Git
+staging until exact destination disclosure eligibility passes. Only approved
+content may enter Git. Native runtime source/model/destination authorization
+must precede page access; this parser is not an access-policy enforcement tool.
+
+A narrowly supported observation from one episode may remain an observation or
+maintained reference. General instructions and standing checks still need the
+separate evidence and reapply proof owned by operationalize and pattern-mining.
+Preserve null, harmful, failed and contradictory outcomes; schema validity and
+retrieval counts do not demonstrate utility.
+
+## Operation and output
+
+The operation reads only the explicit regular `.md` concept file, at most 1 MiB,
+with frontmatter ending within the first 64 KiB. It rejects file symlinks,
+special files and reserved `index.md`/`log.md` pages. It does not traverse a
+bundle, fetch citations, inspect Git or configuration, execute code, start a
+model, schedule work, or write any file. Caller runtime/OS controls own actual
+confinement; a same-user process or page label is not isolation.
+
+JSON is the default; `--json`, `-o json`, and `-o yaml` provide structured output.
+The result names the selected profile and upstream commit, exact input SHA-256,
+`structurally_valid`, fixed field/code issues and an explicit assurance boundary.
+It does not echo page prose, source locators or parser snippets. Exit 0 means
+the selected structure is valid; exit 1 means findings, incompatible profile,
+invalid input, read error or output failure. `--dry-run` performs the same
+read-only check. Neither a successful exit nor `verified` metadata is a PASS.
+
+The synthetic maintained-reference fixture is
+`cli/internal/okfprofile/testdata/maintained-reference.md`; the table-driven
+profile tests also cover narrow promotion candidates and negative examples.
+It is illustrative test data, not knowledge admitted for retrieval.

--- a/registry.json
+++ b/registry.json
@@ -843,7 +843,7 @@
         "has_skill_md": true,
         "name": "cass",
         "path": "skills/cass/",
-        "reference_count": 16,
+        "reference_count": 17,
         "tier": "execution"
       },
       {
@@ -1088,7 +1088,7 @@
         "has_skill_md": true,
         "name": "learn",
         "path": "skills/learn/",
-        "reference_count": 1,
+        "reference_count": 2,
         "tier": "execution"
       },
       {

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "learn",
       "source_skill": "skills/learn",
-      "source_hash": "bf17da90d561f993d1b863a2337e04ba30aa693123da2cb0509ba4641bfd9d9b",
-      "generated_hash": "118ef31f294805ba3dafd8b1aa5b58cb9fe0533ca15a1bf78b2bcaf7dd920117"
+      "source_hash": "22d1def72722df94fa0d1be6e62a952f57c344339aa0f3b7bb9a918424609eda",
+      "generated_hash": "59c3a3d8a93bd30eab75d3ed233c07dda9ac3fddf600852b4662f25533a8637e"
     },
     {
       "name": "ms",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -405,8 +405,8 @@
     {
       "name": "cass",
       "source_skill": "skills/cass",
-      "source_hash": "7cb1e367d30d8cdf8482eae60ee6acb25187e4642fe5089e7452d72ed0578215",
-      "generated_hash": "633b8a299b60ef25621291a97c4c0e5d89312f115daa3a39bfdf3a4923e67172"
+      "source_hash": "55d89dea2068721e97381c9fe9afc11a7b7559902ae77106f07152850c21ebdc",
+      "generated_hash": "018a43b37f201e611578231b693b59dc47f9f5ffad4064947c257507ecc6d9d6"
     },
     {
       "name": "cc-hooks",
@@ -501,8 +501,8 @@
     {
       "name": "learn",
       "source_skill": "skills/learn",
-      "source_hash": "e7d329dd0ef3a4e93075790f7c354d336fb8761376d4eaab2b88b3d3e50d62ab",
-      "generated_hash": "b28e290d568b3bf31a8ee9d863e02c17e5b5f00780a56cece0ca9f8ba657f482"
+      "source_hash": "bf17da90d561f993d1b863a2337e04ba30aa693123da2cb0509ba4641bfd9d9b",
+      "generated_hash": "118ef31f294805ba3dafd8b1aa5b58cb9fe0533ca15a1bf78b2bcaf7dd920117"
     },
     {
       "name": "ms",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -405,8 +405,8 @@
     {
       "name": "cass",
       "source_skill": "skills/cass",
-      "source_hash": "55d89dea2068721e97381c9fe9afc11a7b7559902ae77106f07152850c21ebdc",
-      "generated_hash": "018a43b37f201e611578231b693b59dc47f9f5ffad4064947c257507ecc6d9d6"
+      "source_hash": "e10c9c9a3be283974857bd95a1db54a2b949d6d23a11bb6c2e990368c5d11be4",
+      "generated_hash": "fd146a3d0765ff13af36928b0630021a64787a85c27ce202c05dc272c5a39116"
     },
     {
       "name": "cc-hooks",

--- a/skills-codex/cass/.agentops-generated.json
+++ b/skills-codex/cass/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cass",
   "layout": "modular",
-  "source_hash": "55d89dea2068721e97381c9fe9afc11a7b7559902ae77106f07152850c21ebdc",
-  "generated_hash": "018a43b37f201e611578231b693b59dc47f9f5ffad4064947c257507ecc6d9d6"
+  "source_hash": "e10c9c9a3be283974857bd95a1db54a2b949d6d23a11bb6c2e990368c5d11be4",
+  "generated_hash": "fd146a3d0765ff13af36928b0630021a64787a85c27ce202c05dc272c5a39116"
 }

--- a/skills-codex/cass/.agentops-generated.json
+++ b/skills-codex/cass/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cass",
   "layout": "modular",
-  "source_hash": "7cb1e367d30d8cdf8482eae60ee6acb25187e4642fe5089e7452d72ed0578215",
-  "generated_hash": "633b8a299b60ef25621291a97c4c0e5d89312f115daa3a39bfdf3a4923e67172"
+  "source_hash": "55d89dea2068721e97381c9fe9afc11a7b7559902ae77106f07152850c21ebdc",
+  "generated_hash": "018a43b37f201e611578231b693b59dc47f9f5ffad4064947c257507ecc6d9d6"
 }

--- a/skills-codex/cass/SKILL.md
+++ b/skills-codex/cass/SKILL.md
@@ -219,6 +219,7 @@ Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.bead
 | jq patterns | [PATTERNS.md](references/PATTERNS.md) |
 | Pitfalls & fixes | [PITFALLS.md](references/PITFALLS.md) |
 | Session file formats | [SESSION_FORMATS.md](references/SESSION_FORMATS.md) |
+| Bounded authorized source-byte reads | [RAW_SOURCE_READS.md](references/RAW_SOURCE_READS.md) |
 | Remote sources, multi-machine search | [REMOTE_SOURCES.md](references/REMOTE_SOURCES.md) |
 | Semantic / hybrid / models | [SEMANTIC_AND_HYBRID.md](references/SEMANTIC_AND_HYBRID.md) |
 | Token / tool / model analytics | [ANALYTICS.md](references/ANALYTICS.md) |

--- a/skills-codex/cass/references/RAW_SOURCE_READS.md
+++ b/skills-codex/cass/references/RAW_SOURCE_READS.md
@@ -1,0 +1,113 @@
+# Bounded raw source reads
+
+CASS search, `view` and `expand` locate excerpts. `ao session read-source`
+returns explicit raw bytes after checking caller-selected policy; it does not
+parse records or replace the existing `ao provenance mine-session` tool-call
+contract. Raw bytes include prose, operator corrections, malformed records and
+Unicode line/paragraph separators. If a later consumer parses JSONL, split on
+the byte `\n`, not Unicode line boundaries, and retain rejected records in raw
+coverage accounting.
+
+## Select access before opening bytes
+
+The caller independently supplies the expected native source/project, owner,
+task, model and destination. Existing T05 configuration and its native BD 1.2.2
+maintenance anchor must resolve successfully. The access-policy reference is an
+identity, not permission by its presence. Missing or mismatched context denies
+the read; no source content is included in the error.
+
+The resolved `task_policy_ref` selects a `source-read-policy.v1` JSON document.
+It binds the same source/project/owner/task/model/destination to exact canonical
+file permissions and a measured output profile. The caller, not the source
+record or a knowledge candidate, owns this document. For example, replacing
+these illustrative identities and paths with the independently authorized ones:
+
+```json
+{
+  "schema_version": "source-read-policy.v1",
+  "source_id": "/native/tracker/.beads",
+  "project_id": "native-project-id",
+  "owner_scope": "selected-owner",
+  "task_ref": "selected-task",
+  "model_ref": "selected-model",
+  "destination_ref": "selected-destination",
+  "files": [
+    {"path": "/authorized/source.jsonl", "content_scope": "already-cleared"}
+  ],
+  "output_profile": {
+    "id": "caller-selected-measured-profile",
+    "model_ref": "selected-model",
+    "destination_ref": "selected-destination",
+    "max_serialized_bytes": 2048,
+    "observation_ref": "/protected/host-output-observation.json",
+    "observation_sha256": "replace-with-the-actual-64-character-lowercase-sha256"
+  }
+}
+```
+
+The example size is illustrative, not a default or a universal safe limit.
+Select a limit measured on the actual native tool-result surface and preserve
+its observation bytes/digest. The reader verifies the selected observation's
+integrity; it does not attest its truth or observe host delivery. Policy and
+observation documents have a separate 1 MiB parser resource bound. No source
+locator, task, model, destination or profile has an inferred public default.
+
+Allowed `content_scope` values are `synthetic`, `already-cleared` and `restricted`.
+Current T05 reports `access_enforcement: not_attested`; restricted source reads
+are therefore unavailable. The first two scopes support explicitly authorized
+mechanism checks only. A policy label, file permission or worktree cannot supply
+the native runtime/OS and egress enforcement owned by T39.
+
+## Read and continue the same frozen prefix
+
+```sh
+ao session read-source \
+  --file /authorized/source.jsonl \
+  --access-policy-ref /protected/access-policy.json \
+  --source-id /native/tracker/.beads --project-id native-project-id \
+  --owner-scope selected-owner --task-ref selected-task \
+  --model-ref selected-model --destination-ref selected-destination \
+  --consumer-root /consumer/checkout --native-directory /native/workspace \
+  --start-byte 0 --max-bytes 64 --json
+```
+
+The first invocation freezes the observed file size as `captured_through`.
+Continue with `--start-byte` equal to `next_byte`, and pair
+`--through-byte` with `--expect-prefix-sha256` from that result. The expected
+hash covers **all bytes in `[0, captured_through)`**, not just the previous
+span. Appends after that boundary are allowed. Any changed prefix, including
+only an operator correction between identical tool calls, invalidates it.
+
+Pass the previous `file_before.identity` as `--expect-file-identity` to check
+replacement across invocations, even when a new file has identical contents.
+Without that expectation, the response explicitly says cross-invocation
+replacement was not checked. Within each invocation the reader compares the
+opened file identity with the path before/after reading, rejects short reads,
+and hashes the frozen prefix again to detect concurrent changes. These are
+observations, not an atomic snapshot or a lock against a malicious concurrent
+writer. Native files remain authoritative; no new source/state store is created.
+
+## Interpret output honestly
+
+`source-read.v1` is one compact JSON document, including a trailing newline.
+`start_byte`, `end_byte` and `next_byte` identify the returned half-open span.
+`prefix_sha256` hashes the entire frozen prefix; `span_sha256` hashes exactly
+the returned bytes. `bytes_base64` is reversible and authoritative. `text_view`
+is separately labelled with `text_view_encoding`; invalid or split UTF-8 uses
+a replacement view and must never replace the raw bytes for integrity.
+
+The reader checks the **actual serialized document length**, including metadata,
+base64 expansion, text escapes and newline. Oversize output emits no source
+bytes unless the caller explicitly sets `--allow-oversize`; that override is
+recorded and never establishes complete reading. `profile_bound_satisfied`
+reports the size comparison, not delivery. JSON is the measured output format;
+YAML is rejected rather than silently bypassing its size contract.
+
+Every result reports `host_delivery: host-delivery-unverified`,
+`semantic_processing: not-established` and `complete_reading: false`.
+`serialized_bytes` records emitted document size, not what a tool wrapper
+actually delivered. Preserve the native transcript's actual result and any
+truncation/omission markers. Even a successful producer and an observed final
+sentinel cannot prove the omitted middle was delivered or processed. T09 owns
+later identity-bound coverage/acknowledgement verification; a head-and-tail
+read still leaves the middle unread.

--- a/skills-codex/cass/references/SESSION_FORMATS.md
+++ b/skills-codex/cass/references/SESSION_FORMATS.md
@@ -7,6 +7,7 @@
 ## Contents
 
 - [Work-to-session associations](#work-to-session-associations)
+- [Bounded raw source reads](RAW_SOURCE_READS.md)
 - [Quick Detection](#quick-detection)
 - [Claude Code Format](#claude-code-format)
 - [Codex CLI Format](#codex-cli-format)
@@ -72,6 +73,11 @@ prove bytes were emitted, delivered to the host or semantically processed.
 Head/tail excerpts leave the middle unread; new tails or children belong to a
 later observation, not a rewritten completed denominator. T09 owns the later
 coverage verifier; no coverage command or acceptance claim is introduced here.
+
+For byte-preserving reads of explicitly authorized sources, follow
+[bounded raw source reads](RAW_SOURCE_READS.md). The source reader checks native
+policy before opening bytes and reports frozen prefix/span digests, reversible
+content and delivery limits; emitted stdout does not establish full reading.
 
 ## Quick Detection
 

--- a/skills-codex/learn/.agentops-generated.json
+++ b/skills-codex/learn/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/learn",
   "layout": "modular",
-  "source_hash": "e7d329dd0ef3a4e93075790f7c354d336fb8761376d4eaab2b88b3d3e50d62ab",
-  "generated_hash": "b28e290d568b3bf31a8ee9d863e02c17e5b5f00780a56cece0ca9f8ba657f482"
+  "source_hash": "bf17da90d561f993d1b863a2337e04ba30aa693123da2cb0509ba4641bfd9d9b",
+  "generated_hash": "118ef31f294805ba3dafd8b1aa5b58cb9fe0533ca15a1bf78b2bcaf7dd920117"
 }

--- a/skills-codex/learn/.agentops-generated.json
+++ b/skills-codex/learn/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/learn",
   "layout": "modular",
-  "source_hash": "bf17da90d561f993d1b863a2337e04ba30aa693123da2cb0509ba4641bfd9d9b",
-  "generated_hash": "118ef31f294805ba3dafd8b1aa5b58cb9fe0533ca15a1bf78b2bcaf7dd920117"
+  "source_hash": "22d1def72722df94fa0d1be6e62a952f57c344339aa0f3b7bb9a918424609eda",
+  "generated_hash": "59c3a3d8a93bd30eab75d3ed233c07dda9ac3fddf600852b4662f25533a8637e"
 }

--- a/skills-codex/learn/SKILL.md
+++ b/skills-codex/learn/SKILL.md
@@ -56,7 +56,8 @@ When the caller selects an OKF page for an observation or maintained reference,
 follow the [pinned page profile](references/okf-page-profile.md) and run
 `ao provenance check-okf --file <concept.md>` before exact-content review.
 The command checks structure only: it cannot establish factual support,
-destination disclosure, independent review or usefulness, and it neither
+permission to disclose to the destination, independent review or usefulness,
+and it neither
 admits pages nor promotes rules. This optional representation does not broaden
 Learn's verdict-only input or authorize a new storage destination.
 

--- a/skills-codex/learn/SKILL.md
+++ b/skills-codex/learn/SKILL.md
@@ -52,6 +52,14 @@ Knowledge is revisable. Preserve evidence and provenance when retracting an
 unsupported or stale belief; artifact accumulation is not a monotonic increase
 in truth or utility. Negative, null, and contradictory results remain visible.
 
+When the caller selects an OKF page for an observation or maintained reference,
+follow the [pinned page profile](references/okf-page-profile.md) and run
+`ao provenance check-okf --file <concept.md>` before exact-content review.
+The command checks structure only: it cannot establish factual support,
+destination disclosure, independent review or usefulness, and it neither
+admits pages nor promotes rules. This optional representation does not broaden
+Learn's verdict-only input or authorize a new storage destination.
+
 A repeated finding class may support a check proposal only when causal evidence
 identifies a preventable defect and a concrete consumer needs that check. Name
 the exact behavior the check would refuse and why existing checks missed it;

--- a/skills-codex/learn/references/okf-page-profile.md
+++ b/skills-codex/learn/references/okf-page-profile.md
@@ -1,0 +1,117 @@
+# Selected OKF page profile
+
+Use `ao provenance check-okf --file <concept.md>` to check the structure of one
+caller-selected page. The default and only supported `--profile` is
+`agentops-okf-v0.2/v1`, pinned to [OKF v0.2 SPEC at
+ad30107c31c06aec8a7d5636e0d1058118604e6f](https://github.com/GoogleCloudPlatform/open-knowledge-format/blob/ad30107c31c06aec8a7d5636e0d1058118604e6f/SPEC.md).
+This is a stricter AgentOps authoring profile of ordinary UTF-8 Markdown and
+YAML frontmatter, not a new knowledge syntax or a full bundle conformance test.
+Upstream OKF makes most metadata optional; this selected profile requires the
+fields below. `learning.coherence` does not establish this profile's validity.
+
+The concrete consumer is the caller preparing a maintained reference or an
+advisory candidate before exact-content review. The check catches missing or
+malformed metadata; it does not decide whether prose is meaningful or supported.
+Review this profile when its upstream pin or accepted caller contract changes;
+retire it if no selected maintenance invocation consumes it.
+
+## Required structure
+
+The file begins with a `---` line, one YAML mapping, and a closing `---` line.
+LF and CRLF line endings are accepted and the result hashes the original bytes.
+
+| Field | Mechanical requirement |
+|---|---|
+| `type`, `title`, `description` | Nonempty strings. Unknown descriptive type values are accepted. |
+| `status` | Explicit `draft`, `stable`, or `deprecated`. Omission never inherits upstream's implicit `stable`. |
+| `sources` | Nonempty list of mappings, each with a nonempty string `resource`. Optional IDs are unique strings. Resources may be URLs, relative paths, or source scope descriptions. |
+| `knowledge_use` | Producer metadata: `maintained-reference` or `promotion-candidate`. Neither value promotes a rule. |
+| `applicability` | Nonempty string metadata or an `Applicability` section. |
+| `claim` or `action` | At least one nonempty string or corresponding `Claim`/`Action` section. |
+| `limitations` | Nonempty string metadata or a `Limitations` section. |
+| `consumer` | Nonempty string metadata or a `Consumer` section naming the concrete user or invocation. |
+| `retirement_condition` | Nonempty string metadata or a `Retirement condition` section describing when to review or withdraw the page. |
+
+Named sections use standard ATX headings (`#` through `######`, case insensitive).
+Headings inside fenced code or HTML comments do not supply required sections.
+If a corresponding metadata key is present, it must itself be a nonempty string;
+a body section cannot conceal malformed metadata. The checker confirms text is
+present, not that it describes a useful consumer, valid claim or sufficient limit.
+
+`agentops_profile`, if included as producer metadata, must match the selected
+profile. A repeated `okf_version`, if present, must be the string `"0.2"`.
+OKF's standard bundle version declaration lives in the root `index.md`; this
+single-page check does not discover or read that file. The invoking caller
+selects the pinned profile explicitly or uses the documented default. Unknown
+or incompatible selections fail; no best-effort version fallback is applied.
+
+Other producer keys are accepted without granting them authority. YAML duplicate
+keys, aliases, merge inheritance, non-string mapping keys, nesting beyond 32
+levels and more than 8,192 nodes are rejected to keep metadata explicit and
+bounded. These are profile restrictions, not claims that all such YAML is
+malformed under upstream OKF.
+
+## Generated and verified metadata
+
+Optional `generated` is a mapping with a required actor `by`; `at` is optional.
+Optional `verified` accepts either one `{by, at}` mapping or a list of those
+mappings. A present verification event requires both fields. Actors follow
+`producer/version`, `human:id`, or `process:id`; strings alone establish no
+independent process or factual review. Datetimes in these fields, `stale_after`
+and `sources[].last_modified` use RFC3339 with an explicit UTC offset. An empty
+verification list records no events and is accepted without a trust claim.
+
+The checker does not execute computation or attestation fields, resolve source
+links, evaluate stale dates, classify trust tiers, or prove any other optional
+OKF family. Unknown extension values remain uninterpreted. Broken or unavailable
+source targets need separate authorized review; structural success proves only
+that their declared references have the required shape.
+
+## Three separate decisions
+
+Factual support, permission to disclose to the exact destination, and observed
+usefulness remain distinct. A true page can be confidential; a permitted page
+can be unused or harmful. Page status, owner/access labels and actor strings
+cannot grant clearance, admission or semantic approval.
+
+Prepare the final bytes, including any intended metadata, before independent
+review. Reuse the existing exact-content manifest and `verdict.v2` mechanism;
+keep matching factual-support and destination-disclosure judgments outside the
+page under the caller's independently supplied expected acceptance. A batch may
+cover every changed page and claim in one bounded review. Adding a stamp after
+review changes the content digest and requires a new matching judgment.
+
+Default retrieval still requires matching independent evidence-backed review
+and current applicability. This structural command does not implement retrieval
+or admission. Drafts and review outputs stay in caller-selected protected non-Git
+staging until exact destination disclosure eligibility passes. Only approved
+content may enter Git. Native runtime source/model/destination authorization
+must precede page access; this parser is not an access-policy enforcement tool.
+
+A narrowly supported observation from one episode may remain an observation or
+maintained reference. General instructions and standing checks still need the
+separate evidence and reapply proof owned by operationalize and pattern-mining.
+Preserve null, harmful, failed and contradictory outcomes; schema validity and
+retrieval counts do not demonstrate utility.
+
+## Operation and output
+
+The operation reads only the explicit regular `.md` concept file, at most 1 MiB,
+with frontmatter ending within the first 64 KiB. It rejects file symlinks,
+special files and reserved `index.md`/`log.md` pages. It does not traverse a
+bundle, fetch citations, inspect Git or configuration, execute code, start a
+model, schedule work, or write any file. Caller runtime/OS controls own actual
+confinement; a same-user process or page label is not isolation.
+
+JSON is the default; `--json`, `-o json`, and `-o yaml` provide structured output.
+The result names the selected profile and upstream commit, exact input SHA-256,
+`structurally_valid`, fixed field/code issues and an explicit assurance boundary.
+It does not echo page prose, source locators or parser snippets. Exit 0 means
+the selected structure is valid; exit 1 means findings, incompatible profile,
+invalid input, read error or output failure. `--dry-run` performs the same
+read-only check. Neither a successful exit nor `verified` metadata is a PASS.
+
+The synthetic maintained-reference fixture is
+`cli/internal/okfprofile/testdata/maintained-reference.md`; the table-driven
+profile tests also cover narrow promotion candidates and negative examples.
+It is illustrative test data, not knowledge admitted for retrieval.

--- a/skills/cass/SKILL.md
+++ b/skills/cass/SKILL.md
@@ -241,6 +241,7 @@ Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.bead
 | jq patterns | [PATTERNS.md](references/PATTERNS.md) |
 | Pitfalls & fixes | [PITFALLS.md](references/PITFALLS.md) |
 | Session file formats | [SESSION_FORMATS.md](references/SESSION_FORMATS.md) |
+| Bounded authorized source-byte reads | [RAW_SOURCE_READS.md](references/RAW_SOURCE_READS.md) |
 | Remote sources, multi-machine search | [REMOTE_SOURCES.md](references/REMOTE_SOURCES.md) |
 | Semantic / hybrid / models | [SEMANTIC_AND_HYBRID.md](references/SEMANTIC_AND_HYBRID.md) |
 | Token / tool / model analytics | [ANALYTICS.md](references/ANALYTICS.md) |

--- a/skills/cass/references/RAW_SOURCE_READS.md
+++ b/skills/cass/references/RAW_SOURCE_READS.md
@@ -1,0 +1,113 @@
+# Bounded raw source reads
+
+CASS search, `view` and `expand` locate excerpts. `ao session read-source`
+returns explicit raw bytes after checking caller-selected policy; it does not
+parse records or replace the existing `ao provenance mine-session` tool-call
+contract. Raw bytes include prose, operator corrections, malformed records and
+Unicode line/paragraph separators. If a later consumer parses JSONL, split on
+the byte `\n`, not Unicode line boundaries, and retain rejected records in raw
+coverage accounting.
+
+## Select access before opening bytes
+
+The caller independently supplies the expected native source/project, owner,
+task, model and destination. Existing T05 configuration and its native BD 1.2.2
+maintenance anchor must resolve successfully. The access-policy reference is an
+identity, not permission by its presence. Missing or mismatched context denies
+the read; no source content is included in the error.
+
+The resolved `task_policy_ref` selects a `source-read-policy.v1` JSON document.
+It binds the same source/project/owner/task/model/destination to exact canonical
+file permissions and a measured output profile. The caller, not the source
+record or a knowledge candidate, owns this document. For example, replacing
+these illustrative identities and paths with the independently authorized ones:
+
+```json
+{
+  "schema_version": "source-read-policy.v1",
+  "source_id": "/native/tracker/.beads",
+  "project_id": "native-project-id",
+  "owner_scope": "selected-owner",
+  "task_ref": "selected-task",
+  "model_ref": "selected-model",
+  "destination_ref": "selected-destination",
+  "files": [
+    {"path": "/authorized/source.jsonl", "content_scope": "already-cleared"}
+  ],
+  "output_profile": {
+    "id": "caller-selected-measured-profile",
+    "model_ref": "selected-model",
+    "destination_ref": "selected-destination",
+    "max_serialized_bytes": 2048,
+    "observation_ref": "/protected/host-output-observation.json",
+    "observation_sha256": "replace-with-the-actual-64-character-lowercase-sha256"
+  }
+}
+```
+
+The example size is illustrative, not a default or a universal safe limit.
+Select a limit measured on the actual native tool-result surface and preserve
+its observation bytes/digest. The reader verifies the selected observation's
+integrity; it does not attest its truth or observe host delivery. Policy and
+observation documents have a separate 1 MiB parser resource bound. No source
+locator, task, model, destination or profile has an inferred public default.
+
+Allowed `content_scope` values are `synthetic`, `already-cleared` and `restricted`.
+Current T05 reports `access_enforcement: not_attested`; restricted source reads
+are therefore unavailable. The first two scopes support explicitly authorized
+mechanism checks only. A policy label, file permission or worktree cannot supply
+the native runtime/OS and egress enforcement owned by T39.
+
+## Read and continue the same frozen prefix
+
+```sh
+ao session read-source \
+  --file /authorized/source.jsonl \
+  --access-policy-ref /protected/access-policy.json \
+  --source-id /native/tracker/.beads --project-id native-project-id \
+  --owner-scope selected-owner --task-ref selected-task \
+  --model-ref selected-model --destination-ref selected-destination \
+  --consumer-root /consumer/checkout --native-directory /native/workspace \
+  --start-byte 0 --max-bytes 64 --json
+```
+
+The first invocation freezes the observed file size as `captured_through`.
+Continue with `--start-byte` equal to `next_byte`, and pair
+`--through-byte` with `--expect-prefix-sha256` from that result. The expected
+hash covers **all bytes in `[0, captured_through)`**, not just the previous
+span. Appends after that boundary are allowed. Any changed prefix, including
+only an operator correction between identical tool calls, invalidates it.
+
+Pass the previous `file_before.identity` as `--expect-file-identity` to check
+replacement across invocations, even when a new file has identical contents.
+Without that expectation, the response explicitly says cross-invocation
+replacement was not checked. Within each invocation the reader compares the
+opened file identity with the path before/after reading, rejects short reads,
+and hashes the frozen prefix again to detect concurrent changes. These are
+observations, not an atomic snapshot or a lock against a malicious concurrent
+writer. Native files remain authoritative; no new source/state store is created.
+
+## Interpret output honestly
+
+`source-read.v1` is one compact JSON document, including a trailing newline.
+`start_byte`, `end_byte` and `next_byte` identify the returned half-open span.
+`prefix_sha256` hashes the entire frozen prefix; `span_sha256` hashes exactly
+the returned bytes. `bytes_base64` is reversible and authoritative. `text_view`
+is separately labelled with `text_view_encoding`; invalid or split UTF-8 uses
+a replacement view and must never replace the raw bytes for integrity.
+
+The reader checks the **actual serialized document length**, including metadata,
+base64 expansion, text escapes and newline. Oversize output emits no source
+bytes unless the caller explicitly sets `--allow-oversize`; that override is
+recorded and never establishes complete reading. `profile_bound_satisfied`
+reports the size comparison, not delivery. JSON is the measured output format;
+YAML is rejected rather than silently bypassing its size contract.
+
+Every result reports `host_delivery: host-delivery-unverified`,
+`semantic_processing: not-established` and `complete_reading: false`.
+`serialized_bytes` records emitted document size, not what a tool wrapper
+actually delivered. Preserve the native transcript's actual result and any
+truncation/omission markers. Even a successful producer and an observed final
+sentinel cannot prove the omitted middle was delivered or processed. T09 owns
+later identity-bound coverage/acknowledgement verification; a head-and-tail
+read still leaves the middle unread.

--- a/skills/cass/references/SESSION_FORMATS.md
+++ b/skills/cass/references/SESSION_FORMATS.md
@@ -7,6 +7,7 @@
 ## Contents
 
 - [Work-to-session associations](#work-to-session-associations)
+- [Bounded raw source reads](RAW_SOURCE_READS.md)
 - [Quick Detection](#quick-detection)
 - [Claude Code Format](#claude-code-format)
 - [Codex CLI Format](#codex-cli-format)
@@ -72,6 +73,11 @@ prove bytes were emitted, delivered to the host or semantically processed.
 Head/tail excerpts leave the middle unread; new tails or children belong to a
 later observation, not a rewritten completed denominator. T09 owns the later
 coverage verifier; no coverage command or acceptance claim is introduced here.
+
+For byte-preserving reads of explicitly authorized sources, follow
+[bounded raw source reads](RAW_SOURCE_READS.md). The source reader checks native
+policy before opening bytes and reports frozen prefix/span digests, reversible
+content and delivery limits; emitted stdout does not establish full reading.
 
 ## Quick Detection
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -281,7 +281,7 @@
         "pragmatic-programmer"
       ],
       "produces": [],
-      "references_count": 16,
+      "references_count": 17,
       "tier": "execution",
       "user_invocable": false
     },
@@ -813,7 +813,7 @@
       "produces": [
         "learning-observations"
       ],
-      "references_count": 1,
+      "references_count": 2,
       "tier": "execution",
       "user_invocable": true
     },

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -76,6 +76,14 @@ Knowledge is revisable. Preserve evidence and provenance when retracting an
 unsupported or stale belief; artifact accumulation is not a monotonic increase
 in truth or utility. Negative, null, and contradictory results remain visible.
 
+When the caller selects an OKF page for an observation or maintained reference,
+follow the [pinned page profile](references/okf-page-profile.md) and run
+`ao provenance check-okf --file <concept.md>` before exact-content review.
+The command checks structure only: it cannot establish factual support,
+destination disclosure, independent review or usefulness, and it neither
+admits pages nor promotes rules. This optional representation does not broaden
+Learn's verdict-only input or authorize a new storage destination.
+
 A repeated finding class may support a check proposal only when causal evidence
 identifies a preventable defect and a concrete consumer needs that check. Name
 the exact behavior the check would refuse and why existing checks missed it;

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -80,7 +80,8 @@ When the caller selects an OKF page for an observation or maintained reference,
 follow the [pinned page profile](references/okf-page-profile.md) and run
 `ao provenance check-okf --file <concept.md>` before exact-content review.
 The command checks structure only: it cannot establish factual support,
-destination disclosure, independent review or usefulness, and it neither
+permission to disclose to the destination, independent review or usefulness,
+and it neither
 admits pages nor promotes rules. This optional representation does not broaden
 Learn's verdict-only input or authorize a new storage destination.
 

--- a/skills/learn/references/okf-page-profile.md
+++ b/skills/learn/references/okf-page-profile.md
@@ -1,0 +1,117 @@
+# Selected OKF page profile
+
+Use `ao provenance check-okf --file <concept.md>` to check the structure of one
+caller-selected page. The default and only supported `--profile` is
+`agentops-okf-v0.2/v1`, pinned to [OKF v0.2 SPEC at
+ad30107c31c06aec8a7d5636e0d1058118604e6f](https://github.com/GoogleCloudPlatform/open-knowledge-format/blob/ad30107c31c06aec8a7d5636e0d1058118604e6f/SPEC.md).
+This is a stricter AgentOps authoring profile of ordinary UTF-8 Markdown and
+YAML frontmatter, not a new knowledge syntax or a full bundle conformance test.
+Upstream OKF makes most metadata optional; this selected profile requires the
+fields below. `learning.coherence` does not establish this profile's validity.
+
+The concrete consumer is the caller preparing a maintained reference or an
+advisory candidate before exact-content review. The check catches missing or
+malformed metadata; it does not decide whether prose is meaningful or supported.
+Review this profile when its upstream pin or accepted caller contract changes;
+retire it if no selected maintenance invocation consumes it.
+
+## Required structure
+
+The file begins with a `---` line, one YAML mapping, and a closing `---` line.
+LF and CRLF line endings are accepted and the result hashes the original bytes.
+
+| Field | Mechanical requirement |
+|---|---|
+| `type`, `title`, `description` | Nonempty strings. Unknown descriptive type values are accepted. |
+| `status` | Explicit `draft`, `stable`, or `deprecated`. Omission never inherits upstream's implicit `stable`. |
+| `sources` | Nonempty list of mappings, each with a nonempty string `resource`. Optional IDs are unique strings. Resources may be URLs, relative paths, or source scope descriptions. |
+| `knowledge_use` | Producer metadata: `maintained-reference` or `promotion-candidate`. Neither value promotes a rule. |
+| `applicability` | Nonempty string metadata or an `Applicability` section. |
+| `claim` or `action` | At least one nonempty string or corresponding `Claim`/`Action` section. |
+| `limitations` | Nonempty string metadata or a `Limitations` section. |
+| `consumer` | Nonempty string metadata or a `Consumer` section naming the concrete user or invocation. |
+| `retirement_condition` | Nonempty string metadata or a `Retirement condition` section describing when to review or withdraw the page. |
+
+Named sections use standard ATX headings (`#` through `######`, case insensitive).
+Headings inside fenced code or HTML comments do not supply required sections.
+If a corresponding metadata key is present, it must itself be a nonempty string;
+a body section cannot conceal malformed metadata. The checker confirms text is
+present, not that it describes a useful consumer, valid claim or sufficient limit.
+
+`agentops_profile`, if included as producer metadata, must match the selected
+profile. A repeated `okf_version`, if present, must be the string `"0.2"`.
+OKF's standard bundle version declaration lives in the root `index.md`; this
+single-page check does not discover or read that file. The invoking caller
+selects the pinned profile explicitly or uses the documented default. Unknown
+or incompatible selections fail; no best-effort version fallback is applied.
+
+Other producer keys are accepted without granting them authority. YAML duplicate
+keys, aliases, merge inheritance, non-string mapping keys, nesting beyond 32
+levels and more than 8,192 nodes are rejected to keep metadata explicit and
+bounded. These are profile restrictions, not claims that all such YAML is
+malformed under upstream OKF.
+
+## Generated and verified metadata
+
+Optional `generated` is a mapping with a required actor `by`; `at` is optional.
+Optional `verified` accepts either one `{by, at}` mapping or a list of those
+mappings. A present verification event requires both fields. Actors follow
+`producer/version`, `human:id`, or `process:id`; strings alone establish no
+independent process or factual review. Datetimes in these fields, `stale_after`
+and `sources[].last_modified` use RFC3339 with an explicit UTC offset. An empty
+verification list records no events and is accepted without a trust claim.
+
+The checker does not execute computation or attestation fields, resolve source
+links, evaluate stale dates, classify trust tiers, or prove any other optional
+OKF family. Unknown extension values remain uninterpreted. Broken or unavailable
+source targets need separate authorized review; structural success proves only
+that their declared references have the required shape.
+
+## Three separate decisions
+
+Factual support, permission to disclose to the exact destination, and observed
+usefulness remain distinct. A true page can be confidential; a permitted page
+can be unused or harmful. Page status, owner/access labels and actor strings
+cannot grant clearance, admission or semantic approval.
+
+Prepare the final bytes, including any intended metadata, before independent
+review. Reuse the existing exact-content manifest and `verdict.v2` mechanism;
+keep matching factual-support and destination-disclosure judgments outside the
+page under the caller's independently supplied expected acceptance. A batch may
+cover every changed page and claim in one bounded review. Adding a stamp after
+review changes the content digest and requires a new matching judgment.
+
+Default retrieval still requires matching independent evidence-backed review
+and current applicability. This structural command does not implement retrieval
+or admission. Drafts and review outputs stay in caller-selected protected non-Git
+staging until exact destination disclosure eligibility passes. Only approved
+content may enter Git. Native runtime source/model/destination authorization
+must precede page access; this parser is not an access-policy enforcement tool.
+
+A narrowly supported observation from one episode may remain an observation or
+maintained reference. General instructions and standing checks still need the
+separate evidence and reapply proof owned by operationalize and pattern-mining.
+Preserve null, harmful, failed and contradictory outcomes; schema validity and
+retrieval counts do not demonstrate utility.
+
+## Operation and output
+
+The operation reads only the explicit regular `.md` concept file, at most 1 MiB,
+with frontmatter ending within the first 64 KiB. It rejects file symlinks,
+special files and reserved `index.md`/`log.md` pages. It does not traverse a
+bundle, fetch citations, inspect Git or configuration, execute code, start a
+model, schedule work, or write any file. Caller runtime/OS controls own actual
+confinement; a same-user process or page label is not isolation.
+
+JSON is the default; `--json`, `-o json`, and `-o yaml` provide structured output.
+The result names the selected profile and upstream commit, exact input SHA-256,
+`structurally_valid`, fixed field/code issues and an explicit assurance boundary.
+It does not echo page prose, source locators or parser snippets. Exit 0 means
+the selected structure is valid; exit 1 means findings, incompatible profile,
+invalid input, read error or output failure. `--dry-run` performs the same
+read-only check. Neither a successful exit nor `verified` metadata is a PASS.
+
+The synthetic maintained-reference fixture is
+`cli/internal/okfprofile/testdata/maintained-reference.md`; the table-driven
+profile tests also cover narrow promotion candidates and negative examples.
+It is illustrative test data, not knowledge admitted for retrieval.


### PR DESCRIPTION
Adds two explicit read-only operations for the context delivery lifecycle: bounded raw source reads with reversible bytes and integrity checks, and structural checking of the pinned AgentOps OKF page profile.

Source reads require independently selected context policy and enforce a measured serialized-output bound before emitting content. Emitted bytes do not establish host delivery or understanding; restricted-source processing remains unavailable without native enforcement. The OKF checker rejects missing status and incompatible profiles, and never grants truth, disclosure, or usefulness approval.

Validation: focused tests and Linux/Windows source-reader builds passed. The combined candidate is undergoing the required full repository checks and fresh independent review before landing.
