### PR TITLE
Fix OKF frontmatter boundary and reduce checksum allocations

### DIFF
--- a/cli/internal/commands/provenance/okf_test.go
+++ b/cli/internal/commands/provenance/okf_test.go
@@ -2,7 +2,9 @@ package provenance
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -133,5 +135,67 @@ func TestCheckOKFCapabilityContract(t *testing.T) {
 	}
 	if leaf.Flags().Lookup("profile").DefValue != okfprofile.Profile {
 		t.Fatal("profile default does not match implementation pin")
+	}
+}
+
+func TestCheckOKFCLIFrontmatterByteBoundary(t *testing.T) {
+	fixture, err := os.ReadFile("../../okfprofile/testdata/maintained-reference.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, newline := range []struct{ name, value string }{{"LF", "\n"}, {"CRLF", "\r\n"}} {
+		for _, size := range []int{65535, 65536, 65537} {
+			t.Run(fmt.Sprintf("%s/%d", newline.name, size), func(t *testing.T) {
+				header, body, found := strings.Cut(strings.TrimPrefix(string(fixture), "---\n"), "---\n")
+				if !found {
+					t.Fatal("fixture is missing its closing delimiter")
+				}
+				header = strings.ReplaceAll(header, "\n", newline.value)
+				body = strings.ReplaceAll(body, "\n", newline.value)
+				padding := "# private-boundary-canary: "
+				header += padding + strings.Repeat("x", size-len(header)-len(padding)-len(newline.value)) + newline.value
+				if len(header) != size {
+					t.Fatalf("frontmatter fixture has %d bytes, want %d", len(header), size)
+				}
+				payload := []byte("---" + newline.value + header + "---" + newline.value + body)
+				dir := t.TempDir()
+				file := filepath.Join(dir, "input.md")
+				if err := os.WriteFile(file, payload, 0600); err != nil {
+					t.Fatal(err)
+				}
+				out, err := execProv(t, "must-not-resolve-ledger", "check-okf", "--file", file)
+				if (err == nil) != (size <= 65536) {
+					t.Errorf("%d-byte frontmatter: command error=%v", size, err)
+				}
+				var result okfprofile.Result
+				if err := json.Unmarshal([]byte(out), &result); err != nil {
+					t.Fatal(err)
+				}
+				if result.StructurallyValid != (size <= 65536) {
+					t.Errorf("%d-byte frontmatter: valid=%v, issues=%+v", size, result.StructurallyValid, result.Issues)
+				}
+				if size <= 65536 {
+					if len(result.Issues) != 0 {
+						t.Errorf("valid frontmatter has findings: %+v", result.Issues)
+					}
+				} else if len(result.Issues) != 1 || result.Issues[0] != (okfprofile.Issue{Field: "frontmatter", Code: "exceeds_64_kib"}) {
+					t.Errorf("oversized frontmatter findings: %+v", result.Issues)
+				}
+				if result.ContentSHA256 != fmt.Sprintf("%x", sha256.Sum256(payload)) || result.Assurance != okfprofile.Assurance {
+					t.Error("exact input digest or structural assurance changed")
+				}
+				if strings.Contains(out, "private-boundary-canary") || strings.Contains(out, "declared-source") || strings.Contains(out, "Synthetic request behavior") {
+					t.Error("candidate content echoed")
+				}
+				after, err := os.ReadFile(file)
+				if err != nil || !bytes.Equal(after, payload) {
+					t.Error("checker changed candidate")
+				}
+				entries, err := os.ReadDir(dir)
+				if err != nil || len(entries) != 1 {
+					t.Errorf("unexpected file effects: %v %v", entries, err)
+				}
+			})
+		}
 	}
 }

--- a/cli/internal/okfprofile/profile.go
+++ b/cli/internal/okfprofile/profile.go
@@ -278,7 +278,8 @@ func splitFrontmatter(payload []byte) ([]byte, []byte, string) {
 	}
 	start := opening + 1
 	for position := start; position < len(payload); {
-		if position > MaxFrontmatterBytes {
+		// Count raw header bytes, including its line endings but not delimiters.
+		if position-start > MaxFrontmatterBytes {
 			return nil, nil, "exceeds_64_kib"
 		}
 		length := bytes.IndexByte(payload[position:], '\n')

--- a/cli/internal/okfprofile/profile_test.go
+++ b/cli/internal/okfprofile/profile_test.go
@@ -143,3 +143,42 @@ func TestProfileBoundsAndVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestProfileFrontmatterByteBoundary(t *testing.T) {
+	for _, newline := range []struct{ name, value string }{{"LF", "\n"}, {"CRLF", "\r\n"}} {
+		for _, size := range []int{65535, 65536, 65537} {
+			t.Run(fmt.Sprintf("%s/%d", newline.name, size), func(t *testing.T) {
+				header, body, found := strings.Cut(strings.TrimPrefix(observation, "---\n"), "---\n")
+				if !found {
+					t.Fatal("fixture is missing its closing delimiter")
+				}
+				header = strings.ReplaceAll(header, "\n", newline.value)
+				body = strings.ReplaceAll(body, "\n", newline.value)
+				// The payload includes its line endings, but neither delimiter line.
+				padding := "# byte-boundary-é: "
+				header += padding + strings.Repeat("x", size-len(header)-len(padding)-len(newline.value)) + newline.value
+				if len(header) != size {
+					t.Fatalf("frontmatter fixture has %d bytes, want %d", len(header), size)
+				}
+				payload := []byte("---" + newline.value + header + "---" + newline.value + body)
+				result, err := Check(payload, Profile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if result.StructurallyValid != (size <= 65536) {
+					t.Errorf("%d-byte frontmatter: valid=%v, issues=%+v", size, result.StructurallyValid, result.Issues)
+				}
+				if size <= 65536 {
+					if len(result.Issues) != 0 {
+						t.Errorf("valid frontmatter has findings: %+v", result.Issues)
+					}
+				} else if len(result.Issues) != 1 || result.Issues[0] != (Issue{Field: "frontmatter", Code: "exceeds_64_kib"}) {
+					t.Errorf("oversized frontmatter findings: %+v", result.Issues)
+				}
+				if result.ContentSHA256 != fmt.Sprintf("%x", sha256.Sum256(payload)) {
+					t.Error("receipt is not bound to exact original bytes")
+				}
+			})
+		}
+	}
+}

--- a/cli/internal/provenanceapp/mine_session.go
+++ b/cli/internal/provenanceapp/mine_session.go
@@ -4,6 +4,7 @@
 package provenanceapp
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -219,7 +220,11 @@ func mineEventID(sessionID string, line int, kind, tool string, ordinal int) str
 // `upto`. Used as the rollback sentinel: if the previously-mined prefix's
 // checksum no longer matches, the transcript was rewritten and we re-mine.
 func prefixChecksum(result *parser.ParseResult, upto int) string {
-	var b strings.Builder
+	h := sha256.New()
+	// Buffer string writes in fixed-size chunks instead of allocating the entire
+	// transcript prefix (or converting each full tool output to a byte slice).
+	// The writes and final flush cannot fail because SHA-256 writes cannot fail.
+	b := bufio.NewWriter(h)
 	for _, m := range result.Messages {
 		if m.MessageIndex > upto {
 			continue
@@ -230,23 +235,23 @@ func prefixChecksum(result *parser.ParseResult, upto int) string {
 		// be silently trusted as unchanged, defeating rollback detection. Including
 		// the JSON-serialized input (Go sorts map keys, so it is stable across
 		// re-parses of the same bytes) makes a content rewrite change the checksum.
-		fmt.Fprintf(&b, "%d|%s|", m.MessageIndex, m.Type)
+		fmt.Fprintf(b, "%d|%s|", m.MessageIndex, m.Type)
 		for _, tc := range m.Tools {
-			b.WriteString(tc.Name)
-			b.WriteByte(0x1f)
+			_, _ = b.WriteString(tc.Name)
+			_ = b.WriteByte(0x1f)
 			if len(tc.Input) > 0 {
 				if ib, err := json.Marshal(tc.Input); err == nil {
-					b.Write(ib)
+					_, _ = b.Write(ib)
 				}
 			}
-			b.WriteByte(0x1f)
-			b.WriteString(tc.Output)
-			b.WriteByte(',')
+			_ = b.WriteByte(0x1f)
+			_, _ = b.WriteString(tc.Output)
+			_ = b.WriteByte(',')
 		}
-		b.WriteByte('\n')
+		_ = b.WriteByte('\n')
 	}
-	h := sha256.Sum256([]byte(b.String()))
-	return fmt.Sprintf("%x", h)[:16]
+	_ = b.Flush() // SHA-256 writes cannot fail.
+	return fmt.Sprintf("%x", h.Sum(nil))[:16]
 }
 
 func sessionIDFromPath(path string) string {

--- a/cli/internal/provenanceapp/prefix_checksum_test.go
+++ b/cli/internal/provenanceapp/prefix_checksum_test.go
@@ -1,0 +1,86 @@
+package provenanceapp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/parser"
+	"github.com/boshu2/agentops/cli/internal/types"
+)
+
+func TestPrefixChecksumLegacyDigests(t *testing.T) {
+	// Freeze the checksums produced by the original buffered implementation.
+	// These are compatibility oracles, including its omission of invalid inputs.
+	orderedInput := make(map[string]any)
+	orderedInput["z"] = 2
+	orderedInput["a"] = "first"
+	reorderedInput := make(map[string]any)
+	reorderedInput["a"] = "first"
+	reorderedInput["z"] = 2
+	cases := []struct {
+		name     string
+		messages []types.TranscriptMessage
+		upto     int
+		want     string
+	}{
+		{name: "empty", want: "e3b0c44298fc1c14"},
+		{name: "excluded", messages: []types.TranscriptMessage{{MessageIndex: 3, Type: "assistant"}}, upto: 2, want: "e3b0c44298fc1c14"},
+		{name: "inclusive_cutoff", messages: []types.TranscriptMessage{
+			{MessageIndex: 1, Type: "user"},
+			{MessageIndex: 2, Type: "assistant", Tools: []types.ToolCall{{Name: "Bash", Input: map[string]any{"cmd": "echo ok"}, Output: "ok\n"}}},
+			{MessageIndex: 3, Type: "user"},
+		}, upto: 2, want: "dcab0a0347e887c7"},
+		{name: "traversal_order", messages: []types.TranscriptMessage{
+			{MessageIndex: 2, Type: "assistant", Tools: []types.ToolCall{{Name: "A", Output: "second"}}},
+			{MessageIndex: 99, Type: "skip"},
+			{MessageIndex: 1, Type: "assistant", Tools: []types.ToolCall{{Name: "B", Output: "first"}}},
+		}, upto: 2, want: "9212d8b8d71c71c3"},
+		{name: "map_keys", messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "assistant", Tools: []types.ToolCall{{Name: "Read", Input: orderedInput}}}}, upto: 1, want: "637e7a404f42e186"},
+		{name: "reordered_map_keys", messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "assistant", Tools: []types.ToolCall{{Name: "Read", Input: reorderedInput}}}}, upto: 1, want: "637e7a404f42e186"},
+		{name: "unicode_and_controls", messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "assistant\x1f", Tools: []types.ToolCall{{Name: "読み🛠\x00", Input: map[string]any{"text": "雪\n<&\u2028", "control": "\x00\t"}, Output: "\xffα\n\r\t\x00,\x1f"}}}}, upto: 1, want: "280de88e987a2895"},
+		{name: "unmarshalable_input", messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "assistant", Tools: []types.ToolCall{{Name: "Bash", Input: map[string]any{"bad": func() {}}, Output: "retained"}}}}, upto: 1, want: "9cf829d1a81d839f"},
+		{name: "outputs_and_tool_order", messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "tool_result", Tools: []types.ToolCall{{Name: "Z", Output: "a,b\x1fc\n"}, {Name: "A", Input: map[string]any{}, Output: "last"}}}}, upto: 1, want: "8f4e7534d0ba304d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := prefixChecksum(&parser.ParseResult{Messages: tc.messages}, tc.upto)
+			if got != tc.want {
+				t.Fatalf("prefixChecksum() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrefixChecksumLegacyOutputBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		size int
+		want string
+	}{
+		{4095, "ccf0f9ac29114770"}, {4096, "83aa79bd39127ea2"}, {4097, "711a4b809194e7b5"}, {32769, "6c978517d6dd9edf"},
+	} {
+		t.Run(fmt.Sprint(tc.size), func(t *testing.T) {
+			result := &parser.ParseResult{Messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "tool_result", Tools: []types.ToolCall{{Name: "Bash", Output: strings.Repeat("x", tc.size)}}}}}
+			if got := prefixChecksum(result, 1); got != tc.want {
+				t.Fatalf("prefixChecksum() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+var benchmarkPrefixChecksum string
+
+func BenchmarkPrefixChecksumOutput(b *testing.B) {
+	for _, size := range []int{1 << 20, 8 << 20} {
+		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+			// Keep message count fixed and allocate transcript bytes outside timing.
+			result := &parser.ParseResult{Messages: []types.TranscriptMessage{{MessageIndex: 1, Type: "tool_result", Tools: []types.ToolCall{{Name: "Bash", Output: strings.Repeat("x", size)}}}}}
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkPrefixChecksum = prefixChecksum(result, 1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fix the inclusive 64 KiB frontmatter limit in `ao provenance check-okf`, which rejected valid near-limit LF/CRLF headers. Stream session prefix checksums through a fixed buffer while preserving existing digests, events and watermark state.

## Why

The boundary now measures header payload bytes correctly. Checksum allocation for synthetic 1 MiB and 8 MiB tool outputs drops from approximately 2.1 MB and 16.8 MB to 4.4 KB. Small inputs incur the fixed-buffer cost; this is not a total-CLI memory claim.

## How I tested

Regression tests demonstrated the boundary failure before its fix. Thirteen frozen checksum cases passed before and after the refactor; ten actual CLI scenarios preserved exact event/error/state bytes. Go build, vet, full tests, race/shuffle, lint, Bats, aggregate checks, regeneration verification and applicable worktree gates passed. Fresh author-distinct reviews covered each exact change. Existing optional Bats skips are retained.

## Checklist

- [x] Go build and tests pass
- [x] No secrets or credentials in changes
- [x] Public APIs and output contracts preserved
