### PR TITLE
Apply coding-trial lessons to the existing workflow

### DIFF
--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -10,6 +10,9 @@
 
 ## Before Committing Go Changes
 
+While editing, run focused package tests and `cd cli && make lint` before the
+broad checks below. Catch the repository's lint findings before final review.
+
 ```bash
 cd cli && go build ./... && go vet ./... && go test ./...
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ Build bar for any Go change:
 cd cli && go build ./... && go vet ./... && go test ./...
 ```
 
+During Go edits, run focused package tests and `bash scripts/check-go-lint.sh`
+from the repository root before broad integration and final review. A passing
+Go test does not establish the repository's lint contract.
+
 Run the gates with `ao gate check` (`--full` for the whole registry). Regenerate every metadata-owned projection — `skills-codex/` included — with
 `scripts/regen-all.sh` (`--check` to verify without writing); edit `skills/`, then regenerate. `tests/run-all.sh` is the local aggregate runner and must be green.
 CI is authoritative (`.github/workflows/validate.yml`) and runs the bats suites as

--- a/images/gemini/skills/agent-native/SKILL.md
+++ b/images/gemini/skills/agent-native/SKILL.md
@@ -53,6 +53,11 @@ Named failure mode — **prompt-send optimism**: treating a successfully
 delivered prompt as a working worker; delivery proves transport, not
 engagement.
 
+For new authorized work after a worker completes, use the selected runtime's
+documented follow-up or resume operation that starts a turn. A message operation
+may only queue text for a running worker. Check native state and engagement;
+do not treat a queued repair request as a resumed implementation attempt.
+
 Anti-pattern: restarting an unresponsive worker as the first move. Corrective:
 capture its observable state first — a restart destroys the evidence of why it
 stalled, and rescue is usually cheaper than rerun.

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -77,7 +77,9 @@ return the manifest digest and check receipts, stop.
    a fix and another discriminating check, not a helper or fresh planning lane.
    If evidence disproves an assumption, revise the approach within unchanged
    acceptance and scope; use Plan only to resolve consequential uncertainty.
-4. Run the targeted acceptance checks and capture factual results.
+4. Run the targeted acceptance checks and applicable repository lint/static
+   checks before handing off a candidate for broad integration. Capture factual
+   results; package tests alone do not establish a separate lint contract.
 5. Refactor only while those checks stay green. Refactoring does not change the
    acceptance test.
 6. Have the runtime derive actual changed paths and `subject-manifest.v1` from

--- a/images/gemini/skills/refactor/SKILL.md
+++ b/images/gemini/skills/refactor/SKILL.md
@@ -50,6 +50,10 @@ Refactor billing-service/internal/retry/backoff.go: extract the exponential back
 
 1. Name the preserved behavior and the focused acceptance surface.
 2. Record an honest baseline, including any reproducible ambient failures.
+   For an evaluation comparing executable behavior, pin the starting source
+   and build its baseline before edits; retain that binary and the comparison
+   inputs. Compare the candidate using those inputs and the same toolchain.
+   This adds no executable-comparison ritual to ordinary refactoring.
 3. Apply one bounded transformation: extract, rename, inline, simplify,
    encapsulate, move, or delete dead code.
 4. Run the focused check and the smallest package-level regression check justified

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -52,7 +52,9 @@ small operating charter and fresh judgment, not a scheduler or a second queue.
    work, not a reason for another plan, council or helper.
 4. Use cheap discriminating checks during edits, then the required integration
    checks. Preserve valid exact-input receipts. Reserve finishing capacity for
-   integration, fresh final judgment, repairs and a truthful handoff.
+   integration, fresh final judgment, repairs and a truthful handoff. Complete
+   required checks and known repairs before dispatching final judgment, then
+   keep that subject unchanged until the review returns.
 5. Obtain [Validate](../validate/SKILL.md) in a fresh author-distinct context over
    the exact final subject. Default to the author's model family; cross-model
    review is opt-in. There is no fixed ten-minute cap. Required caller-selected

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -51,6 +51,10 @@ Return PASS, FAIL, or NOT_PROVEN with evidence; stop.
 
 ## Preconditions
 
+- Final judgment starts after required checks and known repairs are complete,
+  over a subject the author keeps unchanged during review. If supplied checks
+  already prove failed acceptance, return FAIL on that subject; do not wait
+  while the author repairs it inside the same review.
 - The subject is a nonempty implementation candidate: the manifest lists at
   least one entry. Plans, audits, and reviews are subjects only when the
   caller explicitly requested document review.
@@ -177,6 +181,10 @@ optional, residual risk, or a non-goal to obtain PASS.
    downstream consumer requires it, persist canonical `verdict.v2` with the
    helper's `store-verdict` (mechanics reference), then return the artifact
    path and digest with the result. Stop.
+
+Keep the judgment proportional to the change. Cite existing receipts instead of
+repeating their history; brevity must preserve every criterion, necessary
+finding, identity, freshness fact and unchecked acceptance surface.
 
 Fresh validation is independent judgment over the exact subject, not a replay
 of every author command: rerun the risk-critical, uncertain, or thinly

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -381,8 +381,8 @@
     {
       "name": "agent-native",
       "source_skill": "skills/agent-native",
-      "source_hash": "82db24856239d7489842a400d273dae6192b8795f908c27884a829336105cd23",
-      "generated_hash": "e17fcecf436bbaab6b863e83a8c94cbc32ff18dfa8a14078e27d949f14ef7f7e"
+      "source_hash": "4cd2a8cf4daea6f4b21fcc765fc796f18a7cc1916f894b900fc78817c0467479",
+      "generated_hash": "a43294b142586708c48324dc339d0729e9079966780bf0e9dadaefc20e8dca63"
     },
     {
       "name": "agy-native",
@@ -501,8 +501,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "bbe13c744a2da8697eb253fbf46a01b557d1eda4ad7963166661178ec8773915",
-      "generated_hash": "4f86a43384647c93bf9f26b37ddabb10d405e11dd1a5ef0a9a6005558da831cf"
+      "source_hash": "dba0558617111701bec303febf9de9ae880801655a365e9d0946f560ba3735e2",
+      "generated_hash": "704d5b78ec0d9c57dd7d5118ef14e1048f15a7025cbc7d3ae593a220d6a10c33"
     },
     {
       "name": "learn",
@@ -585,8 +585,8 @@
     {
       "name": "refactor",
       "source_skill": "skills/refactor",
-      "source_hash": "9b27393da0ab3775d23170b288c60cc0b60038e938e30dd23fbf395bea55b0a2",
-      "generated_hash": "93c9377e2862a9f968f4c820a27c649cc973c534f424065b24f92fbc9b8998b1"
+      "source_hash": "1b33858d4a5ea3a2f7f3489e96b6376c35c817e634db554f0c3d0a73be035242",
+      "generated_hash": "3ef5c82022f25f73b1a1ac58666c3be4ae2ad5cc4f508adb0d4db349251e62c7"
     },
     {
       "name": "research",
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "12e97ce8d2f9d35fe1c6c925438b1a760aa1a8f654edec9495f354f4b08020f8",
-      "generated_hash": "41e97957623941521e73719a2ca3839b3815e9892c6450954ce95dc947982265"
+      "source_hash": "ee6193fccbe9ed0cbef3461dbc232e88d0b401d526afd0d6b3718830ad88a520",
+      "generated_hash": "dbd9fa14966d0bba9da35635e20cc15dc48457434c957eef508a4ec785452128"
     },
     {
       "name": "sbh",
@@ -687,8 +687,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "bb32065fad40750a975908bfd75dc3b051bced9cc5ceddcd5c4249b4db70dc3d",
-      "generated_hash": "a3d85a18264d6ae61fb1c72dc13ed5c4581149d122642889a0adfe4a35b13794"
+      "source_hash": "b22ccc91da9328e8a1f9ecd5577282b0ec7f8a72eae505eb6ff3a7623264ca4c",
+      "generated_hash": "3c8b4a0d968f8a75eb07f7873be9cd8025b6b245691dabd3dafb419a456caf26"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/agent-native/.agentops-generated.json
+++ b/skills-codex/agent-native/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/agent-native",
   "layout": "modular",
-  "source_hash": "82db24856239d7489842a400d273dae6192b8795f908c27884a829336105cd23",
-  "generated_hash": "e17fcecf436bbaab6b863e83a8c94cbc32ff18dfa8a14078e27d949f14ef7f7e"
+  "source_hash": "4cd2a8cf4daea6f4b21fcc765fc796f18a7cc1916f894b900fc78817c0467479",
+  "generated_hash": "a43294b142586708c48324dc339d0729e9079966780bf0e9dadaefc20e8dca63"
 }

--- a/skills-codex/agent-native/SKILL.md
+++ b/skills-codex/agent-native/SKILL.md
@@ -31,6 +31,11 @@ Named failure mode — **prompt-send optimism**: treating a successfully
 delivered prompt as a working worker; delivery proves transport, not
 engagement.
 
+For new authorized work after a worker completes, use the selected runtime's
+documented follow-up or resume operation that starts a turn. A message operation
+may only queue text for a running worker. Check native state and engagement;
+do not treat a queued repair request as a resumed implementation attempt.
+
 Anti-pattern: restarting an unresponsive worker as the first move. Corrective:
 capture its observable state first — a restart destroys the evidence of why it
 stalled, and rescue is usually cheaper than rerun.

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "bbe13c744a2da8697eb253fbf46a01b557d1eda4ad7963166661178ec8773915",
-  "generated_hash": "4f86a43384647c93bf9f26b37ddabb10d405e11dd1a5ef0a9a6005558da831cf"
+  "source_hash": "dba0558617111701bec303febf9de9ae880801655a365e9d0946f560ba3735e2",
+  "generated_hash": "704d5b78ec0d9c57dd7d5118ef14e1048f15a7025cbc7d3ae593a220d6a10c33"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -54,7 +54,9 @@ return the manifest digest and check receipts, stop.
    a fix and another discriminating check, not a helper or fresh planning lane.
    If evidence disproves an assumption, revise the approach within unchanged
    acceptance and scope; use Plan only to resolve consequential uncertainty.
-4. Run the targeted acceptance checks and capture factual results.
+4. Run the targeted acceptance checks and applicable repository lint/static
+   checks before handing off a candidate for broad integration. Capture factual
+   results; package tests alone do not establish a separate lint contract.
 5. Refactor only while those checks stay green. Refactoring does not change the
    acceptance test.
 6. Have the runtime derive actual changed paths and `subject-manifest.v1` from

--- a/skills-codex/refactor/.agentops-generated.json
+++ b/skills-codex/refactor/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/refactor",
   "layout": "modular",
-  "source_hash": "9b27393da0ab3775d23170b288c60cc0b60038e938e30dd23fbf395bea55b0a2",
-  "generated_hash": "93c9377e2862a9f968f4c820a27c649cc973c534f424065b24f92fbc9b8998b1"
+  "source_hash": "1b33858d4a5ea3a2f7f3489e96b6376c35c817e634db554f0c3d0a73be035242",
+  "generated_hash": "3ef5c82022f25f73b1a1ac58666c3be4ae2ad5cc4f508adb0d4db349251e62c7"
 }

--- a/skills-codex/refactor/SKILL.md
+++ b/skills-codex/refactor/SKILL.md
@@ -24,6 +24,10 @@ Refactor billing-service/internal/retry/backoff.go: extract the exponential back
 
 1. Name the preserved behavior and the focused acceptance surface.
 2. Record an honest baseline, including any reproducible ambient failures.
+   For an evaluation comparing executable behavior, pin the starting source
+   and build its baseline before edits; retain that binary and the comparison
+   inputs. Compare the candidate using those inputs and the same toolchain.
+   This adds no executable-comparison ritual to ordinary refactoring.
 3. Apply one bounded transformation: extract, rename, inline, simplify,
    encapsulate, move, or delete dead code.
 4. Run the focused check and the smallest package-level regression check justified

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "12e97ce8d2f9d35fe1c6c925438b1a760aa1a8f654edec9495f354f4b08020f8",
-  "generated_hash": "41e97957623941521e73719a2ca3839b3815e9892c6450954ce95dc947982265"
+  "source_hash": "ee6193fccbe9ed0cbef3461dbc232e88d0b401d526afd0d6b3718830ad88a520",
+  "generated_hash": "dbd9fa14966d0bba9da35635e20cc15dc48457434c957eef508a4ec785452128"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -22,7 +22,9 @@ small operating charter and fresh judgment, not a scheduler or a second queue.
    work, not a reason for another plan, council or helper.
 4. Use cheap discriminating checks during edits, then the required integration
    checks. Preserve valid exact-input receipts. Reserve finishing capacity for
-   integration, fresh final judgment, repairs and a truthful handoff.
+   integration, fresh final judgment, repairs and a truthful handoff. Complete
+   required checks and known repairs before dispatching final judgment, then
+   keep that subject unchanged until the review returns.
 5. Obtain [Validate](../validate/SKILL.md) in a fresh author-distinct context over
    the exact final subject. Default to the author's model family; cross-model
    review is opt-in. There is no fixed ten-minute cap. Required caller-selected

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "bb32065fad40750a975908bfd75dc3b051bced9cc5ceddcd5c4249b4db70dc3d",
-  "generated_hash": "a3d85a18264d6ae61fb1c72dc13ed5c4581149d122642889a0adfe4a35b13794"
+  "source_hash": "b22ccc91da9328e8a1f9ecd5577282b0ec7f8a72eae505eb6ff3a7623264ca4c",
+  "generated_hash": "3c8b4a0d968f8a75eb07f7873be9cd8025b6b245691dabd3dafb419a456caf26"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -23,6 +23,10 @@ Return PASS, FAIL, or NOT_PROVEN with evidence; stop.
 
 ## Preconditions
 
+- Final judgment starts after required checks and known repairs are complete,
+  over a subject the author keeps unchanged during review. If supplied checks
+  already prove failed acceptance, return FAIL on that subject; do not wait
+  while the author repairs it inside the same review.
 - The subject is a nonempty implementation candidate: the manifest lists at
   least one entry. Plans, audits, and reviews are subjects only when the
   caller explicitly requested document review.
@@ -149,6 +153,10 @@ optional, residual risk, or a non-goal to obtain PASS.
    downstream consumer requires it, persist canonical `verdict.v2` with the
    helper's `store-verdict` (mechanics reference), then return the artifact
    path and digest with the result. Stop.
+
+Keep the judgment proportional to the change. Cite existing receipts instead of
+repeating their history; brevity must preserve every criterion, necessary
+finding, identity, freshness fact and unchecked acceptance surface.
 
 Fresh validation is independent judgment over the exact subject, not a replay
 of every author command: rerun the risk-critical, uncertain, or thinly

--- a/skills/agent-native/SKILL.md
+++ b/skills/agent-native/SKILL.md
@@ -53,6 +53,11 @@ Named failure mode — **prompt-send optimism**: treating a successfully
 delivered prompt as a working worker; delivery proves transport, not
 engagement.
 
+For new authorized work after a worker completes, use the selected runtime's
+documented follow-up or resume operation that starts a turn. A message operation
+may only queue text for a running worker. Check native state and engagement;
+do not treat a queued repair request as a resumed implementation attempt.
+
 Anti-pattern: restarting an unresponsive worker as the first move. Corrective:
 capture its observable state first — a restart destroys the evidence of why it
 stalled, and rescue is usually cheaper than rerun.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -77,7 +77,9 @@ return the manifest digest and check receipts, stop.
    a fix and another discriminating check, not a helper or fresh planning lane.
    If evidence disproves an assumption, revise the approach within unchanged
    acceptance and scope; use Plan only to resolve consequential uncertainty.
-4. Run the targeted acceptance checks and capture factual results.
+4. Run the targeted acceptance checks and applicable repository lint/static
+   checks before handing off a candidate for broad integration. Capture factual
+   results; package tests alone do not establish a separate lint contract.
 5. Refactor only while those checks stay green. Refactoring does not change the
    acceptance test.
 6. Have the runtime derive actual changed paths and `subject-manifest.v1` from

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -50,6 +50,10 @@ Refactor billing-service/internal/retry/backoff.go: extract the exponential back
 
 1. Name the preserved behavior and the focused acceptance surface.
 2. Record an honest baseline, including any reproducible ambient failures.
+   For an evaluation comparing executable behavior, pin the starting source
+   and build its baseline before edits; retain that binary and the comparison
+   inputs. Compare the candidate using those inputs and the same toolchain.
+   This adds no executable-comparison ritual to ordinary refactoring.
 3. Apply one bounded transformation: extract, rename, inline, simplify,
    encapsulate, move, or delete dead code.
 4. Run the focused check and the smallest package-level regression check justified

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -52,7 +52,9 @@ small operating charter and fresh judgment, not a scheduler or a second queue.
    work, not a reason for another plan, council or helper.
 4. Use cheap discriminating checks during edits, then the required integration
    checks. Preserve valid exact-input receipts. Reserve finishing capacity for
-   integration, fresh final judgment, repairs and a truthful handoff.
+   integration, fresh final judgment, repairs and a truthful handoff. Complete
+   required checks and known repairs before dispatching final judgment, then
+   keep that subject unchanged until the review returns.
 5. Obtain [Validate](../validate/SKILL.md) in a fresh author-distinct context over
    the exact final subject. Default to the author's model family; cross-model
    review is opt-in. There is no fixed ten-minute cap. Required caller-selected

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -51,6 +51,10 @@ Return PASS, FAIL, or NOT_PROVEN with evidence; stop.
 
 ## Preconditions
 
+- Final judgment starts after required checks and known repairs are complete,
+  over a subject the author keeps unchanged during review. If supplied checks
+  already prove failed acceptance, return FAIL on that subject; do not wait
+  while the author repairs it inside the same review.
 - The subject is a nonempty implementation candidate: the manifest lists at
   least one entry. Plans, audits, and reviews are subjects only when the
   caller explicitly requested document review.
@@ -177,6 +181,10 @@ optional, residual risk, or a non-goal to obtain PASS.
    downstream consumer requires it, persist canonical `verdict.v2` with the
    helper's `store-verdict` (mechanics reference), then return the artifact
    path and digest with the result. Stop.
+
+Keep the judgment proportional to the change. Cite existing receipts instead of
+repeating their history; brevity must preserve every criterion, necessary
+finding, identity, freshness fact and unchecked acceptance surface.
 
 Fresh validation is independent judgment over the exact subject, not a replay
 of every author command: rerun the risk-critical, uncertain, or thinly


### PR DESCRIPTION
Coding trials exposed late lint failures, reviews started while code was still changing, and a completed worker that did not resume when only sent a message. This update puts the existing lint checks earlier, requires completed checks and frozen content before final judgment, and clarifies the native worker resume boundary. Comparative refactor evaluations also pin their baseline before edits.

Changes stay in seven existing workflow sources and their generated projections. No new skill, gate, framework or timeout is added.

Validation: fresh author-distinct review PASS over all 23 changed paths; full Bats suite, aggregate runner, regeneration check and worktree gates passed. The reviewed content digest remains unchanged after rebasing onto current main. These are workflow guidance changes; the following three bounded Go cases will test their application.
