### PR TITLE
Simplify core skills and reduce repeated context work

### DIFF
--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -27,7 +27,7 @@ metadata:
 
 # Implement
 
-Implement the accepted outcome and repair understood defects. Use the existing
+Implement the accepted outcome. Repair ordinary known defects directly. Use the existing
 intent; no Plan, Recall or Learn worksheet is owed for a clear edit. Implement
 owns source changes and factual checks; the runtime derives identity and receipts.
 
@@ -57,7 +57,7 @@ owns source changes and factual checks; the runtime derives identity and receipt
    goldens, tolerances, suppressions and specification text against original
    intent. Mocks, placeholders or weakened oracles cannot substitute for the
    requested behavior.
-6. Derive complete changed paths and `subject-manifest.v1`. When changed paths
+6. Have the runtime derive actual changed paths and `subject-manifest.v1`. When changed paths
    affect bound acceptance evidence, run `ao provenance evidence-orphans --root
    <repo-root>` with one `--changed <path>` per derived path, and retain the
    actual output for the validator. Repeat after repairs that change that

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -27,100 +27,58 @@ metadata:
 
 # Implement
 
-Implement the authorized outcome, including ordinary direct repairs. Use the
-resolved bead or caller intent; do not turn every failed check into a new phase.
-Implement owns subject edits and factual evidence; the runtime derives identity
-and receipts. A clear trivial change needs no Plan, Recall or Learn worksheet.
-
-## Prompt
-
-```text
-Implement bead ag-1234 from its text: acceptance "ao gate check lists
-skill.probe-coverage", scope cli/internal/gates/** plus regen outputs, first
-check `cd cli && go test ./internal/gates/...`. RED first, smallest change,
-return the manifest digest and check receipts, stop.
-```
-
-## It's working if
-
-- After source activation and startup association, the first behavior check
-  is the acceptance check; its output shows the expected failure (or an honest
-  green structural baseline for documentation, relocation, or refactor work).
-- Every path in `git diff --stat` falls inside the declared scope; an outside
-  consumer is reported as `file:line`, not absorbed.
-- The response carries the `subject-manifest.v1` digest, author context ID,
-  and verbatim check output; no `git commit` or `git push` appears.
+Implement the accepted outcome and repair understood defects. Use the existing
+intent; no Plan, Recall or Learn worksheet is owed for a clear edit. Implement
+owns source changes and factual checks; the runtime derives identity and receipts.
 
 ## Workflow
 
-1. Read the intent, acceptance, and scope from their existing source; before
-   the first write, read `boundaries.md` in the rpi skill's `references`
-   directory for what Implement does not own. Before execution can fail, the
-   caller passes source-store/project/work identity and permitted intent
-   locators at dispatch/start. At startup, return observed native runtime,
-   session/context identity (or explicit unknowns) through the caller-owned
-   runtime channel for native comments/metadata recording; do not defer this
-   association until handoff. Follow the fact distinctions in
-   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
-   Parent and resume links need observed provenance; controller dispatch alone
-   does not establish native parentage. If startup observation or recording
-   fails, preserve that failure and the pre-execution reference with the caller,
-   leaving unobserved IDs unknown. Startup association applies when the caller selected episode tracking; a
-   trivial edit does not need a new tracking worksheet. Use the caller-owned
-   runtime channel for handoff facts, without a second work account.
-2. Run the declared first acceptance check before changing behavior. RED-first
-   applies when acceptance is behavioral: preserve evidence that the check
-   fails for the expected missing behavior. Relocations, doc merges, and pure
-   refactors record an honest green pre-change baseline instead.
-3. Make the smallest in-scope change that satisfies the active behavior. Repair
-   ordinary known defects directly. A failed test with an understood cause needs
-   a fix and another discriminating check, not a helper or fresh planning lane.
-   If evidence disproves an assumption, revise the approach within unchanged
-   acceptance and scope; use Plan only to resolve consequential uncertainty.
-4. Run the targeted acceptance checks and applicable repository lint/static
-   checks before handing off a candidate for broad integration. Capture factual
-   results; package tests alone do not establish a separate lint contract.
-5. Refactor only while those checks stay green. Refactoring does not change the
-   acceptance test.
-6. Have the runtime derive actual changed paths and `subject-manifest.v1` from
-   the before/after subject.
-7. When changed files affect bound acceptance evidence, run `ao provenance evidence-orphans --root <repo-root>` with one
-   `--changed <path>` per changed path the runtime derived, and put its JSON
-   output in the check receipts the validator reads, so orphaned evidence
-   arrives as a receipt rather than as a surprise at verify time. Run it again after every repair round, over the
-   paths as they stand, because a repair can orphan evidence the first pass did
-   not. Read the output as written and never hand-list the orphans instead.
-8. Return the manifest digest, author context ID, and exact check receipts in the
-   response or runtime channel. Stop.
+1. Read intent, acceptance, scope and the RPI [boundaries](../rpi/references/boundaries.md)
+   before the first write; reuse contracts already loaded in this context.
+   When the caller selected episode tracking, obtain permitted work/source
+   references before execution and return observed runtime/context identity at
+   startup through the native recording channel. Unknowns and recording failures
+   stay explicit; do not invent parentage or a second tracker. The optional
+   [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+   supplies mechanics for that selected workflow.
+2. Run the first useful acceptance check. Behavioral changes preserve RED for
+   the expected missing behavior; a pure refactor, relocation or documentation
+   change may have an honest green baseline. Avoid building elaborate fixtures
+   when an existing test or small discriminating probe answers the question.
+3. Make the smallest in-scope change. Fix known failures directly, then rerun
+   the affected check. A disproved assumption may change the approach within
+   accepted outcome and scope; use Plan only for consequential uncertainty.
+4. Use targeted tests and applicable repository lint/static checks before
+   broad integration. Read the repository's actual check recipe, including
+   instrumentation and environment, rather than reconstructing it from memory.
+   Run required full checks at integration, not after each small edit. Reuse
+   exact-input receipts only while source, tool and relevant environment match.
+5. Refactor while acceptance remains green. Inspect changed tests, fixtures,
+   goldens, tolerances, suppressions and specification text against original
+   intent. Mocks, placeholders or weakened oracles cannot substitute for the
+   requested behavior.
+6. Derive complete changed paths and `subject-manifest.v1`. When changed paths
+   affect bound acceptance evidence, run `ao provenance evidence-orphans --root
+   <repo-root>` with one `--changed <path>` per derived path, and retain the
+   actual output for the validator. Repeat after repairs that change that
+   subject; do not hand-invent an orphan list.
+7. Return the manifest digest, author context ID, acceptance-check facts and
+   evidence references through the caller's response/runtime channel, then stop.
+   Include command, result and decision-relevant failures. Keep full output
+   accessible instead of pasting successful logs or repeated receipt inventories
+   into every handoff. Missing or truncated evidence must remain visible.
 
-Specialists (standards, domain, test, refactor, security) advise only. During
-edits, run the smallest deterministic checks that can falsify the change,
-reuse exact-input receipts whose subject and tool identity still match, and
-run the full suite at the integration boundary unless the intent makes it the
-first check.
+## Scope and finish
 
-## Scope conflict rule
+Report an uncovered live consumer as `file:line` for a caller scope amendment;
+continue independent authorized work. Generated companions already included as
+scope require no new approval. Acceptance changes always require caller authority.
 
-On discovering a live consumer of the change outside the declared write scope
-(a test asserting the old path, a generated twin, a gate reading the moved
-file), stop and report the exact file and line to the caller for a scope amendment; continue independent authorized work. A different
-acceptance contract needs caller authority. Generated outputs already included
-as a scope class need no new permission.
+Specialists advise only. Known defects stay implementation work; a genuine
+causal stall follows RPI's at-most-one bounded helper rule. Respect remaining
+caller/native bounds and reserve finishing capacity. No retry resets them.
 
-Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
-stubs, hardcoded fixture values, weakened assertions, regenerated goldens,
-widened tolerances, suppression directives, or specification edits standing
-in for real behavior. A changed test, gate, fixture, golden, or acceptance
-source must be required by the original intent, with green coming from the
-implemented behavior; a check that passes against a substitute or weakened
-oracle is not evidence: finish the behavior or report it as not built.
-
-## Boundary
-
-Do not issue semantic PASS or infer Git, tracker or delivery permission from
-this skill. Follow the caller's existing authority and repository policy.
-An implement-only handoff returns facts to its caller; a full outcome request
-uses RPI through fresh final validation. Known defects stay implementation work.
-On a genuine causal stall, use RPI's at-most-one bounded helper rule, never a
-helper chain. Reserve finishing capacity and respect actual caller/native bounds;
-a retry count alone is not a spent time or quota budget.
+Return facts, not semantic PASS. An implement-only handoff does not authorize
+Git, tracker or delivery transitions; existing caller authority remains usable.
+A full outcome request uses RPI through fresh final judgment. Success is working
+behavior with usable evidence, not volume of logs or process artifacts.

--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -24,8 +24,9 @@ metadata:
 
 # Plan
 
-Shape only missing intent in the caller's bead, conversation or supplied text.
-Planning produces no AgentOps packet. A clear change can proceed directly.
+Shape only missing intent. Prefer the caller's tracker, if any; otherwise use
+the conversation or supplied text. Planning produces no AgentOps packet.
+A clear change can proceed directly.
 
 ## Workflow
 

--- a/images/gemini/skills/plan/SKILL.md
+++ b/images/gemini/skills/plan/SKILL.md
@@ -24,67 +24,48 @@ metadata:
 
 # Plan
 
-Shape only what is missing from the authorized intent. Prefer the caller's tracker, if any;
-otherwise use the caller's conversation or supplied text. A clear trivial change
-needs no planning worksheet or separate Plan dispatch. Planning produces no AgentOps packet.
+Shape only missing intent in the caller's bead, conversation or supplied text.
+Planning produces no AgentOps packet. A clear change can proceed directly.
 
 ## Workflow
 
-1. Read the actual intent, relevant source owners and active constraints. Find
-   the caller-visible outcome, allowed write scope and first useful check.
-   Inspect only enough context to resolve a consequential uncertainty.
-2. Where needed, clarify acceptance examples, important non-goals and scope in
-   the existing source. Include generated companions as a class: hand-edited
-   sources plus every output of the owning regeneration commands. Include tests
-   and live consumers that must change with them. Scope is authority, not a
-   prediction of an exact file count.
-3. Choose the smallest acceptance-advancing action or discriminating check.
-   Identify evidence the change could invalidate and include recapture where
-   required. Use `ao provenance evidence-orphans` for affected bound evidence;
-   avoid a mandatory ledger or taxonomy for changes that do not need one.
-4. Revise the approach when evidence disproves an assumption under unchanged
-   accepted outcome and scope. Record the disproved assumption, evidence and
-   revised check briefly in the existing source or handoff. No new permission
-   is needed for this approach revision. Changing acceptance or expanding scope
-   needs caller authority; never quietly weaken the original check.
-5. When another context needs the intent, pass enough exact source and references
-   to act without the author's private reasoning. The runtime binds accepted
-   intent for final validation; useful approach notes are separate from frozen
-   acceptance so revising a hypothesis does not fabricate acceptance drift.
+1. Read accepted intent and relevant source owners and active constraints.
+   Resolve only consequential uncertainty; do not reopen settled decisions
+   without new evidence. Identify the caller-visible outcome, scope and first
+   useful check.
+2. Clarify missing acceptance examples and non-goals in that existing source.
+   Scope includes the hand-edited owners, affected tests/live consumers and
+   generator-owned companions as a class; it is authority, not a predicted
+   file count. A consequential assumption deserves an early discriminating
+   check, not a general checklist or exhaustive survey.
+3. Choose the smallest action that advances acceptance or falsifies the risky
+   assumption. Include recapture of affected bound evidence where necessary;
+   use `ao provenance evidence-orphans` when applicable, not a mandatory ledger.
+4. When evidence disproves an approach, briefly retain the failed assumption,
+   evidence and revised check in the existing intent or handoff. Approach
+   changes within accepted outcome and scope need no new permission; acceptance
+   or scope expansion requires caller authority. Never relabel a failed
+   acceptance condition as a caveat to obtain green.
+5. Give another context exact intent references and the evidence it needs to
+   act. Keep approach notes separate from frozen acceptance. Do not transmit
+   the entire research history when a focused source reference will suffice.
 
-A plan is sufficient when the implementer can act and the validator can judge.
-Then stop planning and implement. Specialists and
-[ground-truth routing](references/ground-truth-routing.md) are optional tools for
-consequential integration or design uncertainty, not universal worksheets.
-[Memory recall](../memory/references/recall.md) is useful only when applicable
-prior experience may change this work's next action.
+Stop planning once the implementer can act and the validator can judge. More
+research, decomposition or review must resolve a named remaining uncertainty.
+Specialists and [ground-truth routing](references/ground-truth-routing.md) are
+optional. [Memory recall](../memory/references/recall.md) is useful only when
+prior evidence could change the next action.
 
 ## Identity and scope
 
-Use the runtime's source reference and digest for exact accepted intent. For
-conversation-only intent, existing `ao provenance snapshot-intent --source -
---evidence-root <explicit-root>` stores resolved bytes in a caller-selected
-protected external non-Git evidence directory. Missing routing does not authorize
-a workspace fallback or a second plan artifact. Preserve legacy proof.
+Use runtime-derived source identity and digest. If conversation intent needs
+an exact snapshot, existing `ao provenance snapshot-intent --source -
+--evidence-root <explicit-root>` uses caller-selected protected external
+non-Git storage. Missing routing permits neither workspace fallback nor a
+second planning artifact. Preserve legacy proof.
 
-Scope patterns are normalized repository-relative paths, cover the behavior,
-and include generator-owned companions without granting unrelated directories.
-A live consumer outside accepted scope needs a concise exact-file amendment to
-the caller; continue independent authorized work while that decision is pending.
-[Boundaries](../rpi/references/boundaries.md) keep work/status in the caller's
-tracker and Git/delivery under repository policy.
-
-## Prompt
-
-```text
-Use Plan to resolve the uncertain parser interface for this accepted change.
-Keep acceptance and scope; use a real consumer check to test the assumption.
-Revise the approach if it fails, then implement. No new planning artifact.
-```
-
-## It's working if
-
-A clear small change skips planning paperwork. A falsified assumption changes
-the approach and the next check; it does not trigger another approval round
-unless outcome or scope changes. Generated outputs remain in scope and the
-existing intent gives a fresh implementer enough information to act.
+Use normalized repository-relative scope patterns. An uncovered live consumer
+needs a concise exact-file amendment to the caller; continue independent
+in-scope work meanwhile. Generated companions already in scope need no extra
+permission. [Boundaries](../rpi/references/boundaries.md) keep work/status in
+the caller's tracker and delivery under repository policy.

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -34,7 +34,7 @@ output_contract: 'concise human-readable result; optional rpi-report.v1 when a c
 
 # RPI
 
-Own the authorized outcome through finish using the native coding agent and
+Own the authorized outcome through finish. Use the native coding agent and
 shell. BD or the caller's tracker owns work and handoffs; Git owns content and
 delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
@@ -47,7 +47,8 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
    shapes missing intent or revises a disproved approach. Once an implementer
    can act and a validator can judge, implement; do not keep improving the plan.
    Approach revisions preserve acceptance and authorized scope.
-3. [Implement](../implement/SKILL.md) and repair understood defects directly.
+   Acceptance changes need caller authority.
+3. [Implement](../implement/SKILL.md) and repair ordinary known defects directly.
    A known test failure needs a fix and a discriminating check, not another
    planning phase, council or helper.
 4. Use focused checks during edits and complete required integration checks
@@ -56,7 +57,8 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
    Keep the final subject unchanged while it is being judged.
 5. Obtain [Validate](../validate/SKILL.md) from one fresh author-distinct context
    in the author's model family unless the caller selects required additional
-   legs. Risk deepens evidence, not automatic reviewer multiplication. Repair
+   legs. There is no fixed ten-minute cap; explicitly required
+   reviewers remain required. Risk deepens evidence, not reviewer multiplication. Repair
    actionable findings within authority and remaining bounds, then revalidate
    the changed exact subject.
 6. Stop at completed acceptance, cancellation, refusal, a spent real bound or
@@ -82,13 +84,14 @@ Use observed runtime capabilities; prompt wording does not prove isolation.
 Return concise findings, check facts and accessible evidence references. Keep
 full logs available, showing only decision-relevant excerpts; disclose truncation
 or missing evidence. Reuse one caller-owned handoff instead of multiplying
-plans, receipt summaries and status documents. Machine evidence is optional
-unless requested or required by a declared consumer.
+plans, receipt summaries and status documents. Machine evidence such as `verdict.v2` is optional
+unless requested or required by a declared consumer. When no machine
+artifact is requested or required, return the result without creating one.
 
 ## Causal stall and bounds
 
-Unknown cause, recurrence, no progress or a wrong objective admits at most one
-bounded fresh helper for that incident within authority and remaining bounds.
+Unknown cause, recurrence, no progress or a wrong objective admits
+at most one bounded fresh helper for that incident within authority and bounds.
 Give it the failed assumption, evidence and one discriminating question. Resume
 only with a different testable approach; an unhelpful answer ends the attempt.
 Do not chain helpers or rename the incident. Known failures get direct repair.

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -34,106 +34,90 @@ output_contract: 'concise human-readable result; optional rpi-report.v1 when a c
 
 # RPI
 
-Own the authorized outcome through finish. Use the native coding agent and
-shell; BD or the caller's tracker owns work/status/handoffs, Git owns content
-and delivery history. Keep one authoritative work account. AgentOps adds a
-small operating charter and fresh judgment, not a scheduler or a second queue.
+Own the authorized outcome through finish using the native coding agent and
+shell. BD or the caller's tracker owns work and handoffs; Git owns content and
+delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
 ## Operating charter
 
-1. Keep the accepted outcome, scope and real bounds in view. Use the existing
-   intent; a trivial clear change needs no Plan, Recall or Learn worksheet.
-2. Take the smallest action that advances acceptance or resolves a consequential
-   uncertainty. Load [Plan](../plan/SKILL.md) only when intent or approach needs
-   shaping. Evidence may disprove an assumption: revise the approach within
-   unchanged accepted outcome and scope. Acceptance changes need caller authority.
-3. [Implement](../implement/SKILL.md) the change and repair ordinary known
-   defects directly. A failed check with an understood cause is implementation
-   work, not a reason for another plan, council or helper.
-4. Use cheap discriminating checks during edits, then the required integration
-   checks. Preserve valid exact-input receipts. Reserve finishing capacity for
-   integration, fresh final judgment, repairs and a truthful handoff. Complete
-   required checks and known repairs before dispatching final judgment, then
-   keep that subject unchanged until the review returns.
-5. Obtain [Validate](../validate/SKILL.md) in a fresh author-distinct context over
-   the exact final subject. Default to the author's model family; cross-model
-   review is opt-in. There is no fixed ten-minute cap. Required caller-selected
-   reviewers remain required. Every necessary finding stays visible.
-6. Repair actionable findings within authority and real remaining bounds, then
-   obtain fresh judgment over the changed subject. Stop at completed acceptance,
-   cancellation, an explicit refusal, a spent real bound, or a genuine causal
-   stall that the bounded help below cannot resolve. Activity, saved pages,
-   changed digests and repeated reviews are not completed capability.
+1. Use the existing accepted outcome, scope and real bounds. A clear change
+   needs no Plan, Recall or Learn worksheet. Resolve uncertainty only when it
+   could change the implementation or acceptance decision.
+2. Take the smallest acceptance-advancing action. [Plan](../plan/SKILL.md)
+   shapes missing intent or revises a disproved approach. Once an implementer
+   can act and a validator can judge, implement; do not keep improving the plan.
+   Approach revisions preserve acceptance and authorized scope.
+3. [Implement](../implement/SKILL.md) and repair understood defects directly.
+   A known test failure needs a fix and a discriminating check, not another
+   planning phase, council or helper.
+4. Use focused checks during edits and complete required integration checks
+   before final judgment. Reuse valid exact-input receipts; rerun affected
+   checks after changes. Reserve capacity for integration, review and repair.
+   Keep the final subject unchanged while it is being judged.
+5. Obtain [Validate](../validate/SKILL.md) from one fresh author-distinct context
+   in the author's model family unless the caller selects required additional
+   legs. Risk deepens evidence, not automatic reviewer multiplication. Repair
+   actionable findings within authority and remaining bounds, then revalidate
+   the changed exact subject.
+6. Stop at completed acceptance, cancellation, refusal, a spent real bound or
+   an unresolved causal stall after the help below. Adjacent improvements are
+   not permission to expand the goal. Report them briefly only when useful;
+   do not turn them into another work batch.
+
+## Context and handoffs
+
+Load required contracts once per context, then inspect the source or evidence
+needed for the next decision. A reference link is available context, not a
+reading list. Search before opening large files; retrieve relevant sections
+and expand when uncertainty requires it. Do not reread unchanged material or
+copy full logs into successive tool results and handoffs.
+
+When delegation is authorized and useful, give each worker task-specific
+context: accepted intent and scope, exact subject, relevant evidence, remaining
+bounds and the requested result. Prefer a new task-only context for an
+independent subtask; resume the original worker for a direct repair when useful.
+Validators always receive fresh context, without the author's desired verdict.
+Use observed runtime capabilities; prompt wording does not prove isolation.
+
+Return concise findings, check facts and accessible evidence references. Keep
+full logs available, showing only decision-relevant excerpts; disclose truncation
+or missing evidence. Reuse one caller-owned handoff instead of multiplying
+plans, receipt summaries and status documents. Machine evidence is optional
+unless requested or required by a declared consumer.
 
 ## Causal stall and bounds
 
-Unknown cause, recurrence, no progress or evidence of the wrong objective calls
-for causal examination. A genuine causal stall admits **at most one bounded
-fresh helper** for that incident, when authorized and within remaining bounds.
+Unknown cause, recurrence, no progress or a wrong objective admits at most one
+bounded fresh helper for that incident within authority and remaining bounds.
 Give it the failed assumption, evidence and one discriminating question. Resume
-only when the answer supplies a different testable approach; an unhelpful answer
-ends the attempt with the unresolved facts. Do not create a helper chain or
-rename the same incident to obtain another helper. Known failures get direct
-repair. Cancellation, refusal and spent hard time/cost/quota skip help.
+only with a different testable approach; an unhelpful answer ends the attempt.
+Do not chain helpers or rename the incident. Known failures get direct repair.
+Cancellation, refusal and spent hard time/cost/quota skip help.
 
-Respect actual caller/native limits, including an explicit repair-round bound
-when supplied; no invocation, compaction, helper or new subject renews them.
-A retry count alone is not a spent time or quota budget. Keep compact recovery
-state only when interruption threatens evidence: accepted intent, exact current
-subject, useful receipts, unresolved cause, bounds and helper use, in the native
-handoff source. Prompt text is no proof of native enforcement.
-[Outer-goal guidance](references/outer-goal.md) is optional and outside the core.
+Respect actual caller/native limits, including explicit repair-round bounds.
+Retries, compaction, helpers and new subjects never renew them; retry count
+alone is not a spent budget. If interruption threatens evidence, preserve
+accepted intent, exact subject, useful receipts, unresolved cause, bounds and
+helper use in the native handoff. Prompt text proves no native enforcement.
+[Outer-goal guidance](references/outer-goal.md) remains optional.
 
-## On-demand tools
+## Evidence and boundaries
 
-- Plan shapes missing intent or revises an approach falsified by evidence.
-- Implement owns edits, direct repairs and factual checks.
-- Validate owns fresh exact-subject judgment; the author cannot issue binding PASS.
-- [Memory](../memory/SKILL.md) recalls applicable reviewed topic pages, or performs
-  separately budgeted mining and curation when requested. It is never an entry
-  or completion toll. No-match and no-change are valid.
+Bind accepted intent, complete changed paths, exact subject and factual receipts
+for the fresh validator; disclose affected orphaned acceptance evidence. Use
+existing provenance helpers rather than a new evidence format. Requested proof
+uses caller-selected protected external non-Git storage; preserve legacy
+`.agents/` evidence. Missing identity, freshness or proof means NOT_PROVEN;
+proven failed acceptance or scope violation means FAIL. PASS needs every
+criterion verified and empty `not_checked`. Authors cannot issue binding PASS.
 
-Specialists, including anti-ceremony, premortem, council, research and runtime
-adapters, remain optional. Risk increases evidence depth; it does not mandate a
-specialist dispatch. Read [boundaries](references/boundaries.md) when a source,
-review or delivery boundary matters; do not turn the charter into another packet.
+[Memory](../memory/SKILL.md), specialists and runtime adapters are on demand;
+no-match and no-change are valid. Read [boundaries](references/boundaries.md)
+when authority, scope, evidence or delivery is at issue. The optional
+[fixed-dispatch adapter](references/bounded-adapter.md) is not the native
+execution engine. Do not invent a runtime, hidden machine artifact or workflow
+to finish an ordinary change.
 
-## Evidence and report
-
-Bind the accepted intent and exact subject for the fresh validator, derive
-complete changed paths and factual check receipts, and disclose orphaned
-acceptance evidence when the change affects it. Use the existing provenance
-helpers described in Validate; new proof uses caller-selected protected external
-non-Git storage. Preserve legacy `.agents/` evidence. Do not invent an identity
-or treat a model's declared role as freshness. Missing freshness or necessary
-evidence means NOT_PROVEN; proven acceptance failure means FAIL.
-
-Return the caller-visible result, changed subject, strongest checks and material
-unchecked acceptance. PASS requires all acceptance, exact identity and empty
-`not_checked`; the report never hides remaining work. `NOT_PLANNED` and
-`NOT_BUILT` describe progress, not semantic judgment. Do not append a next action
-as a substitute for finishing authorized work. The interactive response is the
-default; persist `verdict.v2` or `rpi-report.v1` only when the caller requests
-machine-readable evidence or a declared consumer requires it. When no machine
-artifact was requested, do not create a hidden one.
-
-## Prompt
-
-```text
-Use rpi to finish this accepted change within its scope and remaining deadline.
-Repair understood failures directly. If an assumption fails, revise the approach
-without changing acceptance. Run required checks and obtain fresh final Validate.
-Use Memory only if an applicable prior constraint would change the next action.
-```
-
-## It's working if
-
-A clear small edit reaches checks without planning or memory paperwork; an
-understood test failure is fixed directly; a disproved assumption changes the
-approach; an unknown recurring failure gets no helper chain; the final exact
-subject receives fresh author-distinct judgment and the report states any gap.
-
-The grandfathered developer-only Python reference is an optional fixed-dispatch
-adapter with explicit repair rounds, not the native charter's execution engine.
-Its narrower [adapter contract](references/bounded-adapter.md) and tests remain
-available without adding a runtime, command, scheduler or mandatory worksheet.
+Report the result, strongest checks and material limits. Plans, activity,
+reviews and saved pages earn no capability credit; NOT_PLANNED and NOT_BUILT
+are progress descriptions, not semantic verdicts.

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -32,183 +32,90 @@ output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_
 
 # Validate
 
-Independently judge one exact subject against the acceptance in its existing
-bead or caller source, return one semantic result, and stop. Validate is the
-sole semantic author of `verdict.v2` when persistence is requested.
-`ao provenance store-verdict` supplies structural verification and atomic storage. Before the verdict,
-read `boundaries.md` in the rpi skill's `references` directory for the state
-Validate leaves to the caller.
+Freshly judge the exact candidate against accepted intent, return PASS, FAIL or
+NOT_PROVEN, and stop. The author cannot provide binding PASS. Read RPI
+[boundaries](../rpi/references/boundaries.md) before judgment; load helper flags
+and storage details from [mechanics](references/mechanics.md) when needed.
 
-## Prompt
+## Preconditions and freshness
 
-```text
-Validate bead ag-1234 in this fresh context. Intent: the bead text and digest.
-Subject: manifest.json from:
-ao provenance manifest --root . --include cli/internal/gates
-Author context ctx-a1. Re-run `cd cli && go test ./internal/gates/...`.
-Return PASS, FAIL, or NOT_PROVEN with evidence; stop.
-```
+Final review starts after required checks and known repairs, with the candidate
+held unchanged. Supplied failed-acceptance evidence means FAIL on that subject;
+do not review a moving repair. The subject manifest is nonempty; plans, audits
+and reviews are subjects only when the caller requested document review.
 
-## Preconditions
+Use exact caller/runtime-owned intent bytes and derived acceptance identity.
+Author and validator context IDs must be explicit and distinct; freshness is
+attested by runtime or caller with the attester's identity. Missing, colliding
+or unattested identity means NOT_PROVEN, not proof of isolation by role name.
 
-- Final judgment starts after required checks and known repairs are complete,
-  over a subject the author keeps unchanged during review. If supplied checks
-  already prove failed acceptance, return FAIL on that subject; do not wait
-  while the author repairs it inside the same review.
-- The subject is a nonempty implementation candidate: the manifest lists at
-  least one entry. Plans, audits, and reviews are subjects only when the
-  caller explicitly requested document review.
-- The intent source is a caller-owned artifact or a runtime-owned
-  content-addressed snapshot; its acceptance digest is derived automatically.
-- Author and validator context IDs are explicit, and freshness is attested
-  with `source: runtime | caller` and an attester identity. Missing,
-  colliding, or unattested identities produce `NOT_PROVEN`: a declared trust
-  fact, not cryptographic proof of isolation.
+Default to one fresh reviewer in the author's model family: Codex/OpenAI for
+Codex/OpenAI, Claude/Anthropic for Claude/Anthropic. Use the runtime's configured
+capable model unless pinned. A new role in the author's context is not fresh.
+Supply task-specific intent, scope, exact subject and relevant evidence, without
+full author history, desired verdict or peer conclusions. Retrieve more source
+when a criterion requires it; concise input must not omit necessary evidence.
 
-## Fresh validator and model selection
+Cross-model review is opt-in. `--cross-model [model]` is a skill prompt selection,
+not an AO flag; it adds a fresh other-family reviewer. Required legs remain
+required: unavailable diversity yields `diversity_unsatisfied` and NOT_PROVEN
+for the combined request, even if another leg passed. Preserve delivered FAILs
+and dissent; neither voting nor model preference makes a split PASS. Optional
+unavailable diversity stays disclosed without erasing findings. Exact invocation,
+authorization, runtime identity and independent-input rules live in
+[model-dispatch](../agent-native/references/model-dispatch.md). No fixed
+ten-minute cap applies; respect real caller/native bounds without renewing them.
+A timeout is missing judgment, not FAIL. Shared-family or cross-family agreement
+alone is not truth or proof of freedom from training bias.
 
-Default to one fresh, author-distinct validator from the author's model family:
-Codex/OpenAI work uses a fresh Codex/OpenAI reviewer; Claude/Anthropic work uses
-a fresh Claude/Anthropic reviewer. Use the runtime's configured capable model
-unless the caller pins one. Fresh context is required even when model weights
-are identical; a new role instruction in the author's session is not fresh.
-Risk determines the depth of evidence inspection, not an automatic second family.
+## Judgment
 
-Acceptance, tests/gates, stopping, allowances, safety, disclosure, hooks and
-executable controls warrant deeper checks, including policy written as prose.
-Conservative risk cues include `cli/internal/gates/**`, `scripts/check-*.sh`,
-`tests/**`, `skills/*/scripts/**`, `skills/cc-hooks/policies/**`, `lib/**`,
-`.github/workflows/**` and `scripts/security-gate.sh`. Unknown risk receives
-deeper inspection; it does not silently change the selected model families.
+1. Derive `subject-manifest.v1` using the existing helper at start and end.
+   A mismatch means mutation and NOT_PROVEN. Verify exact intent continuity,
+   cited evidence digests and complete changed-path coverage; missing integrity
+   is NOT_PROVEN. Proven out-of-scope change is FAIL.
+2. Inspect the actual diff against every acceptance criterion. Risk determines
+   depth: acceptance, permissions, tests/gates, stopping, disclosure, hooks and
+   executable controls warrant deeper inspection, including prose policy.
+   Unknown risk merits examination, not automatic extra reviewers.
+3. Re-execute discriminating proofs for risk-critical, uncertain or thinly
+   evidenced claims. Valid digest-bound receipts may establish routine facts;
+   do not replay every author command or full suite merely because this is a
+   fresh context. The repository's required integration checks still run on
+   the final subject. A changed subject needs new judgment and affected checks.
+4. Classify commands before executing them. Regeneration, synchronization,
+   formatting and `--force` are subject-mutating until proven otherwise; run
+   them only on a disposable copy or a committed subject, never an uncommitted
+   judged tree. Do not overwrite the candidate while validating it.
+5. Reject green obtained through weaker assertions, tolerances, goldens,
+   suppressions or acceptance edits. Each criterion needs supporting evidence;
+   explanation alone is not proof. A necessary finding cannot become an
+   optional caveat or non-goal. Publication/provenance claims in docs also need
+   verifiable evidence.
+6. Return one result with criterion-level evidence, findings, checked scope,
+   `not_checked`, author/judge identities and contexts, and the freshness
+   attestation. PASS requires all criteria verified, nonempty checked scope and
+   top-level evidence, and empty `not_checked`. An unverified criterion means
+   NOT_PROVEN; proven failed acceptance or scope violation means FAIL.
 
-The caller can request `--cross-model` or say "cross-model review" to add one
-fresh validator from a different family. `--cross-model <model>` pins that
-additional reviewer, for example `--cross-model claude-fable-5-1` from Codex
-or `--cross-model gpt-6-astra` from Claude. These are skill prompt options,
-not `ao` CLI flags. RPI forwards them unchanged. Without a pin, use an available,
-authorized capable model from the other family; never silently substitute for
-a pinned model or count two models in one family as cross-family diversity.
-An explicit caller requirement remains required until the caller changes it;
-changing the default cannot erase a finding or relabel a missing verdict as PASS.
+## Findings and report
 
-Route selection and invocation through
-[agent-native model-dispatch](../agent-native/references/model-dispatch.md);
-[references/mechanics.md](references/mechanics.md) owns evidence storage.
-There is no fixed ten-minute review timeout. Use the caller's selected review
-timeout or remaining native deadline, respecting any earlier host or goal limit.
-A timeout is missing judgment, not FAIL; never restart to renew an allowance.
+`not_checked` means in-scope acceptance that was not verified. Other limits
+remain in criterion reasoning, declared non-goals or residual-risk prose; never
+hide or delete them to obtain PASS. Keep prior findings visible. For each new
+finding, name a short stable nonempty `class` describing the defect, reused on
+recurrence, and distinguish pre-existing, introduced or unknown cause using
+before/after or equivalent causal evidence. Counts and timestamps alone do not
+establish cause. Known findings return to direct repair; causal stalls use the
+RPI single-helper rule, not repairs delegated to this validator.
 
-Each selected judge receives the exact subject, unchanged acceptance and
-authorized evidence independently, without the author's desired verdict or peer
-conclusions. Record actual model/context identities and runtime receipts.
-Missing freshness, an unbound subject, incomplete acceptance evidence, or
-nonempty `not_checked` prevents PASS regardless of model family.
-With no authorized adapter for requested diversity, disclose
-`diversity_unsatisfied`: the required combined result is `NOT_PROVEN` even if
-the same-family judge passed. A delivered FAIL stands. Advisory diversity that
-the caller explicitly made optional may accompany the same-family result with
-that limitation; it cannot discard an acceptance-relevant finding.
+Keep the report proportional: cite existing receipts and include only excerpts
+needed to assess a finding. Do not retell the investigation or duplicate logs.
+Brevity must retain every criterion, necessary finding, identity, freshness
+fact and unchecked surface.
 
-When selected judges disagree, preserve both verdicts and their evidence.
-Required diversity converges only when both pass; neither majority vote nor a
-preferred judge settles a split. Repair addresses known findings directly under RPI and real caller/native
-bounds. Report unresolved dissent and the caller's decision openly.
-Same-family fresh judgment reduces anchoring, but does not prove independence
-from shared training biases; cross-family agreement is corroboration, not truth.
-
-## Mutating-check quarantine
-
-Classify every acceptance-listed command as read-only or subject-mutating
-before running it: regen scripts, sync scripts, formatters, and anything with
-`--force` are mutating until proven otherwise. Run a mutating check only
-against a disposable copy or a committed subject, never the judged working
-tree (the boundaries appendix records the regen that overwrote a subject).
-
-## Scope disclosure
-
-`not_checked` has exactly one meaning: **in-scope acceptance surface this
-validation did not verify**. PASS asserts the whole declared acceptance
-surface was verified, so a PASS carries no `not_checked` entries; every other
-scope limit has a home that survives inside a PASS: a bounded proof in
-`criteria[].reason`, a declared non-goal in the intent source, residual risk
-in the report (table in the mechanics reference). Emptying `not_checked` to
-obtain PASS is a contract violation: unverified acceptance makes the honest
-result `NOT_PROVEN`, and an entry that was never acceptance moves to its home
-and stays visible. A finding necessary to acceptance cannot be relabeled as
-optional, residual risk, or a non-goal to obtain PASS.
-
-## Workflow
-
-1. Derive `subject-manifest.v1` with the helper's `manifest` command (flags
-   in the mechanics reference) at the start and again at the end; any
-   mismatch is subject mutation and returns `NOT_PROVEN`.
-2. Confirm the intent-source digest is unchanged since implementation, every
-   cited evidence digest matches the artifact it names, and complete
-   changed-path coverage can be derived; otherwise `NOT_PROVEN`.
-3. Adjudicate the actual diff: runtime-derived changed paths against the
-   intent's scope classes. A proven out-of-scope path is `FAIL`; incomplete
-   scope evidence is `NOT_PROVEN`.
-4. Inspect the exact subject and evidence. Reported exit codes are claims:
-   re-execute the proofs that bear on acceptance. A changed test, gate,
-   fixture, golden, tolerance, suppression, or acceptance source must be
-   required by the original intent, with green coming from implemented
-   behavior; green obtained by weakening acceptance is `FAIL`. Judge every
-   acceptance criterion against its own evidence reference; a criterion with
-   no evidence of its own is unverified, not passed.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
-   it with criterion-level results, findings, evidence references, `checked`,
-   `not_checked`, both identities, both context IDs, and the freshness
-   attestation. Name a `class` for each finding: one short stable name for the
-   kind of defect, one per finding, reused word for word when the same kind
-   recurs, so the orchestrator can see a closed kind come back. Explain in the
-   existing summary and evidence whether a newly exposed defect pre-existed the
-   change, was introduced by it, or has unknown cause. Use before/after proof or
-   equivalent causal evidence under unchanged acceptance; counts and timestamps
-   do not establish cause. Recurrence calls for causal examination and does not
-   by itself prove a design failure. Known defects return to direct repair;
-   unknown cause, recurrence or no progress uses the charter's single bounded
-   helper rule, without delegating repairs to this validator. Name the class or omit it; a `class` that is
-   present and blank is a finding against this validator,
-   and so is a class that does not describe its finding. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   nonempty top-level evidence, evidence for every criterion, and an empty
-   `not_checked`. A documentation sentence claiming something is published,
-   pinned, or proven is an acceptance criterion like any other: it needs a
-   check this validator can run, or it is `not_checked`. The
-   `docs.claims-tracked` gate covers the tracked-file half of that and nothing
-   more.
-6. Only when the caller requests machine-readable evidence or a declared
-   downstream consumer requires it, persist canonical `verdict.v2` with the
-   helper's `store-verdict` (mechanics reference), then return the artifact
-   path and digest with the result. Stop.
-
-Keep the judgment proportional to the change. Cite existing receipts instead of
-repeating their history; brevity must preserve every criterion, necessary
-finding, identity, freshness fact and unchecked acceptance surface.
-
-Fresh validation is independent judgment over the exact subject, not a replay
-of every author command: rerun the risk-critical, uncertain, or thinly
-evidenced checks; a digest-bound deterministic receipt may prove routine
-facts; replay an expensive full suite only when acceptance requires it. The
-repository's full literal CI command set, as quoted in `AGENTS.md`, runs
-once, on the final integrated subject.
-
-## It's working if
-
-Observable in the trace, without reading the prose, and the rubric a fresh
-independent judge scores this skill against:
-
-- A criterion whose evidence is a justification rather than a proof is named,
-  and the result is `NOT_PROVEN` rather than `PASS`.
-- Green obtained by widening a tolerance, skipping a case, or re-baselining a
-  budget is reported as `FAIL`, never as completion.
-- Every scope limit is placed in one of the Scope-disclosure homes; none was
-  deleted to reach `PASS`.
-- The subject manifest is derived twice, at the start and at the end, and the
-  two are compared.
-
-## Boundary
-
-Validate emits no next action, repair, retry, replan, or delivery state (full
-list in the boundaries reference); ledger availability cannot change a
-verdict's validity.
+Only when requested or required by a declared consumer, persist `verdict.v2`
+through `ao provenance store-verdict`. Validate supplies semantic judgment;
+Go verifies structure and storage, not truth. Otherwise return the result
+through the existing caller channel without hidden machine artifacts.
+Validate owns no repair, retry, delivery or tracker transition.

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -70,6 +70,12 @@ alone is not truth or proof of freedom from training bias.
 
 ## Judgment
 
+Use the helper for each changed path (repeat `--include` for complete scope):
+
+```sh
+ao provenance manifest --root "$REPO_ROOT" --include "$CHANGED_PATH"
+```
+
 1. Derive `subject-manifest.v1` using the existing helper at start and end.
    A mismatch means mutation and NOT_PROVEN. Verify exact intent continuity,
    cited evidence digests and complete changed-path coverage; missing integrity

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -32,8 +32,8 @@ output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_
 
 # Validate
 
-Freshly judge the exact candidate against accepted intent, return PASS, FAIL or
-NOT_PROVEN, and stop. The author cannot provide binding PASS. Read RPI
+Freshly judge the exact candidate against accepted intent, return
+`PASS`, `FAIL`, or `NOT_PROVEN`, and stop. The author cannot provide binding PASS. Read RPI
 [boundaries](../rpi/references/boundaries.md) before judgment; load helper flags
 and storage details from [mechanics](references/mechanics.md) when needed.
 
@@ -41,7 +41,7 @@ and storage details from [mechanics](references/mechanics.md) when needed.
 
 Final review starts after required checks and known repairs, with the candidate
 held unchanged. Supplied failed-acceptance evidence means FAIL on that subject;
-do not review a moving repair. The subject manifest is nonempty; plans, audits
+do not review a moving repair. The subject is a nonempty implementation candidate; plans, audits
 and reviews are subjects only when the caller requested document review.
 
 Use exact caller/runtime-owned intent bytes and derived acceptance identity.
@@ -114,8 +114,9 @@ needed to assess a finding. Do not retell the investigation or duplicate logs.
 Brevity must retain every criterion, necessary finding, identity, freshness
 fact and unchecked surface.
 
-Only when requested or required by a declared consumer, persist `verdict.v2`
-through `ao provenance store-verdict`. Validate supplies semantic judgment;
+Validate is the sole semantic author of `verdict.v2`.
+Only when the caller requests machine-readable evidence or a declared consumer
+requires it, persist through `ao provenance store-verdict`. Validate supplies judgment;
 Go verifies structure and storage, not truth. Otherwise return the result
 through the existing caller channel without hidden machine artifacts.
 Validate owns no repair, retry, delivery or tracker transition.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -687,8 +687,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "f3a1e5e6281f0dd08b0e8f87854d7fe013702e5d1548e5009f8875fdef439be5",
-      "generated_hash": "184645e1c205399ee7e98eb608b531b39e1046900d47290ded584a2e9b35bb06"
+      "source_hash": "d458f6c3ccc510825984c9decff2eae90e8aca5111e8561be6e06bd12c2c17b6",
+      "generated_hash": "f8aabaed14d3e61c1f9b23376c7f79fb3b28751567418fe3a2e043efa53b30f7"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "1bfc04850b64d54138914110df9e5f819222d068304c77d2085527ba3b94472a",
-      "generated_hash": "a060f31a10362f7f97f106e520d333eac4b286a960943706f59fd00348efc66f"
+      "source_hash": "6f62d8d6ccbaf2f03c4158607ef43ef0c00ac020fc7652125184ac726db3d732",
+      "generated_hash": "98fe63ece2adc8084e724f9fe54e72d3a4829d40903f0b0aab28ce73ac28090c"
     },
     {
       "name": "learn",
@@ -549,8 +549,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "555ff311ffa1f892b66a8e90a6ae5125bb57e2513b6d8c4842846ef3963ac0b2",
-      "generated_hash": "2b5df8b57afc0f5f099b98e28b18a99923c498fd2fd694bc85536302b1bf7cba"
+      "source_hash": "197bff6ba45c503871ebb58120abf6f031da524568139a6c31bb5a65e01e4917",
+      "generated_hash": "9a20e81d0a9a51b5ed72a9d0d03d4304a9098bf14cb5665c88b79366083f4a65"
     },
     {
       "name": "postmortem",
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "8ce5165c2defd8d427ce8bca0f9357022a8145900c71f205f7af444db0a473d9",
-      "generated_hash": "394bb2617d6626aeb0a1eba853dc62cd84a001c16df143338c678a82deeaf8a2"
+      "source_hash": "d56324d3257f0ee5619ab6675052faa5207747bf39e465aca0ff94621aef2f90",
+      "generated_hash": "98322805a85787c8b7cf6880f9ce756a8573a062dc9219ab12a7d895be7679db"
     },
     {
       "name": "sbh",
@@ -687,8 +687,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "72358771a67fb6e736cc74a75d1b922a3f94a55f66cb037f2602f984eb247d5c",
-      "generated_hash": "477e89bac82acea4425dcff254f411ac92ff1049a389d715a05bd1c1304b08b0"
+      "source_hash": "f3a1e5e6281f0dd08b0e8f87854d7fe013702e5d1548e5009f8875fdef439be5",
+      "generated_hash": "184645e1c205399ee7e98eb608b531b39e1046900d47290ded584a2e9b35bb06"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "dba0558617111701bec303febf9de9ae880801655a365e9d0946f560ba3735e2",
-      "generated_hash": "704d5b78ec0d9c57dd7d5118ef14e1048f15a7025cbc7d3ae593a220d6a10c33"
+      "source_hash": "1bfc04850b64d54138914110df9e5f819222d068304c77d2085527ba3b94472a",
+      "generated_hash": "a060f31a10362f7f97f106e520d333eac4b286a960943706f59fd00348efc66f"
     },
     {
       "name": "learn",
@@ -549,8 +549,8 @@
     {
       "name": "plan",
       "source_skill": "skills/plan",
-      "source_hash": "2a51bd355c0ce2dde9da62bd03e2898a5e2c05f1248a97550f9278f372a9a6d1",
-      "generated_hash": "f24926c0841ef5a441c9ad163612116f4767caa54e90d0e91ded3369d1d2d350"
+      "source_hash": "555ff311ffa1f892b66a8e90a6ae5125bb57e2513b6d8c4842846ef3963ac0b2",
+      "generated_hash": "2b5df8b57afc0f5f099b98e28b18a99923c498fd2fd694bc85536302b1bf7cba"
     },
     {
       "name": "postmortem",
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "ee6193fccbe9ed0cbef3461dbc232e88d0b401d526afd0d6b3718830ad88a520",
-      "generated_hash": "dbd9fa14966d0bba9da35635e20cc15dc48457434c957eef508a4ec785452128"
+      "source_hash": "8ce5165c2defd8d427ce8bca0f9357022a8145900c71f205f7af444db0a473d9",
+      "generated_hash": "394bb2617d6626aeb0a1eba853dc62cd84a001c16df143338c678a82deeaf8a2"
     },
     {
       "name": "sbh",
@@ -687,8 +687,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "b22ccc91da9328e8a1f9ecd5577282b0ec7f8a72eae505eb6ff3a7623264ca4c",
-      "generated_hash": "3c8b4a0d968f8a75eb07f7873be9cd8025b6b245691dabd3dafb419a456caf26"
+      "source_hash": "72358771a67fb6e736cc74a75d1b922a3f94a55f66cb037f2602f984eb247d5c",
+      "generated_hash": "477e89bac82acea4425dcff254f411ac92ff1049a389d715a05bd1c1304b08b0"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "dba0558617111701bec303febf9de9ae880801655a365e9d0946f560ba3735e2",
-  "generated_hash": "704d5b78ec0d9c57dd7d5118ef14e1048f15a7025cbc7d3ae593a220d6a10c33"
+  "source_hash": "1bfc04850b64d54138914110df9e5f819222d068304c77d2085527ba3b94472a",
+  "generated_hash": "a060f31a10362f7f97f106e520d333eac4b286a960943706f59fd00348efc66f"
 }

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "1bfc04850b64d54138914110df9e5f819222d068304c77d2085527ba3b94472a",
-  "generated_hash": "a060f31a10362f7f97f106e520d333eac4b286a960943706f59fd00348efc66f"
+  "source_hash": "6f62d8d6ccbaf2f03c4158607ef43ef0c00ac020fc7652125184ac726db3d732",
+  "generated_hash": "98fe63ece2adc8084e724f9fe54e72d3a4829d40903f0b0aab28ce73ac28090c"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -4,100 +4,58 @@ description: 'Implement authorized work and repair understood defects; return de
 ---
 # Implement
 
-Implement the authorized outcome, including ordinary direct repairs. Use the
-resolved bead or caller intent; do not turn every failed check into a new phase.
-Implement owns subject edits and factual evidence; the runtime derives identity
-and receipts. A clear trivial change needs no Plan, Recall or Learn worksheet.
-
-## Prompt
-
-```text
-Implement bead ag-1234 from its text: acceptance "ao gate check lists
-skill.probe-coverage", scope cli/internal/gates/** plus regen outputs, first
-check `cd cli && go test ./internal/gates/...`. RED first, smallest change,
-return the manifest digest and check receipts, stop.
-```
-
-## It's working if
-
-- After source activation and startup association, the first behavior check
-  is the acceptance check; its output shows the expected failure (or an honest
-  green structural baseline for documentation, relocation, or refactor work).
-- Every path in `git diff --stat` falls inside the declared scope; an outside
-  consumer is reported as `file:line`, not absorbed.
-- The response carries the `subject-manifest.v1` digest, author context ID,
-  and verbatim check output; no `git commit` or `git push` appears.
+Implement the accepted outcome and repair understood defects. Use the existing
+intent; no Plan, Recall or Learn worksheet is owed for a clear edit. Implement
+owns source changes and factual checks; the runtime derives identity and receipts.
 
 ## Workflow
 
-1. Read the intent, acceptance, and scope from their existing source; before
-   the first write, read `boundaries.md` in the rpi skill's `references`
-   directory for what Implement does not own. Before execution can fail, the
-   caller passes source-store/project/work identity and permitted intent
-   locators at dispatch/start. At startup, return observed native runtime,
-   session/context identity (or explicit unknowns) through the caller-owned
-   runtime channel for native comments/metadata recording; do not defer this
-   association until handoff. Follow the fact distinctions in
-   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
-   Parent and resume links need observed provenance; controller dispatch alone
-   does not establish native parentage. If startup observation or recording
-   fails, preserve that failure and the pre-execution reference with the caller,
-   leaving unobserved IDs unknown. Startup association applies when the caller selected episode tracking; a
-   trivial edit does not need a new tracking worksheet. Use the caller-owned
-   runtime channel for handoff facts, without a second work account.
-2. Run the declared first acceptance check before changing behavior. RED-first
-   applies when acceptance is behavioral: preserve evidence that the check
-   fails for the expected missing behavior. Relocations, doc merges, and pure
-   refactors record an honest green pre-change baseline instead.
-3. Make the smallest in-scope change that satisfies the active behavior. Repair
-   ordinary known defects directly. A failed test with an understood cause needs
-   a fix and another discriminating check, not a helper or fresh planning lane.
-   If evidence disproves an assumption, revise the approach within unchanged
-   acceptance and scope; use Plan only to resolve consequential uncertainty.
-4. Run the targeted acceptance checks and applicable repository lint/static
-   checks before handing off a candidate for broad integration. Capture factual
-   results; package tests alone do not establish a separate lint contract.
-5. Refactor only while those checks stay green. Refactoring does not change the
-   acceptance test.
-6. Have the runtime derive actual changed paths and `subject-manifest.v1` from
-   the before/after subject.
-7. When changed files affect bound acceptance evidence, run `ao provenance evidence-orphans --root <repo-root>` with one
-   `--changed <path>` per changed path the runtime derived, and put its JSON
-   output in the check receipts the validator reads, so orphaned evidence
-   arrives as a receipt rather than as a surprise at verify time. Run it again after every repair round, over the
-   paths as they stand, because a repair can orphan evidence the first pass did
-   not. Read the output as written and never hand-list the orphans instead.
-8. Return the manifest digest, author context ID, and exact check receipts in the
-   response or runtime channel. Stop.
+1. Read intent, acceptance, scope and the RPI [boundaries](../rpi/references/boundaries.md)
+   before the first write; reuse contracts already loaded in this context.
+   When the caller selected episode tracking, obtain permitted work/source
+   references before execution and return observed runtime/context identity at
+   startup through the native recording channel. Unknowns and recording failures
+   stay explicit; do not invent parentage or a second tracker. The optional
+   [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+   supplies mechanics for that selected workflow.
+2. Run the first useful acceptance check. Behavioral changes preserve RED for
+   the expected missing behavior; a pure refactor, relocation or documentation
+   change may have an honest green baseline. Avoid building elaborate fixtures
+   when an existing test or small discriminating probe answers the question.
+3. Make the smallest in-scope change. Fix known failures directly, then rerun
+   the affected check. A disproved assumption may change the approach within
+   accepted outcome and scope; use Plan only for consequential uncertainty.
+4. Use targeted tests and applicable repository lint/static checks before
+   broad integration. Read the repository's actual check recipe, including
+   instrumentation and environment, rather than reconstructing it from memory.
+   Run required full checks at integration, not after each small edit. Reuse
+   exact-input receipts only while source, tool and relevant environment match.
+5. Refactor while acceptance remains green. Inspect changed tests, fixtures,
+   goldens, tolerances, suppressions and specification text against original
+   intent. Mocks, placeholders or weakened oracles cannot substitute for the
+   requested behavior.
+6. Derive complete changed paths and `subject-manifest.v1`. When changed paths
+   affect bound acceptance evidence, run `ao provenance evidence-orphans --root
+   <repo-root>` with one `--changed <path>` per derived path, and retain the
+   actual output for the validator. Repeat after repairs that change that
+   subject; do not hand-invent an orphan list.
+7. Return the manifest digest, author context ID, acceptance-check facts and
+   evidence references through the caller's response/runtime channel, then stop.
+   Include command, result and decision-relevant failures. Keep full output
+   accessible instead of pasting successful logs or repeated receipt inventories
+   into every handoff. Missing or truncated evidence must remain visible.
 
-Specialists (standards, domain, test, refactor, security) advise only. During
-edits, run the smallest deterministic checks that can falsify the change,
-reuse exact-input receipts whose subject and tool identity still match, and
-run the full suite at the integration boundary unless the intent makes it the
-first check.
+## Scope and finish
 
-## Scope conflict rule
+Report an uncovered live consumer as `file:line` for a caller scope amendment;
+continue independent authorized work. Generated companions already included as
+scope require no new approval. Acceptance changes always require caller authority.
 
-On discovering a live consumer of the change outside the declared write scope
-(a test asserting the old path, a generated twin, a gate reading the moved
-file), stop and report the exact file and line to the caller for a scope amendment; continue independent authorized work. A different
-acceptance contract needs caller authority. Generated outputs already included
-as a scope class need no new permission.
+Specialists advise only. Known defects stay implementation work; a genuine
+causal stall follows RPI's at-most-one bounded helper rule. Respect remaining
+caller/native bounds and reserve finishing capacity. No retry resets them.
 
-Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
-stubs, hardcoded fixture values, weakened assertions, regenerated goldens,
-widened tolerances, suppression directives, or specification edits standing
-in for real behavior. A changed test, gate, fixture, golden, or acceptance
-source must be required by the original intent, with green coming from the
-implemented behavior; a check that passes against a substitute or weakened
-oracle is not evidence: finish the behavior or report it as not built.
-
-## Boundary
-
-Do not issue semantic PASS or infer Git, tracker or delivery permission from
-this skill. Follow the caller's existing authority and repository policy.
-An implement-only handoff returns facts to its caller; a full outcome request
-uses RPI through fresh final validation. Known defects stay implementation work.
-On a genuine causal stall, use RPI's at-most-one bounded helper rule, never a
-helper chain. Reserve finishing capacity and respect actual caller/native bounds;
-a retry count alone is not a spent time or quota budget.
+Return facts, not semantic PASS. An implement-only handoff does not authorize
+Git, tracker or delivery transitions; existing caller authority remains usable.
+A full outcome request uses RPI through fresh final judgment. Success is working
+behavior with usable evidence, not volume of logs or process artifacts.

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -4,7 +4,7 @@ description: 'Implement authorized work and repair understood defects; return de
 ---
 # Implement
 
-Implement the accepted outcome and repair understood defects. Use the existing
+Implement the accepted outcome. Repair ordinary known defects directly. Use the existing
 intent; no Plan, Recall or Learn worksheet is owed for a clear edit. Implement
 owns source changes and factual checks; the runtime derives identity and receipts.
 
@@ -34,7 +34,7 @@ owns source changes and factual checks; the runtime derives identity and receipt
    goldens, tolerances, suppressions and specification text against original
    intent. Mocks, placeholders or weakened oracles cannot substitute for the
    requested behavior.
-6. Derive complete changed paths and `subject-manifest.v1`. When changed paths
+6. Have the runtime derive actual changed paths and `subject-manifest.v1`. When changed paths
    affect bound acceptance evidence, run `ao provenance evidence-orphans --root
    <repo-root>` with one `--changed <path>` per derived path, and retain the
    actual output for the validator. Repeat after repairs that change that

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "555ff311ffa1f892b66a8e90a6ae5125bb57e2513b6d8c4842846ef3963ac0b2",
-  "generated_hash": "2b5df8b57afc0f5f099b98e28b18a99923c498fd2fd694bc85536302b1bf7cba"
+  "source_hash": "197bff6ba45c503871ebb58120abf6f031da524568139a6c31bb5a65e01e4917",
+  "generated_hash": "9a20e81d0a9a51b5ed72a9d0d03d4304a9098bf14cb5665c88b79366083f4a65"
 }

--- a/skills-codex/plan/.agentops-generated.json
+++ b/skills-codex/plan/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/plan",
   "layout": "modular",
-  "source_hash": "2a51bd355c0ce2dde9da62bd03e2898a5e2c05f1248a97550f9278f372a9a6d1",
-  "generated_hash": "f24926c0841ef5a441c9ad163612116f4767caa54e90d0e91ded3369d1d2d350"
+  "source_hash": "555ff311ffa1f892b66a8e90a6ae5125bb57e2513b6d8c4842846ef3963ac0b2",
+  "generated_hash": "2b5df8b57afc0f5f099b98e28b18a99923c498fd2fd694bc85536302b1bf7cba"
 }

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -4,67 +4,48 @@ description: 'Shape or refine the existing bead or caller intent in place. Trigg
 ---
 # Plan
 
-Shape only what is missing from the authorized intent. Prefer the caller's tracker, if any;
-otherwise use the caller's conversation or supplied text. A clear trivial change
-needs no planning worksheet or separate Plan dispatch. Planning produces no AgentOps packet.
+Shape only missing intent in the caller's bead, conversation or supplied text.
+Planning produces no AgentOps packet. A clear change can proceed directly.
 
 ## Workflow
 
-1. Read the actual intent, relevant source owners and active constraints. Find
-   the caller-visible outcome, allowed write scope and first useful check.
-   Inspect only enough context to resolve a consequential uncertainty.
-2. Where needed, clarify acceptance examples, important non-goals and scope in
-   the existing source. Include generated companions as a class: hand-edited
-   sources plus every output of the owning regeneration commands. Include tests
-   and live consumers that must change with them. Scope is authority, not a
-   prediction of an exact file count.
-3. Choose the smallest acceptance-advancing action or discriminating check.
-   Identify evidence the change could invalidate and include recapture where
-   required. Use `ao provenance evidence-orphans` for affected bound evidence;
-   avoid a mandatory ledger or taxonomy for changes that do not need one.
-4. Revise the approach when evidence disproves an assumption under unchanged
-   accepted outcome and scope. Record the disproved assumption, evidence and
-   revised check briefly in the existing source or handoff. No new permission
-   is needed for this approach revision. Changing acceptance or expanding scope
-   needs caller authority; never quietly weaken the original check.
-5. When another context needs the intent, pass enough exact source and references
-   to act without the author's private reasoning. The runtime binds accepted
-   intent for final validation; useful approach notes are separate from frozen
-   acceptance so revising a hypothesis does not fabricate acceptance drift.
+1. Read accepted intent and relevant source owners and active constraints.
+   Resolve only consequential uncertainty; do not reopen settled decisions
+   without new evidence. Identify the caller-visible outcome, scope and first
+   useful check.
+2. Clarify missing acceptance examples and non-goals in that existing source.
+   Scope includes the hand-edited owners, affected tests/live consumers and
+   generator-owned companions as a class; it is authority, not a predicted
+   file count. A consequential assumption deserves an early discriminating
+   check, not a general checklist or exhaustive survey.
+3. Choose the smallest action that advances acceptance or falsifies the risky
+   assumption. Include recapture of affected bound evidence where necessary;
+   use `ao provenance evidence-orphans` when applicable, not a mandatory ledger.
+4. When evidence disproves an approach, briefly retain the failed assumption,
+   evidence and revised check in the existing intent or handoff. Approach
+   changes within accepted outcome and scope need no new permission; acceptance
+   or scope expansion requires caller authority. Never relabel a failed
+   acceptance condition as a caveat to obtain green.
+5. Give another context exact intent references and the evidence it needs to
+   act. Keep approach notes separate from frozen acceptance. Do not transmit
+   the entire research history when a focused source reference will suffice.
 
-A plan is sufficient when the implementer can act and the validator can judge.
-Then stop planning and implement. Specialists and
-[ground-truth routing](references/ground-truth-routing.md) are optional tools for
-consequential integration or design uncertainty, not universal worksheets.
-[Memory recall](../memory/references/recall.md) is useful only when applicable
-prior experience may change this work's next action.
+Stop planning once the implementer can act and the validator can judge. More
+research, decomposition or review must resolve a named remaining uncertainty.
+Specialists and [ground-truth routing](references/ground-truth-routing.md) are
+optional. [Memory recall](../memory/references/recall.md) is useful only when
+prior evidence could change the next action.
 
 ## Identity and scope
 
-Use the runtime's source reference and digest for exact accepted intent. For
-conversation-only intent, existing `ao provenance snapshot-intent --source -
---evidence-root <explicit-root>` stores resolved bytes in a caller-selected
-protected external non-Git evidence directory. Missing routing does not authorize
-a workspace fallback or a second plan artifact. Preserve legacy proof.
+Use runtime-derived source identity and digest. If conversation intent needs
+an exact snapshot, existing `ao provenance snapshot-intent --source -
+--evidence-root <explicit-root>` uses caller-selected protected external
+non-Git storage. Missing routing permits neither workspace fallback nor a
+second planning artifact. Preserve legacy proof.
 
-Scope patterns are normalized repository-relative paths, cover the behavior,
-and include generator-owned companions without granting unrelated directories.
-A live consumer outside accepted scope needs a concise exact-file amendment to
-the caller; continue independent authorized work while that decision is pending.
-[Boundaries](../rpi/references/boundaries.md) keep work/status in the caller's
-tracker and Git/delivery under repository policy.
-
-## Prompt
-
-```text
-Use Plan to resolve the uncertain parser interface for this accepted change.
-Keep acceptance and scope; use a real consumer check to test the assumption.
-Revise the approach if it fails, then implement. No new planning artifact.
-```
-
-## It's working if
-
-A clear small change skips planning paperwork. A falsified assumption changes
-the approach and the next check; it does not trigger another approval round
-unless outcome or scope changes. Generated outputs remain in scope and the
-existing intent gives a fresh implementer enough information to act.
+Use normalized repository-relative scope patterns. An uncovered live consumer
+needs a concise exact-file amendment to the caller; continue independent
+in-scope work meanwhile. Generated companions already in scope need no extra
+permission. [Boundaries](../rpi/references/boundaries.md) keep work/status in
+the caller's tracker and delivery under repository policy.

--- a/skills-codex/plan/SKILL.md
+++ b/skills-codex/plan/SKILL.md
@@ -4,8 +4,9 @@ description: 'Shape or refine the existing bead or caller intent in place. Trigg
 ---
 # Plan
 
-Shape only missing intent in the caller's bead, conversation or supplied text.
-Planning produces no AgentOps packet. A clear change can proceed directly.
+Shape only missing intent. Prefer the caller's tracker, if any; otherwise use
+the conversation or supplied text. Planning produces no AgentOps packet.
+A clear change can proceed directly.
 
 ## Workflow
 

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "ee6193fccbe9ed0cbef3461dbc232e88d0b401d526afd0d6b3718830ad88a520",
-  "generated_hash": "dbd9fa14966d0bba9da35635e20cc15dc48457434c957eef508a4ec785452128"
+  "source_hash": "8ce5165c2defd8d427ce8bca0f9357022a8145900c71f205f7af444db0a473d9",
+  "generated_hash": "394bb2617d6626aeb0a1eba853dc62cd84a001c16df143338c678a82deeaf8a2"
 }

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "8ce5165c2defd8d427ce8bca0f9357022a8145900c71f205f7af444db0a473d9",
-  "generated_hash": "394bb2617d6626aeb0a1eba853dc62cd84a001c16df143338c678a82deeaf8a2"
+  "source_hash": "d56324d3257f0ee5619ab6675052faa5207747bf39e465aca0ff94621aef2f90",
+  "generated_hash": "98322805a85787c8b7cf6880f9ce756a8573a062dc9219ab12a7d895be7679db"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -4,106 +4,90 @@ description: 'Own an authorized outcome through implementation, checks and fresh
 ---
 # RPI
 
-Own the authorized outcome through finish. Use the native coding agent and
-shell; BD or the caller's tracker owns work/status/handoffs, Git owns content
-and delivery history. Keep one authoritative work account. AgentOps adds a
-small operating charter and fresh judgment, not a scheduler or a second queue.
+Own the authorized outcome through finish using the native coding agent and
+shell. BD or the caller's tracker owns work and handoffs; Git owns content and
+delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
 ## Operating charter
 
-1. Keep the accepted outcome, scope and real bounds in view. Use the existing
-   intent; a trivial clear change needs no Plan, Recall or Learn worksheet.
-2. Take the smallest action that advances acceptance or resolves a consequential
-   uncertainty. Load [Plan](../plan/SKILL.md) only when intent or approach needs
-   shaping. Evidence may disprove an assumption: revise the approach within
-   unchanged accepted outcome and scope. Acceptance changes need caller authority.
-3. [Implement](../implement/SKILL.md) the change and repair ordinary known
-   defects directly. A failed check with an understood cause is implementation
-   work, not a reason for another plan, council or helper.
-4. Use cheap discriminating checks during edits, then the required integration
-   checks. Preserve valid exact-input receipts. Reserve finishing capacity for
-   integration, fresh final judgment, repairs and a truthful handoff. Complete
-   required checks and known repairs before dispatching final judgment, then
-   keep that subject unchanged until the review returns.
-5. Obtain [Validate](../validate/SKILL.md) in a fresh author-distinct context over
-   the exact final subject. Default to the author's model family; cross-model
-   review is opt-in. There is no fixed ten-minute cap. Required caller-selected
-   reviewers remain required. Every necessary finding stays visible.
-6. Repair actionable findings within authority and real remaining bounds, then
-   obtain fresh judgment over the changed subject. Stop at completed acceptance,
-   cancellation, an explicit refusal, a spent real bound, or a genuine causal
-   stall that the bounded help below cannot resolve. Activity, saved pages,
-   changed digests and repeated reviews are not completed capability.
+1. Use the existing accepted outcome, scope and real bounds. A clear change
+   needs no Plan, Recall or Learn worksheet. Resolve uncertainty only when it
+   could change the implementation or acceptance decision.
+2. Take the smallest acceptance-advancing action. [Plan](../plan/SKILL.md)
+   shapes missing intent or revises a disproved approach. Once an implementer
+   can act and a validator can judge, implement; do not keep improving the plan.
+   Approach revisions preserve acceptance and authorized scope.
+3. [Implement](../implement/SKILL.md) and repair understood defects directly.
+   A known test failure needs a fix and a discriminating check, not another
+   planning phase, council or helper.
+4. Use focused checks during edits and complete required integration checks
+   before final judgment. Reuse valid exact-input receipts; rerun affected
+   checks after changes. Reserve capacity for integration, review and repair.
+   Keep the final subject unchanged while it is being judged.
+5. Obtain [Validate](../validate/SKILL.md) from one fresh author-distinct context
+   in the author's model family unless the caller selects required additional
+   legs. Risk deepens evidence, not automatic reviewer multiplication. Repair
+   actionable findings within authority and remaining bounds, then revalidate
+   the changed exact subject.
+6. Stop at completed acceptance, cancellation, refusal, a spent real bound or
+   an unresolved causal stall after the help below. Adjacent improvements are
+   not permission to expand the goal. Report them briefly only when useful;
+   do not turn them into another work batch.
+
+## Context and handoffs
+
+Load required contracts once per context, then inspect the source or evidence
+needed for the next decision. A reference link is available context, not a
+reading list. Search before opening large files; retrieve relevant sections
+and expand when uncertainty requires it. Do not reread unchanged material or
+copy full logs into successive tool results and handoffs.
+
+When delegation is authorized and useful, give each worker task-specific
+context: accepted intent and scope, exact subject, relevant evidence, remaining
+bounds and the requested result. Prefer a new task-only context for an
+independent subtask; resume the original worker for a direct repair when useful.
+Validators always receive fresh context, without the author's desired verdict.
+Use observed runtime capabilities; prompt wording does not prove isolation.
+
+Return concise findings, check facts and accessible evidence references. Keep
+full logs available, showing only decision-relevant excerpts; disclose truncation
+or missing evidence. Reuse one caller-owned handoff instead of multiplying
+plans, receipt summaries and status documents. Machine evidence is optional
+unless requested or required by a declared consumer.
 
 ## Causal stall and bounds
 
-Unknown cause, recurrence, no progress or evidence of the wrong objective calls
-for causal examination. A genuine causal stall admits **at most one bounded
-fresh helper** for that incident, when authorized and within remaining bounds.
+Unknown cause, recurrence, no progress or a wrong objective admits at most one
+bounded fresh helper for that incident within authority and remaining bounds.
 Give it the failed assumption, evidence and one discriminating question. Resume
-only when the answer supplies a different testable approach; an unhelpful answer
-ends the attempt with the unresolved facts. Do not create a helper chain or
-rename the same incident to obtain another helper. Known failures get direct
-repair. Cancellation, refusal and spent hard time/cost/quota skip help.
+only with a different testable approach; an unhelpful answer ends the attempt.
+Do not chain helpers or rename the incident. Known failures get direct repair.
+Cancellation, refusal and spent hard time/cost/quota skip help.
 
-Respect actual caller/native limits, including an explicit repair-round bound
-when supplied; no invocation, compaction, helper or new subject renews them.
-A retry count alone is not a spent time or quota budget. Keep compact recovery
-state only when interruption threatens evidence: accepted intent, exact current
-subject, useful receipts, unresolved cause, bounds and helper use, in the native
-handoff source. Prompt text is no proof of native enforcement.
-[Outer-goal guidance](references/outer-goal.md) is optional and outside the core.
+Respect actual caller/native limits, including explicit repair-round bounds.
+Retries, compaction, helpers and new subjects never renew them; retry count
+alone is not a spent budget. If interruption threatens evidence, preserve
+accepted intent, exact subject, useful receipts, unresolved cause, bounds and
+helper use in the native handoff. Prompt text proves no native enforcement.
+[Outer-goal guidance](references/outer-goal.md) remains optional.
 
-## On-demand tools
+## Evidence and boundaries
 
-- Plan shapes missing intent or revises an approach falsified by evidence.
-- Implement owns edits, direct repairs and factual checks.
-- Validate owns fresh exact-subject judgment; the author cannot issue binding PASS.
-- [Memory](../memory/SKILL.md) recalls applicable reviewed topic pages, or performs
-  separately budgeted mining and curation when requested. It is never an entry
-  or completion toll. No-match and no-change are valid.
+Bind accepted intent, complete changed paths, exact subject and factual receipts
+for the fresh validator; disclose affected orphaned acceptance evidence. Use
+existing provenance helpers rather than a new evidence format. Requested proof
+uses caller-selected protected external non-Git storage; preserve legacy
+`.agents/` evidence. Missing identity, freshness or proof means NOT_PROVEN;
+proven failed acceptance or scope violation means FAIL. PASS needs every
+criterion verified and empty `not_checked`. Authors cannot issue binding PASS.
 
-Specialists, including anti-ceremony, premortem, council, research and runtime
-adapters, remain optional. Risk increases evidence depth; it does not mandate a
-specialist dispatch. Read [boundaries](references/boundaries.md) when a source,
-review or delivery boundary matters; do not turn the charter into another packet.
+[Memory](../memory/SKILL.md), specialists and runtime adapters are on demand;
+no-match and no-change are valid. Read [boundaries](references/boundaries.md)
+when authority, scope, evidence or delivery is at issue. The optional
+[fixed-dispatch adapter](references/bounded-adapter.md) is not the native
+execution engine. Do not invent a runtime, hidden machine artifact or workflow
+to finish an ordinary change.
 
-## Evidence and report
-
-Bind the accepted intent and exact subject for the fresh validator, derive
-complete changed paths and factual check receipts, and disclose orphaned
-acceptance evidence when the change affects it. Use the existing provenance
-helpers described in Validate; new proof uses caller-selected protected external
-non-Git storage. Preserve legacy `.agents/` evidence. Do not invent an identity
-or treat a model's declared role as freshness. Missing freshness or necessary
-evidence means NOT_PROVEN; proven acceptance failure means FAIL.
-
-Return the caller-visible result, changed subject, strongest checks and material
-unchecked acceptance. PASS requires all acceptance, exact identity and empty
-`not_checked`; the report never hides remaining work. `NOT_PLANNED` and
-`NOT_BUILT` describe progress, not semantic judgment. Do not append a next action
-as a substitute for finishing authorized work. The interactive response is the
-default; persist `verdict.v2` or `rpi-report.v1` only when the caller requests
-machine-readable evidence or a declared consumer requires it. When no machine
-artifact was requested, do not create a hidden one.
-
-## Prompt
-
-```text
-Use rpi to finish this accepted change within its scope and remaining deadline.
-Repair understood failures directly. If an assumption fails, revise the approach
-without changing acceptance. Run required checks and obtain fresh final Validate.
-Use Memory only if an applicable prior constraint would change the next action.
-```
-
-## It's working if
-
-A clear small edit reaches checks without planning or memory paperwork; an
-understood test failure is fixed directly; a disproved assumption changes the
-approach; an unknown recurring failure gets no helper chain; the final exact
-subject receives fresh author-distinct judgment and the report states any gap.
-
-The grandfathered developer-only Python reference is an optional fixed-dispatch
-adapter with explicit repair rounds, not the native charter's execution engine.
-Its narrower [adapter contract](references/bounded-adapter.md) and tests remain
-available without adding a runtime, command, scheduler or mandatory worksheet.
+Report the result, strongest checks and material limits. Plans, activity,
+reviews and saved pages earn no capability credit; NOT_PLANNED and NOT_BUILT
+are progress descriptions, not semantic verdicts.

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -4,7 +4,7 @@ description: 'Own an authorized outcome through implementation, checks and fresh
 ---
 # RPI
 
-Own the authorized outcome through finish using the native coding agent and
+Own the authorized outcome through finish. Use the native coding agent and
 shell. BD or the caller's tracker owns work and handoffs; Git owns content and
 delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
@@ -17,7 +17,8 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
    shapes missing intent or revises a disproved approach. Once an implementer
    can act and a validator can judge, implement; do not keep improving the plan.
    Approach revisions preserve acceptance and authorized scope.
-3. [Implement](../implement/SKILL.md) and repair understood defects directly.
+   Acceptance changes need caller authority.
+3. [Implement](../implement/SKILL.md) and repair ordinary known defects directly.
    A known test failure needs a fix and a discriminating check, not another
    planning phase, council or helper.
 4. Use focused checks during edits and complete required integration checks
@@ -26,7 +27,8 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
    Keep the final subject unchanged while it is being judged.
 5. Obtain [Validate](../validate/SKILL.md) from one fresh author-distinct context
    in the author's model family unless the caller selects required additional
-   legs. Risk deepens evidence, not automatic reviewer multiplication. Repair
+   legs. There is no fixed ten-minute cap; explicitly required
+   reviewers remain required. Risk deepens evidence, not reviewer multiplication. Repair
    actionable findings within authority and remaining bounds, then revalidate
    the changed exact subject.
 6. Stop at completed acceptance, cancellation, refusal, a spent real bound or
@@ -52,13 +54,14 @@ Use observed runtime capabilities; prompt wording does not prove isolation.
 Return concise findings, check facts and accessible evidence references. Keep
 full logs available, showing only decision-relevant excerpts; disclose truncation
 or missing evidence. Reuse one caller-owned handoff instead of multiplying
-plans, receipt summaries and status documents. Machine evidence is optional
-unless requested or required by a declared consumer.
+plans, receipt summaries and status documents. Machine evidence such as `verdict.v2` is optional
+unless requested or required by a declared consumer. When no machine
+artifact is requested or required, return the result without creating one.
 
 ## Causal stall and bounds
 
-Unknown cause, recurrence, no progress or a wrong objective admits at most one
-bounded fresh helper for that incident within authority and remaining bounds.
+Unknown cause, recurrence, no progress or a wrong objective admits
+at most one bounded fresh helper for that incident within authority and bounds.
 Give it the failed assumption, evidence and one discriminating question. Resume
 only with a different testable approach; an unhelpful answer ends the attempt.
 Do not chain helpers or rename the incident. Known failures get direct repair.

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "72358771a67fb6e736cc74a75d1b922a3f94a55f66cb037f2602f984eb247d5c",
-  "generated_hash": "477e89bac82acea4425dcff254f411ac92ff1049a389d715a05bd1c1304b08b0"
+  "source_hash": "f3a1e5e6281f0dd08b0e8f87854d7fe013702e5d1548e5009f8875fdef439be5",
+  "generated_hash": "184645e1c205399ee7e98eb608b531b39e1046900d47290ded584a2e9b35bb06"
 }

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "b22ccc91da9328e8a1f9ecd5577282b0ec7f8a72eae505eb6ff3a7623264ca4c",
-  "generated_hash": "3c8b4a0d968f8a75eb07f7873be9cd8025b6b245691dabd3dafb419a456caf26"
+  "source_hash": "72358771a67fb6e736cc74a75d1b922a3f94a55f66cb037f2602f984eb247d5c",
+  "generated_hash": "477e89bac82acea4425dcff254f411ac92ff1049a389d715a05bd1c1304b08b0"
 }

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "f3a1e5e6281f0dd08b0e8f87854d7fe013702e5d1548e5009f8875fdef439be5",
-  "generated_hash": "184645e1c205399ee7e98eb608b531b39e1046900d47290ded584a2e9b35bb06"
+  "source_hash": "d458f6c3ccc510825984c9decff2eae90e8aca5111e8561be6e06bd12c2c17b6",
+  "generated_hash": "f8aabaed14d3e61c1f9b23376c7f79fb3b28751567418fe3a2e043efa53b30f7"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -4,8 +4,8 @@ description: 'Freshly judge a finished change against its acceptance: PASS, FAIL
 ---
 # Validate
 
-Freshly judge the exact candidate against accepted intent, return PASS, FAIL or
-NOT_PROVEN, and stop. The author cannot provide binding PASS. Read RPI
+Freshly judge the exact candidate against accepted intent, return
+`PASS`, `FAIL`, or `NOT_PROVEN`, and stop. The author cannot provide binding PASS. Read RPI
 [boundaries](../rpi/references/boundaries.md) before judgment; load helper flags
 and storage details from [mechanics](references/mechanics.md) when needed.
 
@@ -13,7 +13,7 @@ and storage details from [mechanics](references/mechanics.md) when needed.
 
 Final review starts after required checks and known repairs, with the candidate
 held unchanged. Supplied failed-acceptance evidence means FAIL on that subject;
-do not review a moving repair. The subject manifest is nonempty; plans, audits
+do not review a moving repair. The subject is a nonempty implementation candidate; plans, audits
 and reviews are subjects only when the caller requested document review.
 
 Use exact caller/runtime-owned intent bytes and derived acceptance identity.
@@ -86,8 +86,9 @@ needed to assess a finding. Do not retell the investigation or duplicate logs.
 Brevity must retain every criterion, necessary finding, identity, freshness
 fact and unchecked surface.
 
-Only when requested or required by a declared consumer, persist `verdict.v2`
-through `ao provenance store-verdict`. Validate supplies semantic judgment;
+Validate is the sole semantic author of `verdict.v2`.
+Only when the caller requests machine-readable evidence or a declared consumer
+requires it, persist through `ao provenance store-verdict`. Validate supplies judgment;
 Go verifies structure and storage, not truth. Otherwise return the result
 through the existing caller channel without hidden machine artifacts.
 Validate owns no repair, retry, delivery or tracker transition.

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -4,183 +4,90 @@ description: 'Freshly judge a finished change against its acceptance: PASS, FAIL
 ---
 # Validate
 
-Independently judge one exact subject against the acceptance in its existing
-bead or caller source, return one semantic result, and stop. Validate is the
-sole semantic author of `verdict.v2` when persistence is requested.
-`ao provenance store-verdict` supplies structural verification and atomic storage. Before the verdict,
-read `boundaries.md` in the rpi skill's `references` directory for the state
-Validate leaves to the caller.
+Freshly judge the exact candidate against accepted intent, return PASS, FAIL or
+NOT_PROVEN, and stop. The author cannot provide binding PASS. Read RPI
+[boundaries](../rpi/references/boundaries.md) before judgment; load helper flags
+and storage details from [mechanics](references/mechanics.md) when needed.
 
-## Prompt
+## Preconditions and freshness
 
-```text
-Validate bead ag-1234 in this fresh context. Intent: the bead text and digest.
-Subject: manifest.json from:
-ao provenance manifest --root . --include cli/internal/gates
-Author context ctx-a1. Re-run `cd cli && go test ./internal/gates/...`.
-Return PASS, FAIL, or NOT_PROVEN with evidence; stop.
-```
+Final review starts after required checks and known repairs, with the candidate
+held unchanged. Supplied failed-acceptance evidence means FAIL on that subject;
+do not review a moving repair. The subject manifest is nonempty; plans, audits
+and reviews are subjects only when the caller requested document review.
 
-## Preconditions
+Use exact caller/runtime-owned intent bytes and derived acceptance identity.
+Author and validator context IDs must be explicit and distinct; freshness is
+attested by runtime or caller with the attester's identity. Missing, colliding
+or unattested identity means NOT_PROVEN, not proof of isolation by role name.
 
-- Final judgment starts after required checks and known repairs are complete,
-  over a subject the author keeps unchanged during review. If supplied checks
-  already prove failed acceptance, return FAIL on that subject; do not wait
-  while the author repairs it inside the same review.
-- The subject is a nonempty implementation candidate: the manifest lists at
-  least one entry. Plans, audits, and reviews are subjects only when the
-  caller explicitly requested document review.
-- The intent source is a caller-owned artifact or a runtime-owned
-  content-addressed snapshot; its acceptance digest is derived automatically.
-- Author and validator context IDs are explicit, and freshness is attested
-  with `source: runtime | caller` and an attester identity. Missing,
-  colliding, or unattested identities produce `NOT_PROVEN`: a declared trust
-  fact, not cryptographic proof of isolation.
+Default to one fresh reviewer in the author's model family: Codex/OpenAI for
+Codex/OpenAI, Claude/Anthropic for Claude/Anthropic. Use the runtime's configured
+capable model unless pinned. A new role in the author's context is not fresh.
+Supply task-specific intent, scope, exact subject and relevant evidence, without
+full author history, desired verdict or peer conclusions. Retrieve more source
+when a criterion requires it; concise input must not omit necessary evidence.
 
-## Fresh validator and model selection
+Cross-model review is opt-in. `--cross-model [model]` is a skill prompt selection,
+not an AO flag; it adds a fresh other-family reviewer. Required legs remain
+required: unavailable diversity yields `diversity_unsatisfied` and NOT_PROVEN
+for the combined request, even if another leg passed. Preserve delivered FAILs
+and dissent; neither voting nor model preference makes a split PASS. Optional
+unavailable diversity stays disclosed without erasing findings. Exact invocation,
+authorization, runtime identity and independent-input rules live in
+[model-dispatch](../agent-native/references/model-dispatch.md). No fixed
+ten-minute cap applies; respect real caller/native bounds without renewing them.
+A timeout is missing judgment, not FAIL. Shared-family or cross-family agreement
+alone is not truth or proof of freedom from training bias.
 
-Default to one fresh, author-distinct validator from the author's model family:
-Codex/OpenAI work uses a fresh Codex/OpenAI reviewer; Claude/Anthropic work uses
-a fresh Claude/Anthropic reviewer. Use the runtime's configured capable model
-unless the caller pins one. Fresh context is required even when model weights
-are identical; a new role instruction in the author's session is not fresh.
-Risk determines the depth of evidence inspection, not an automatic second family.
+## Judgment
 
-Acceptance, tests/gates, stopping, allowances, safety, disclosure, hooks and
-executable controls warrant deeper checks, including policy written as prose.
-Conservative risk cues include `cli/internal/gates/**`, `scripts/check-*.sh`,
-`tests/**`, `skills/*/scripts/**`, `skills/cc-hooks/policies/**`, `lib/**`,
-`.github/workflows/**` and `scripts/security-gate.sh`. Unknown risk receives
-deeper inspection; it does not silently change the selected model families.
+1. Derive `subject-manifest.v1` using the existing helper at start and end.
+   A mismatch means mutation and NOT_PROVEN. Verify exact intent continuity,
+   cited evidence digests and complete changed-path coverage; missing integrity
+   is NOT_PROVEN. Proven out-of-scope change is FAIL.
+2. Inspect the actual diff against every acceptance criterion. Risk determines
+   depth: acceptance, permissions, tests/gates, stopping, disclosure, hooks and
+   executable controls warrant deeper inspection, including prose policy.
+   Unknown risk merits examination, not automatic extra reviewers.
+3. Re-execute discriminating proofs for risk-critical, uncertain or thinly
+   evidenced claims. Valid digest-bound receipts may establish routine facts;
+   do not replay every author command or full suite merely because this is a
+   fresh context. The repository's required integration checks still run on
+   the final subject. A changed subject needs new judgment and affected checks.
+4. Classify commands before executing them. Regeneration, synchronization,
+   formatting and `--force` are subject-mutating until proven otherwise; run
+   them only on a disposable copy or a committed subject, never an uncommitted
+   judged tree. Do not overwrite the candidate while validating it.
+5. Reject green obtained through weaker assertions, tolerances, goldens,
+   suppressions or acceptance edits. Each criterion needs supporting evidence;
+   explanation alone is not proof. A necessary finding cannot become an
+   optional caveat or non-goal. Publication/provenance claims in docs also need
+   verifiable evidence.
+6. Return one result with criterion-level evidence, findings, checked scope,
+   `not_checked`, author/judge identities and contexts, and the freshness
+   attestation. PASS requires all criteria verified, nonempty checked scope and
+   top-level evidence, and empty `not_checked`. An unverified criterion means
+   NOT_PROVEN; proven failed acceptance or scope violation means FAIL.
 
-The caller can request `--cross-model` or say "cross-model review" to add one
-fresh validator from a different family. `--cross-model <model>` pins that
-additional reviewer, for example `--cross-model claude-fable-5-1` from Codex
-or `--cross-model gpt-6-astra` from Claude. These are skill prompt options,
-not `ao` CLI flags. RPI forwards them unchanged. Without a pin, use an available,
-authorized capable model from the other family; never silently substitute for
-a pinned model or count two models in one family as cross-family diversity.
-An explicit caller requirement remains required until the caller changes it;
-changing the default cannot erase a finding or relabel a missing verdict as PASS.
+## Findings and report
 
-Route selection and invocation through
-[agent-native model-dispatch](../agent-native/references/model-dispatch.md);
-[references/mechanics.md](references/mechanics.md) owns evidence storage.
-There is no fixed ten-minute review timeout. Use the caller's selected review
-timeout or remaining native deadline, respecting any earlier host or goal limit.
-A timeout is missing judgment, not FAIL; never restart to renew an allowance.
+`not_checked` means in-scope acceptance that was not verified. Other limits
+remain in criterion reasoning, declared non-goals or residual-risk prose; never
+hide or delete them to obtain PASS. Keep prior findings visible. For each new
+finding, name a short stable nonempty `class` describing the defect, reused on
+recurrence, and distinguish pre-existing, introduced or unknown cause using
+before/after or equivalent causal evidence. Counts and timestamps alone do not
+establish cause. Known findings return to direct repair; causal stalls use the
+RPI single-helper rule, not repairs delegated to this validator.
 
-Each selected judge receives the exact subject, unchanged acceptance and
-authorized evidence independently, without the author's desired verdict or peer
-conclusions. Record actual model/context identities and runtime receipts.
-Missing freshness, an unbound subject, incomplete acceptance evidence, or
-nonempty `not_checked` prevents PASS regardless of model family.
-With no authorized adapter for requested diversity, disclose
-`diversity_unsatisfied`: the required combined result is `NOT_PROVEN` even if
-the same-family judge passed. A delivered FAIL stands. Advisory diversity that
-the caller explicitly made optional may accompany the same-family result with
-that limitation; it cannot discard an acceptance-relevant finding.
+Keep the report proportional: cite existing receipts and include only excerpts
+needed to assess a finding. Do not retell the investigation or duplicate logs.
+Brevity must retain every criterion, necessary finding, identity, freshness
+fact and unchecked surface.
 
-When selected judges disagree, preserve both verdicts and their evidence.
-Required diversity converges only when both pass; neither majority vote nor a
-preferred judge settles a split. Repair addresses known findings directly under RPI and real caller/native
-bounds. Report unresolved dissent and the caller's decision openly.
-Same-family fresh judgment reduces anchoring, but does not prove independence
-from shared training biases; cross-family agreement is corroboration, not truth.
-
-## Mutating-check quarantine
-
-Classify every acceptance-listed command as read-only or subject-mutating
-before running it: regen scripts, sync scripts, formatters, and anything with
-`--force` are mutating until proven otherwise. Run a mutating check only
-against a disposable copy or a committed subject, never the judged working
-tree (the boundaries appendix records the regen that overwrote a subject).
-
-## Scope disclosure
-
-`not_checked` has exactly one meaning: **in-scope acceptance surface this
-validation did not verify**. PASS asserts the whole declared acceptance
-surface was verified, so a PASS carries no `not_checked` entries; every other
-scope limit has a home that survives inside a PASS: a bounded proof in
-`criteria[].reason`, a declared non-goal in the intent source, residual risk
-in the report (table in the mechanics reference). Emptying `not_checked` to
-obtain PASS is a contract violation: unverified acceptance makes the honest
-result `NOT_PROVEN`, and an entry that was never acceptance moves to its home
-and stays visible. A finding necessary to acceptance cannot be relabeled as
-optional, residual risk, or a non-goal to obtain PASS.
-
-## Workflow
-
-1. Derive `subject-manifest.v1` with the helper's `manifest` command (flags
-   in the mechanics reference) at the start and again at the end; any
-   mismatch is subject mutation and returns `NOT_PROVEN`.
-2. Confirm the intent-source digest is unchanged since implementation, every
-   cited evidence digest matches the artifact it names, and complete
-   changed-path coverage can be derived; otherwise `NOT_PROVEN`.
-3. Adjudicate the actual diff: runtime-derived changed paths against the
-   intent's scope classes. A proven out-of-scope path is `FAIL`; incomplete
-   scope evidence is `NOT_PROVEN`.
-4. Inspect the exact subject and evidence. Reported exit codes are claims:
-   re-execute the proofs that bear on acceptance. A changed test, gate,
-   fixture, golden, tolerance, suppression, or acceptance source must be
-   required by the original intent, with green coming from implemented
-   behavior; green obtained by weakening acceptance is `FAIL`. Judge every
-   acceptance criterion against its own evidence reference; a criterion with
-   no evidence of its own is unverified, not passed.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
-   it with criterion-level results, findings, evidence references, `checked`,
-   `not_checked`, both identities, both context IDs, and the freshness
-   attestation. Name a `class` for each finding: one short stable name for the
-   kind of defect, one per finding, reused word for word when the same kind
-   recurs, so the orchestrator can see a closed kind come back. Explain in the
-   existing summary and evidence whether a newly exposed defect pre-existed the
-   change, was introduced by it, or has unknown cause. Use before/after proof or
-   equivalent causal evidence under unchanged acceptance; counts and timestamps
-   do not establish cause. Recurrence calls for causal examination and does not
-   by itself prove a design failure. Known defects return to direct repair;
-   unknown cause, recurrence or no progress uses the charter's single bounded
-   helper rule, without delegating repairs to this validator. Name the class or omit it; a `class` that is
-   present and blank is a finding against this validator,
-   and so is a class that does not describe its finding. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   nonempty top-level evidence, evidence for every criterion, and an empty
-   `not_checked`. A documentation sentence claiming something is published,
-   pinned, or proven is an acceptance criterion like any other: it needs a
-   check this validator can run, or it is `not_checked`. The
-   `docs.claims-tracked` gate covers the tracked-file half of that and nothing
-   more.
-6. Only when the caller requests machine-readable evidence or a declared
-   downstream consumer requires it, persist canonical `verdict.v2` with the
-   helper's `store-verdict` (mechanics reference), then return the artifact
-   path and digest with the result. Stop.
-
-Keep the judgment proportional to the change. Cite existing receipts instead of
-repeating their history; brevity must preserve every criterion, necessary
-finding, identity, freshness fact and unchecked acceptance surface.
-
-Fresh validation is independent judgment over the exact subject, not a replay
-of every author command: rerun the risk-critical, uncertain, or thinly
-evidenced checks; a digest-bound deterministic receipt may prove routine
-facts; replay an expensive full suite only when acceptance requires it. The
-repository's full literal CI command set, as quoted in `AGENTS.md`, runs
-once, on the final integrated subject.
-
-## It's working if
-
-Observable in the trace, without reading the prose, and the rubric a fresh
-independent judge scores this skill against:
-
-- A criterion whose evidence is a justification rather than a proof is named,
-  and the result is `NOT_PROVEN` rather than `PASS`.
-- Green obtained by widening a tolerance, skipping a case, or re-baselining a
-  budget is reported as `FAIL`, never as completion.
-- Every scope limit is placed in one of the Scope-disclosure homes; none was
-  deleted to reach `PASS`.
-- The subject manifest is derived twice, at the start and at the end, and the
-  two are compared.
-
-## Boundary
-
-Validate emits no next action, repair, retry, replan, or delivery state (full
-list in the boundaries reference); ledger availability cannot change a
-verdict's validity.
+Only when requested or required by a declared consumer, persist `verdict.v2`
+through `ao provenance store-verdict`. Validate supplies semantic judgment;
+Go verifies structure and storage, not truth. Otherwise return the result
+through the existing caller channel without hidden machine artifacts.
+Validate owns no repair, retry, delivery or tracker transition.

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -42,6 +42,12 @@ alone is not truth or proof of freedom from training bias.
 
 ## Judgment
 
+Use the helper for each changed path (repeat `--include` for complete scope):
+
+```sh
+ao provenance manifest --root "$REPO_ROOT" --include "$CHANGED_PATH"
+```
+
 1. Derive `subject-manifest.v1` using the existing helper at start and end.
    A mismatch means mutation and NOT_PROVEN. Verify exact intent continuity,
    cited evidence digests and complete changed-path coverage; missing integrity

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -27,7 +27,7 @@ metadata:
 
 # Implement
 
-Implement the accepted outcome and repair understood defects. Use the existing
+Implement the accepted outcome. Repair ordinary known defects directly. Use the existing
 intent; no Plan, Recall or Learn worksheet is owed for a clear edit. Implement
 owns source changes and factual checks; the runtime derives identity and receipts.
 
@@ -57,7 +57,7 @@ owns source changes and factual checks; the runtime derives identity and receipt
    goldens, tolerances, suppressions and specification text against original
    intent. Mocks, placeholders or weakened oracles cannot substitute for the
    requested behavior.
-6. Derive complete changed paths and `subject-manifest.v1`. When changed paths
+6. Have the runtime derive actual changed paths and `subject-manifest.v1`. When changed paths
    affect bound acceptance evidence, run `ao provenance evidence-orphans --root
    <repo-root>` with one `--changed <path>` per derived path, and retain the
    actual output for the validator. Repeat after repairs that change that

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -27,100 +27,58 @@ metadata:
 
 # Implement
 
-Implement the authorized outcome, including ordinary direct repairs. Use the
-resolved bead or caller intent; do not turn every failed check into a new phase.
-Implement owns subject edits and factual evidence; the runtime derives identity
-and receipts. A clear trivial change needs no Plan, Recall or Learn worksheet.
-
-## Prompt
-
-```text
-Implement bead ag-1234 from its text: acceptance "ao gate check lists
-skill.probe-coverage", scope cli/internal/gates/** plus regen outputs, first
-check `cd cli && go test ./internal/gates/...`. RED first, smallest change,
-return the manifest digest and check receipts, stop.
-```
-
-## It's working if
-
-- After source activation and startup association, the first behavior check
-  is the acceptance check; its output shows the expected failure (or an honest
-  green structural baseline for documentation, relocation, or refactor work).
-- Every path in `git diff --stat` falls inside the declared scope; an outside
-  consumer is reported as `file:line`, not absorbed.
-- The response carries the `subject-manifest.v1` digest, author context ID,
-  and verbatim check output; no `git commit` or `git push` appears.
+Implement the accepted outcome and repair understood defects. Use the existing
+intent; no Plan, Recall or Learn worksheet is owed for a clear edit. Implement
+owns source changes and factual checks; the runtime derives identity and receipts.
 
 ## Workflow
 
-1. Read the intent, acceptance, and scope from their existing source; before
-   the first write, read `boundaries.md` in the rpi skill's `references`
-   directory for what Implement does not own. Before execution can fail, the
-   caller passes source-store/project/work identity and permitted intent
-   locators at dispatch/start. At startup, return observed native runtime,
-   session/context identity (or explicit unknowns) through the caller-owned
-   runtime channel for native comments/metadata recording; do not defer this
-   association until handoff. Follow the fact distinctions in
-   [session associations](../cass/references/SESSION_FORMATS.md#work-to-session-associations).
-   Parent and resume links need observed provenance; controller dispatch alone
-   does not establish native parentage. If startup observation or recording
-   fails, preserve that failure and the pre-execution reference with the caller,
-   leaving unobserved IDs unknown. Startup association applies when the caller selected episode tracking; a
-   trivial edit does not need a new tracking worksheet. Use the caller-owned
-   runtime channel for handoff facts, without a second work account.
-2. Run the declared first acceptance check before changing behavior. RED-first
-   applies when acceptance is behavioral: preserve evidence that the check
-   fails for the expected missing behavior. Relocations, doc merges, and pure
-   refactors record an honest green pre-change baseline instead.
-3. Make the smallest in-scope change that satisfies the active behavior. Repair
-   ordinary known defects directly. A failed test with an understood cause needs
-   a fix and another discriminating check, not a helper or fresh planning lane.
-   If evidence disproves an assumption, revise the approach within unchanged
-   acceptance and scope; use Plan only to resolve consequential uncertainty.
-4. Run the targeted acceptance checks and applicable repository lint/static
-   checks before handing off a candidate for broad integration. Capture factual
-   results; package tests alone do not establish a separate lint contract.
-5. Refactor only while those checks stay green. Refactoring does not change the
-   acceptance test.
-6. Have the runtime derive actual changed paths and `subject-manifest.v1` from
-   the before/after subject.
-7. When changed files affect bound acceptance evidence, run `ao provenance evidence-orphans --root <repo-root>` with one
-   `--changed <path>` per changed path the runtime derived, and put its JSON
-   output in the check receipts the validator reads, so orphaned evidence
-   arrives as a receipt rather than as a surprise at verify time. Run it again after every repair round, over the
-   paths as they stand, because a repair can orphan evidence the first pass did
-   not. Read the output as written and never hand-list the orphans instead.
-8. Return the manifest digest, author context ID, and exact check receipts in the
-   response or runtime channel. Stop.
+1. Read intent, acceptance, scope and the RPI [boundaries](../rpi/references/boundaries.md)
+   before the first write; reuse contracts already loaded in this context.
+   When the caller selected episode tracking, obtain permitted work/source
+   references before execution and return observed runtime/context identity at
+   startup through the native recording channel. Unknowns and recording failures
+   stay explicit; do not invent parentage or a second tracker. The optional
+   [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
+   supplies mechanics for that selected workflow.
+2. Run the first useful acceptance check. Behavioral changes preserve RED for
+   the expected missing behavior; a pure refactor, relocation or documentation
+   change may have an honest green baseline. Avoid building elaborate fixtures
+   when an existing test or small discriminating probe answers the question.
+3. Make the smallest in-scope change. Fix known failures directly, then rerun
+   the affected check. A disproved assumption may change the approach within
+   accepted outcome and scope; use Plan only for consequential uncertainty.
+4. Use targeted tests and applicable repository lint/static checks before
+   broad integration. Read the repository's actual check recipe, including
+   instrumentation and environment, rather than reconstructing it from memory.
+   Run required full checks at integration, not after each small edit. Reuse
+   exact-input receipts only while source, tool and relevant environment match.
+5. Refactor while acceptance remains green. Inspect changed tests, fixtures,
+   goldens, tolerances, suppressions and specification text against original
+   intent. Mocks, placeholders or weakened oracles cannot substitute for the
+   requested behavior.
+6. Derive complete changed paths and `subject-manifest.v1`. When changed paths
+   affect bound acceptance evidence, run `ao provenance evidence-orphans --root
+   <repo-root>` with one `--changed <path>` per derived path, and retain the
+   actual output for the validator. Repeat after repairs that change that
+   subject; do not hand-invent an orphan list.
+7. Return the manifest digest, author context ID, acceptance-check facts and
+   evidence references through the caller's response/runtime channel, then stop.
+   Include command, result and decision-relevant failures. Keep full output
+   accessible instead of pasting successful logs or repeated receipt inventories
+   into every handoff. Missing or truncated evidence must remain visible.
 
-Specialists (standards, domain, test, refactor, security) advise only. During
-edits, run the smallest deterministic checks that can falsify the change,
-reuse exact-input receipts whose subject and tool identity still match, and
-run the full suite at the integration boundary unless the intent makes it the
-first check.
+## Scope and finish
 
-## Scope conflict rule
+Report an uncovered live consumer as `file:line` for a caller scope amendment;
+continue independent authorized work. Generated companions already included as
+scope require no new approval. Acceptance changes always require caller authority.
 
-On discovering a live consumer of the change outside the declared write scope
-(a test asserting the old path, a generated twin, a gate reading the moved
-file), stop and report the exact file and line to the caller for a scope amendment; continue independent authorized work. A different
-acceptance contract needs caller authority. Generated outputs already included
-as a scope class need no new permission.
+Specialists advise only. Known defects stay implementation work; a genuine
+causal stall follows RPI's at-most-one bounded helper rule. Respect remaining
+caller/native bounds and reserve finishing capacity. No retry resets them.
 
-Before declaring GREEN, self-audit the diff for mocks, placeholders, TODO
-stubs, hardcoded fixture values, weakened assertions, regenerated goldens,
-widened tolerances, suppression directives, or specification edits standing
-in for real behavior. A changed test, gate, fixture, golden, or acceptance
-source must be required by the original intent, with green coming from the
-implemented behavior; a check that passes against a substitute or weakened
-oracle is not evidence: finish the behavior or report it as not built.
-
-## Boundary
-
-Do not issue semantic PASS or infer Git, tracker or delivery permission from
-this skill. Follow the caller's existing authority and repository policy.
-An implement-only handoff returns facts to its caller; a full outcome request
-uses RPI through fresh final validation. Known defects stay implementation work.
-On a genuine causal stall, use RPI's at-most-one bounded helper rule, never a
-helper chain. Reserve finishing capacity and respect actual caller/native bounds;
-a retry count alone is not a spent time or quota budget.
+Return facts, not semantic PASS. An implement-only handoff does not authorize
+Git, tracker or delivery transitions; existing caller authority remains usable.
+A full outcome request uses RPI through fresh final judgment. Success is working
+behavior with usable evidence, not volume of logs or process artifacts.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -24,8 +24,9 @@ metadata:
 
 # Plan
 
-Shape only missing intent in the caller's bead, conversation or supplied text.
-Planning produces no AgentOps packet. A clear change can proceed directly.
+Shape only missing intent. Prefer the caller's tracker, if any; otherwise use
+the conversation or supplied text. Planning produces no AgentOps packet.
+A clear change can proceed directly.
 
 ## Workflow
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -24,67 +24,48 @@ metadata:
 
 # Plan
 
-Shape only what is missing from the authorized intent. Prefer the caller's tracker, if any;
-otherwise use the caller's conversation or supplied text. A clear trivial change
-needs no planning worksheet or separate Plan dispatch. Planning produces no AgentOps packet.
+Shape only missing intent in the caller's bead, conversation or supplied text.
+Planning produces no AgentOps packet. A clear change can proceed directly.
 
 ## Workflow
 
-1. Read the actual intent, relevant source owners and active constraints. Find
-   the caller-visible outcome, allowed write scope and first useful check.
-   Inspect only enough context to resolve a consequential uncertainty.
-2. Where needed, clarify acceptance examples, important non-goals and scope in
-   the existing source. Include generated companions as a class: hand-edited
-   sources plus every output of the owning regeneration commands. Include tests
-   and live consumers that must change with them. Scope is authority, not a
-   prediction of an exact file count.
-3. Choose the smallest acceptance-advancing action or discriminating check.
-   Identify evidence the change could invalidate and include recapture where
-   required. Use `ao provenance evidence-orphans` for affected bound evidence;
-   avoid a mandatory ledger or taxonomy for changes that do not need one.
-4. Revise the approach when evidence disproves an assumption under unchanged
-   accepted outcome and scope. Record the disproved assumption, evidence and
-   revised check briefly in the existing source or handoff. No new permission
-   is needed for this approach revision. Changing acceptance or expanding scope
-   needs caller authority; never quietly weaken the original check.
-5. When another context needs the intent, pass enough exact source and references
-   to act without the author's private reasoning. The runtime binds accepted
-   intent for final validation; useful approach notes are separate from frozen
-   acceptance so revising a hypothesis does not fabricate acceptance drift.
+1. Read accepted intent and relevant source owners and active constraints.
+   Resolve only consequential uncertainty; do not reopen settled decisions
+   without new evidence. Identify the caller-visible outcome, scope and first
+   useful check.
+2. Clarify missing acceptance examples and non-goals in that existing source.
+   Scope includes the hand-edited owners, affected tests/live consumers and
+   generator-owned companions as a class; it is authority, not a predicted
+   file count. A consequential assumption deserves an early discriminating
+   check, not a general checklist or exhaustive survey.
+3. Choose the smallest action that advances acceptance or falsifies the risky
+   assumption. Include recapture of affected bound evidence where necessary;
+   use `ao provenance evidence-orphans` when applicable, not a mandatory ledger.
+4. When evidence disproves an approach, briefly retain the failed assumption,
+   evidence and revised check in the existing intent or handoff. Approach
+   changes within accepted outcome and scope need no new permission; acceptance
+   or scope expansion requires caller authority. Never relabel a failed
+   acceptance condition as a caveat to obtain green.
+5. Give another context exact intent references and the evidence it needs to
+   act. Keep approach notes separate from frozen acceptance. Do not transmit
+   the entire research history when a focused source reference will suffice.
 
-A plan is sufficient when the implementer can act and the validator can judge.
-Then stop planning and implement. Specialists and
-[ground-truth routing](references/ground-truth-routing.md) are optional tools for
-consequential integration or design uncertainty, not universal worksheets.
-[Memory recall](../memory/references/recall.md) is useful only when applicable
-prior experience may change this work's next action.
+Stop planning once the implementer can act and the validator can judge. More
+research, decomposition or review must resolve a named remaining uncertainty.
+Specialists and [ground-truth routing](references/ground-truth-routing.md) are
+optional. [Memory recall](../memory/references/recall.md) is useful only when
+prior evidence could change the next action.
 
 ## Identity and scope
 
-Use the runtime's source reference and digest for exact accepted intent. For
-conversation-only intent, existing `ao provenance snapshot-intent --source -
---evidence-root <explicit-root>` stores resolved bytes in a caller-selected
-protected external non-Git evidence directory. Missing routing does not authorize
-a workspace fallback or a second plan artifact. Preserve legacy proof.
+Use runtime-derived source identity and digest. If conversation intent needs
+an exact snapshot, existing `ao provenance snapshot-intent --source -
+--evidence-root <explicit-root>` uses caller-selected protected external
+non-Git storage. Missing routing permits neither workspace fallback nor a
+second planning artifact. Preserve legacy proof.
 
-Scope patterns are normalized repository-relative paths, cover the behavior,
-and include generator-owned companions without granting unrelated directories.
-A live consumer outside accepted scope needs a concise exact-file amendment to
-the caller; continue independent authorized work while that decision is pending.
-[Boundaries](../rpi/references/boundaries.md) keep work/status in the caller's
-tracker and Git/delivery under repository policy.
-
-## Prompt
-
-```text
-Use Plan to resolve the uncertain parser interface for this accepted change.
-Keep acceptance and scope; use a real consumer check to test the assumption.
-Revise the approach if it fails, then implement. No new planning artifact.
-```
-
-## It's working if
-
-A clear small change skips planning paperwork. A falsified assumption changes
-the approach and the next check; it does not trigger another approval round
-unless outcome or scope changes. Generated outputs remain in scope and the
-existing intent gives a fresh implementer enough information to act.
+Use normalized repository-relative scope patterns. An uncovered live consumer
+needs a concise exact-file amendment to the caller; continue independent
+in-scope work meanwhile. Generated companions already in scope need no extra
+permission. [Boundaries](../rpi/references/boundaries.md) keep work/status in
+the caller's tracker and delivery under repository policy.

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -34,7 +34,7 @@ output_contract: 'concise human-readable result; optional rpi-report.v1 when a c
 
 # RPI
 
-Own the authorized outcome through finish using the native coding agent and
+Own the authorized outcome through finish. Use the native coding agent and
 shell. BD or the caller's tracker owns work and handoffs; Git owns content and
 delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
@@ -47,7 +47,8 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
    shapes missing intent or revises a disproved approach. Once an implementer
    can act and a validator can judge, implement; do not keep improving the plan.
    Approach revisions preserve acceptance and authorized scope.
-3. [Implement](../implement/SKILL.md) and repair understood defects directly.
+   Acceptance changes need caller authority.
+3. [Implement](../implement/SKILL.md) and repair ordinary known defects directly.
    A known test failure needs a fix and a discriminating check, not another
    planning phase, council or helper.
 4. Use focused checks during edits and complete required integration checks
@@ -56,7 +57,8 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
    Keep the final subject unchanged while it is being judged.
 5. Obtain [Validate](../validate/SKILL.md) from one fresh author-distinct context
    in the author's model family unless the caller selects required additional
-   legs. Risk deepens evidence, not automatic reviewer multiplication. Repair
+   legs. There is no fixed ten-minute cap; explicitly required
+   reviewers remain required. Risk deepens evidence, not reviewer multiplication. Repair
    actionable findings within authority and remaining bounds, then revalidate
    the changed exact subject.
 6. Stop at completed acceptance, cancellation, refusal, a spent real bound or
@@ -82,13 +84,14 @@ Use observed runtime capabilities; prompt wording does not prove isolation.
 Return concise findings, check facts and accessible evidence references. Keep
 full logs available, showing only decision-relevant excerpts; disclose truncation
 or missing evidence. Reuse one caller-owned handoff instead of multiplying
-plans, receipt summaries and status documents. Machine evidence is optional
-unless requested or required by a declared consumer.
+plans, receipt summaries and status documents. Machine evidence such as `verdict.v2` is optional
+unless requested or required by a declared consumer. When no machine
+artifact is requested or required, return the result without creating one.
 
 ## Causal stall and bounds
 
-Unknown cause, recurrence, no progress or a wrong objective admits at most one
-bounded fresh helper for that incident within authority and remaining bounds.
+Unknown cause, recurrence, no progress or a wrong objective admits
+at most one bounded fresh helper for that incident within authority and bounds.
 Give it the failed assumption, evidence and one discriminating question. Resume
 only with a different testable approach; an unhelpful answer ends the attempt.
 Do not chain helpers or rename the incident. Known failures get direct repair.

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -34,106 +34,90 @@ output_contract: 'concise human-readable result; optional rpi-report.v1 when a c
 
 # RPI
 
-Own the authorized outcome through finish. Use the native coding agent and
-shell; BD or the caller's tracker owns work/status/handoffs, Git owns content
-and delivery history. Keep one authoritative work account. AgentOps adds a
-small operating charter and fresh judgment, not a scheduler or a second queue.
+Own the authorized outcome through finish using the native coding agent and
+shell. BD or the caller's tracker owns work and handoffs; Git owns content and
+delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
 ## Operating charter
 
-1. Keep the accepted outcome, scope and real bounds in view. Use the existing
-   intent; a trivial clear change needs no Plan, Recall or Learn worksheet.
-2. Take the smallest action that advances acceptance or resolves a consequential
-   uncertainty. Load [Plan](../plan/SKILL.md) only when intent or approach needs
-   shaping. Evidence may disprove an assumption: revise the approach within
-   unchanged accepted outcome and scope. Acceptance changes need caller authority.
-3. [Implement](../implement/SKILL.md) the change and repair ordinary known
-   defects directly. A failed check with an understood cause is implementation
-   work, not a reason for another plan, council or helper.
-4. Use cheap discriminating checks during edits, then the required integration
-   checks. Preserve valid exact-input receipts. Reserve finishing capacity for
-   integration, fresh final judgment, repairs and a truthful handoff. Complete
-   required checks and known repairs before dispatching final judgment, then
-   keep that subject unchanged until the review returns.
-5. Obtain [Validate](../validate/SKILL.md) in a fresh author-distinct context over
-   the exact final subject. Default to the author's model family; cross-model
-   review is opt-in. There is no fixed ten-minute cap. Required caller-selected
-   reviewers remain required. Every necessary finding stays visible.
-6. Repair actionable findings within authority and real remaining bounds, then
-   obtain fresh judgment over the changed subject. Stop at completed acceptance,
-   cancellation, an explicit refusal, a spent real bound, or a genuine causal
-   stall that the bounded help below cannot resolve. Activity, saved pages,
-   changed digests and repeated reviews are not completed capability.
+1. Use the existing accepted outcome, scope and real bounds. A clear change
+   needs no Plan, Recall or Learn worksheet. Resolve uncertainty only when it
+   could change the implementation or acceptance decision.
+2. Take the smallest acceptance-advancing action. [Plan](../plan/SKILL.md)
+   shapes missing intent or revises a disproved approach. Once an implementer
+   can act and a validator can judge, implement; do not keep improving the plan.
+   Approach revisions preserve acceptance and authorized scope.
+3. [Implement](../implement/SKILL.md) and repair understood defects directly.
+   A known test failure needs a fix and a discriminating check, not another
+   planning phase, council or helper.
+4. Use focused checks during edits and complete required integration checks
+   before final judgment. Reuse valid exact-input receipts; rerun affected
+   checks after changes. Reserve capacity for integration, review and repair.
+   Keep the final subject unchanged while it is being judged.
+5. Obtain [Validate](../validate/SKILL.md) from one fresh author-distinct context
+   in the author's model family unless the caller selects required additional
+   legs. Risk deepens evidence, not automatic reviewer multiplication. Repair
+   actionable findings within authority and remaining bounds, then revalidate
+   the changed exact subject.
+6. Stop at completed acceptance, cancellation, refusal, a spent real bound or
+   an unresolved causal stall after the help below. Adjacent improvements are
+   not permission to expand the goal. Report them briefly only when useful;
+   do not turn them into another work batch.
+
+## Context and handoffs
+
+Load required contracts once per context, then inspect the source or evidence
+needed for the next decision. A reference link is available context, not a
+reading list. Search before opening large files; retrieve relevant sections
+and expand when uncertainty requires it. Do not reread unchanged material or
+copy full logs into successive tool results and handoffs.
+
+When delegation is authorized and useful, give each worker task-specific
+context: accepted intent and scope, exact subject, relevant evidence, remaining
+bounds and the requested result. Prefer a new task-only context for an
+independent subtask; resume the original worker for a direct repair when useful.
+Validators always receive fresh context, without the author's desired verdict.
+Use observed runtime capabilities; prompt wording does not prove isolation.
+
+Return concise findings, check facts and accessible evidence references. Keep
+full logs available, showing only decision-relevant excerpts; disclose truncation
+or missing evidence. Reuse one caller-owned handoff instead of multiplying
+plans, receipt summaries and status documents. Machine evidence is optional
+unless requested or required by a declared consumer.
 
 ## Causal stall and bounds
 
-Unknown cause, recurrence, no progress or evidence of the wrong objective calls
-for causal examination. A genuine causal stall admits **at most one bounded
-fresh helper** for that incident, when authorized and within remaining bounds.
+Unknown cause, recurrence, no progress or a wrong objective admits at most one
+bounded fresh helper for that incident within authority and remaining bounds.
 Give it the failed assumption, evidence and one discriminating question. Resume
-only when the answer supplies a different testable approach; an unhelpful answer
-ends the attempt with the unresolved facts. Do not create a helper chain or
-rename the same incident to obtain another helper. Known failures get direct
-repair. Cancellation, refusal and spent hard time/cost/quota skip help.
+only with a different testable approach; an unhelpful answer ends the attempt.
+Do not chain helpers or rename the incident. Known failures get direct repair.
+Cancellation, refusal and spent hard time/cost/quota skip help.
 
-Respect actual caller/native limits, including an explicit repair-round bound
-when supplied; no invocation, compaction, helper or new subject renews them.
-A retry count alone is not a spent time or quota budget. Keep compact recovery
-state only when interruption threatens evidence: accepted intent, exact current
-subject, useful receipts, unresolved cause, bounds and helper use, in the native
-handoff source. Prompt text is no proof of native enforcement.
-[Outer-goal guidance](references/outer-goal.md) is optional and outside the core.
+Respect actual caller/native limits, including explicit repair-round bounds.
+Retries, compaction, helpers and new subjects never renew them; retry count
+alone is not a spent budget. If interruption threatens evidence, preserve
+accepted intent, exact subject, useful receipts, unresolved cause, bounds and
+helper use in the native handoff. Prompt text proves no native enforcement.
+[Outer-goal guidance](references/outer-goal.md) remains optional.
 
-## On-demand tools
+## Evidence and boundaries
 
-- Plan shapes missing intent or revises an approach falsified by evidence.
-- Implement owns edits, direct repairs and factual checks.
-- Validate owns fresh exact-subject judgment; the author cannot issue binding PASS.
-- [Memory](../memory/SKILL.md) recalls applicable reviewed topic pages, or performs
-  separately budgeted mining and curation when requested. It is never an entry
-  or completion toll. No-match and no-change are valid.
+Bind accepted intent, complete changed paths, exact subject and factual receipts
+for the fresh validator; disclose affected orphaned acceptance evidence. Use
+existing provenance helpers rather than a new evidence format. Requested proof
+uses caller-selected protected external non-Git storage; preserve legacy
+`.agents/` evidence. Missing identity, freshness or proof means NOT_PROVEN;
+proven failed acceptance or scope violation means FAIL. PASS needs every
+criterion verified and empty `not_checked`. Authors cannot issue binding PASS.
 
-Specialists, including anti-ceremony, premortem, council, research and runtime
-adapters, remain optional. Risk increases evidence depth; it does not mandate a
-specialist dispatch. Read [boundaries](references/boundaries.md) when a source,
-review or delivery boundary matters; do not turn the charter into another packet.
+[Memory](../memory/SKILL.md), specialists and runtime adapters are on demand;
+no-match and no-change are valid. Read [boundaries](references/boundaries.md)
+when authority, scope, evidence or delivery is at issue. The optional
+[fixed-dispatch adapter](references/bounded-adapter.md) is not the native
+execution engine. Do not invent a runtime, hidden machine artifact or workflow
+to finish an ordinary change.
 
-## Evidence and report
-
-Bind the accepted intent and exact subject for the fresh validator, derive
-complete changed paths and factual check receipts, and disclose orphaned
-acceptance evidence when the change affects it. Use the existing provenance
-helpers described in Validate; new proof uses caller-selected protected external
-non-Git storage. Preserve legacy `.agents/` evidence. Do not invent an identity
-or treat a model's declared role as freshness. Missing freshness or necessary
-evidence means NOT_PROVEN; proven acceptance failure means FAIL.
-
-Return the caller-visible result, changed subject, strongest checks and material
-unchecked acceptance. PASS requires all acceptance, exact identity and empty
-`not_checked`; the report never hides remaining work. `NOT_PLANNED` and
-`NOT_BUILT` describe progress, not semantic judgment. Do not append a next action
-as a substitute for finishing authorized work. The interactive response is the
-default; persist `verdict.v2` or `rpi-report.v1` only when the caller requests
-machine-readable evidence or a declared consumer requires it. When no machine
-artifact was requested, do not create a hidden one.
-
-## Prompt
-
-```text
-Use rpi to finish this accepted change within its scope and remaining deadline.
-Repair understood failures directly. If an assumption fails, revise the approach
-without changing acceptance. Run required checks and obtain fresh final Validate.
-Use Memory only if an applicable prior constraint would change the next action.
-```
-
-## It's working if
-
-A clear small edit reaches checks without planning or memory paperwork; an
-understood test failure is fixed directly; a disproved assumption changes the
-approach; an unknown recurring failure gets no helper chain; the final exact
-subject receives fresh author-distinct judgment and the report states any gap.
-
-The grandfathered developer-only Python reference is an optional fixed-dispatch
-adapter with explicit repair rounds, not the native charter's execution engine.
-Its narrower [adapter contract](references/bounded-adapter.md) and tests remain
-available without adding a runtime, command, scheduler or mandatory worksheet.
+Report the result, strongest checks and material limits. Plans, activity,
+reviews and saved pages earn no capability credit; NOT_PLANNED and NOT_BUILT
+are progress descriptions, not semantic verdicts.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -32,183 +32,90 @@ output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_
 
 # Validate
 
-Independently judge one exact subject against the acceptance in its existing
-bead or caller source, return one semantic result, and stop. Validate is the
-sole semantic author of `verdict.v2` when persistence is requested.
-`ao provenance store-verdict` supplies structural verification and atomic storage. Before the verdict,
-read `boundaries.md` in the rpi skill's `references` directory for the state
-Validate leaves to the caller.
+Freshly judge the exact candidate against accepted intent, return PASS, FAIL or
+NOT_PROVEN, and stop. The author cannot provide binding PASS. Read RPI
+[boundaries](../rpi/references/boundaries.md) before judgment; load helper flags
+and storage details from [mechanics](references/mechanics.md) when needed.
 
-## Prompt
+## Preconditions and freshness
 
-```text
-Validate bead ag-1234 in this fresh context. Intent: the bead text and digest.
-Subject: manifest.json from:
-ao provenance manifest --root . --include cli/internal/gates
-Author context ctx-a1. Re-run `cd cli && go test ./internal/gates/...`.
-Return PASS, FAIL, or NOT_PROVEN with evidence; stop.
-```
+Final review starts after required checks and known repairs, with the candidate
+held unchanged. Supplied failed-acceptance evidence means FAIL on that subject;
+do not review a moving repair. The subject manifest is nonempty; plans, audits
+and reviews are subjects only when the caller requested document review.
 
-## Preconditions
+Use exact caller/runtime-owned intent bytes and derived acceptance identity.
+Author and validator context IDs must be explicit and distinct; freshness is
+attested by runtime or caller with the attester's identity. Missing, colliding
+or unattested identity means NOT_PROVEN, not proof of isolation by role name.
 
-- Final judgment starts after required checks and known repairs are complete,
-  over a subject the author keeps unchanged during review. If supplied checks
-  already prove failed acceptance, return FAIL on that subject; do not wait
-  while the author repairs it inside the same review.
-- The subject is a nonempty implementation candidate: the manifest lists at
-  least one entry. Plans, audits, and reviews are subjects only when the
-  caller explicitly requested document review.
-- The intent source is a caller-owned artifact or a runtime-owned
-  content-addressed snapshot; its acceptance digest is derived automatically.
-- Author and validator context IDs are explicit, and freshness is attested
-  with `source: runtime | caller` and an attester identity. Missing,
-  colliding, or unattested identities produce `NOT_PROVEN`: a declared trust
-  fact, not cryptographic proof of isolation.
+Default to one fresh reviewer in the author's model family: Codex/OpenAI for
+Codex/OpenAI, Claude/Anthropic for Claude/Anthropic. Use the runtime's configured
+capable model unless pinned. A new role in the author's context is not fresh.
+Supply task-specific intent, scope, exact subject and relevant evidence, without
+full author history, desired verdict or peer conclusions. Retrieve more source
+when a criterion requires it; concise input must not omit necessary evidence.
 
-## Fresh validator and model selection
+Cross-model review is opt-in. `--cross-model [model]` is a skill prompt selection,
+not an AO flag; it adds a fresh other-family reviewer. Required legs remain
+required: unavailable diversity yields `diversity_unsatisfied` and NOT_PROVEN
+for the combined request, even if another leg passed. Preserve delivered FAILs
+and dissent; neither voting nor model preference makes a split PASS. Optional
+unavailable diversity stays disclosed without erasing findings. Exact invocation,
+authorization, runtime identity and independent-input rules live in
+[model-dispatch](../agent-native/references/model-dispatch.md). No fixed
+ten-minute cap applies; respect real caller/native bounds without renewing them.
+A timeout is missing judgment, not FAIL. Shared-family or cross-family agreement
+alone is not truth or proof of freedom from training bias.
 
-Default to one fresh, author-distinct validator from the author's model family:
-Codex/OpenAI work uses a fresh Codex/OpenAI reviewer; Claude/Anthropic work uses
-a fresh Claude/Anthropic reviewer. Use the runtime's configured capable model
-unless the caller pins one. Fresh context is required even when model weights
-are identical; a new role instruction in the author's session is not fresh.
-Risk determines the depth of evidence inspection, not an automatic second family.
+## Judgment
 
-Acceptance, tests/gates, stopping, allowances, safety, disclosure, hooks and
-executable controls warrant deeper checks, including policy written as prose.
-Conservative risk cues include `cli/internal/gates/**`, `scripts/check-*.sh`,
-`tests/**`, `skills/*/scripts/**`, `skills/cc-hooks/policies/**`, `lib/**`,
-`.github/workflows/**` and `scripts/security-gate.sh`. Unknown risk receives
-deeper inspection; it does not silently change the selected model families.
+1. Derive `subject-manifest.v1` using the existing helper at start and end.
+   A mismatch means mutation and NOT_PROVEN. Verify exact intent continuity,
+   cited evidence digests and complete changed-path coverage; missing integrity
+   is NOT_PROVEN. Proven out-of-scope change is FAIL.
+2. Inspect the actual diff against every acceptance criterion. Risk determines
+   depth: acceptance, permissions, tests/gates, stopping, disclosure, hooks and
+   executable controls warrant deeper inspection, including prose policy.
+   Unknown risk merits examination, not automatic extra reviewers.
+3. Re-execute discriminating proofs for risk-critical, uncertain or thinly
+   evidenced claims. Valid digest-bound receipts may establish routine facts;
+   do not replay every author command or full suite merely because this is a
+   fresh context. The repository's required integration checks still run on
+   the final subject. A changed subject needs new judgment and affected checks.
+4. Classify commands before executing them. Regeneration, synchronization,
+   formatting and `--force` are subject-mutating until proven otherwise; run
+   them only on a disposable copy or a committed subject, never an uncommitted
+   judged tree. Do not overwrite the candidate while validating it.
+5. Reject green obtained through weaker assertions, tolerances, goldens,
+   suppressions or acceptance edits. Each criterion needs supporting evidence;
+   explanation alone is not proof. A necessary finding cannot become an
+   optional caveat or non-goal. Publication/provenance claims in docs also need
+   verifiable evidence.
+6. Return one result with criterion-level evidence, findings, checked scope,
+   `not_checked`, author/judge identities and contexts, and the freshness
+   attestation. PASS requires all criteria verified, nonempty checked scope and
+   top-level evidence, and empty `not_checked`. An unverified criterion means
+   NOT_PROVEN; proven failed acceptance or scope violation means FAIL.
 
-The caller can request `--cross-model` or say "cross-model review" to add one
-fresh validator from a different family. `--cross-model <model>` pins that
-additional reviewer, for example `--cross-model claude-fable-5-1` from Codex
-or `--cross-model gpt-6-astra` from Claude. These are skill prompt options,
-not `ao` CLI flags. RPI forwards them unchanged. Without a pin, use an available,
-authorized capable model from the other family; never silently substitute for
-a pinned model or count two models in one family as cross-family diversity.
-An explicit caller requirement remains required until the caller changes it;
-changing the default cannot erase a finding or relabel a missing verdict as PASS.
+## Findings and report
 
-Route selection and invocation through
-[agent-native model-dispatch](../agent-native/references/model-dispatch.md);
-[references/mechanics.md](references/mechanics.md) owns evidence storage.
-There is no fixed ten-minute review timeout. Use the caller's selected review
-timeout or remaining native deadline, respecting any earlier host or goal limit.
-A timeout is missing judgment, not FAIL; never restart to renew an allowance.
+`not_checked` means in-scope acceptance that was not verified. Other limits
+remain in criterion reasoning, declared non-goals or residual-risk prose; never
+hide or delete them to obtain PASS. Keep prior findings visible. For each new
+finding, name a short stable nonempty `class` describing the defect, reused on
+recurrence, and distinguish pre-existing, introduced or unknown cause using
+before/after or equivalent causal evidence. Counts and timestamps alone do not
+establish cause. Known findings return to direct repair; causal stalls use the
+RPI single-helper rule, not repairs delegated to this validator.
 
-Each selected judge receives the exact subject, unchanged acceptance and
-authorized evidence independently, without the author's desired verdict or peer
-conclusions. Record actual model/context identities and runtime receipts.
-Missing freshness, an unbound subject, incomplete acceptance evidence, or
-nonempty `not_checked` prevents PASS regardless of model family.
-With no authorized adapter for requested diversity, disclose
-`diversity_unsatisfied`: the required combined result is `NOT_PROVEN` even if
-the same-family judge passed. A delivered FAIL stands. Advisory diversity that
-the caller explicitly made optional may accompany the same-family result with
-that limitation; it cannot discard an acceptance-relevant finding.
+Keep the report proportional: cite existing receipts and include only excerpts
+needed to assess a finding. Do not retell the investigation or duplicate logs.
+Brevity must retain every criterion, necessary finding, identity, freshness
+fact and unchecked surface.
 
-When selected judges disagree, preserve both verdicts and their evidence.
-Required diversity converges only when both pass; neither majority vote nor a
-preferred judge settles a split. Repair addresses known findings directly under RPI and real caller/native
-bounds. Report unresolved dissent and the caller's decision openly.
-Same-family fresh judgment reduces anchoring, but does not prove independence
-from shared training biases; cross-family agreement is corroboration, not truth.
-
-## Mutating-check quarantine
-
-Classify every acceptance-listed command as read-only or subject-mutating
-before running it: regen scripts, sync scripts, formatters, and anything with
-`--force` are mutating until proven otherwise. Run a mutating check only
-against a disposable copy or a committed subject, never the judged working
-tree (the boundaries appendix records the regen that overwrote a subject).
-
-## Scope disclosure
-
-`not_checked` has exactly one meaning: **in-scope acceptance surface this
-validation did not verify**. PASS asserts the whole declared acceptance
-surface was verified, so a PASS carries no `not_checked` entries; every other
-scope limit has a home that survives inside a PASS: a bounded proof in
-`criteria[].reason`, a declared non-goal in the intent source, residual risk
-in the report (table in the mechanics reference). Emptying `not_checked` to
-obtain PASS is a contract violation: unverified acceptance makes the honest
-result `NOT_PROVEN`, and an entry that was never acceptance moves to its home
-and stays visible. A finding necessary to acceptance cannot be relabeled as
-optional, residual risk, or a non-goal to obtain PASS.
-
-## Workflow
-
-1. Derive `subject-manifest.v1` with the helper's `manifest` command (flags
-   in the mechanics reference) at the start and again at the end; any
-   mismatch is subject mutation and returns `NOT_PROVEN`.
-2. Confirm the intent-source digest is unchanged since implementation, every
-   cited evidence digest matches the artifact it names, and complete
-   changed-path coverage can be derived; otherwise `NOT_PROVEN`.
-3. Adjudicate the actual diff: runtime-derived changed paths against the
-   intent's scope classes. A proven out-of-scope path is `FAIL`; incomplete
-   scope evidence is `NOT_PROVEN`.
-4. Inspect the exact subject and evidence. Reported exit codes are claims:
-   re-execute the proofs that bear on acceptance. A changed test, gate,
-   fixture, golden, tolerance, suppression, or acceptance source must be
-   required by the original intent, with green coming from implemented
-   behavior; green obtained by weakening acceptance is `FAIL`. Judge every
-   acceptance criterion against its own evidence reference; a criterion with
-   no evidence of its own is unverified, not passed.
-5. Choose exactly one semantic result: `PASS`, `FAIL`, or `NOT_PROVEN`. Return
-   it with criterion-level results, findings, evidence references, `checked`,
-   `not_checked`, both identities, both context IDs, and the freshness
-   attestation. Name a `class` for each finding: one short stable name for the
-   kind of defect, one per finding, reused word for word when the same kind
-   recurs, so the orchestrator can see a closed kind come back. Explain in the
-   existing summary and evidence whether a newly exposed defect pre-existed the
-   change, was introduced by it, or has unknown cause. Use before/after proof or
-   equivalent causal evidence under unchanged acceptance; counts and timestamps
-   do not establish cause. Recurrence calls for causal examination and does not
-   by itself prove a design failure. Known defects return to direct repair;
-   unknown cause, recurrence or no progress uses the charter's single bounded
-   helper rule, without delegating repairs to this validator. Name the class or omit it; a `class` that is
-   present and blank is a finding against this validator,
-   and so is a class that does not describe its finding. PASS
-   requires distinct identities, explicit freshness, nonempty checked scope,
-   nonempty top-level evidence, evidence for every criterion, and an empty
-   `not_checked`. A documentation sentence claiming something is published,
-   pinned, or proven is an acceptance criterion like any other: it needs a
-   check this validator can run, or it is `not_checked`. The
-   `docs.claims-tracked` gate covers the tracked-file half of that and nothing
-   more.
-6. Only when the caller requests machine-readable evidence or a declared
-   downstream consumer requires it, persist canonical `verdict.v2` with the
-   helper's `store-verdict` (mechanics reference), then return the artifact
-   path and digest with the result. Stop.
-
-Keep the judgment proportional to the change. Cite existing receipts instead of
-repeating their history; brevity must preserve every criterion, necessary
-finding, identity, freshness fact and unchecked acceptance surface.
-
-Fresh validation is independent judgment over the exact subject, not a replay
-of every author command: rerun the risk-critical, uncertain, or thinly
-evidenced checks; a digest-bound deterministic receipt may prove routine
-facts; replay an expensive full suite only when acceptance requires it. The
-repository's full literal CI command set, as quoted in `AGENTS.md`, runs
-once, on the final integrated subject.
-
-## It's working if
-
-Observable in the trace, without reading the prose, and the rubric a fresh
-independent judge scores this skill against:
-
-- A criterion whose evidence is a justification rather than a proof is named,
-  and the result is `NOT_PROVEN` rather than `PASS`.
-- Green obtained by widening a tolerance, skipping a case, or re-baselining a
-  budget is reported as `FAIL`, never as completion.
-- Every scope limit is placed in one of the Scope-disclosure homes; none was
-  deleted to reach `PASS`.
-- The subject manifest is derived twice, at the start and at the end, and the
-  two are compared.
-
-## Boundary
-
-Validate emits no next action, repair, retry, replan, or delivery state (full
-list in the boundaries reference); ledger availability cannot change a
-verdict's validity.
+Only when requested or required by a declared consumer, persist `verdict.v2`
+through `ao provenance store-verdict`. Validate supplies semantic judgment;
+Go verifies structure and storage, not truth. Otherwise return the result
+through the existing caller channel without hidden machine artifacts.
+Validate owns no repair, retry, delivery or tracker transition.

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -70,6 +70,12 @@ alone is not truth or proof of freedom from training bias.
 
 ## Judgment
 
+Use the helper for each changed path (repeat `--include` for complete scope):
+
+```sh
+ao provenance manifest --root "$REPO_ROOT" --include "$CHANGED_PATH"
+```
+
 1. Derive `subject-manifest.v1` using the existing helper at start and end.
    A mismatch means mutation and NOT_PROVEN. Verify exact intent continuity,
    cited evidence digests and complete changed-path coverage; missing integrity

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -32,8 +32,8 @@ output_contract: 'PASS | FAIL | NOT_PROVEN with criteria, evidence, checked/not_
 
 # Validate
 
-Freshly judge the exact candidate against accepted intent, return PASS, FAIL or
-NOT_PROVEN, and stop. The author cannot provide binding PASS. Read RPI
+Freshly judge the exact candidate against accepted intent, return
+`PASS`, `FAIL`, or `NOT_PROVEN`, and stop. The author cannot provide binding PASS. Read RPI
 [boundaries](../rpi/references/boundaries.md) before judgment; load helper flags
 and storage details from [mechanics](references/mechanics.md) when needed.
 
@@ -41,7 +41,7 @@ and storage details from [mechanics](references/mechanics.md) when needed.
 
 Final review starts after required checks and known repairs, with the candidate
 held unchanged. Supplied failed-acceptance evidence means FAIL on that subject;
-do not review a moving repair. The subject manifest is nonempty; plans, audits
+do not review a moving repair. The subject is a nonempty implementation candidate; plans, audits
 and reviews are subjects only when the caller requested document review.
 
 Use exact caller/runtime-owned intent bytes and derived acceptance identity.
@@ -114,8 +114,9 @@ needed to assess a finding. Do not retell the investigation or duplicate logs.
 Brevity must retain every criterion, necessary finding, identity, freshness
 fact and unchecked surface.
 
-Only when requested or required by a declared consumer, persist `verdict.v2`
-through `ao provenance store-verdict`. Validate supplies semantic judgment;
+Validate is the sole semantic author of `verdict.v2`.
+Only when the caller requests machine-readable evidence or a declared consumer
+requires it, persist through `ao provenance store-verdict`. Validate supplies judgment;
 Go verifies structure and storage, not truth. Otherwise return the result
 through the existing caller channel without hidden machine artifacts.
 Validate owns no repair, retry, delivery or tracker transition.


### PR DESCRIPTION
The core skills repeated context, bookkeeping and review instructions, and Implement required verbatim check output in handoffs. That encouraged unnecessary reading and repeated logs during longer work.

This change simplifies RPI, Plan, Implement and Validate and regenerates their Codex/Gemini projections. It asks agents to resolve consequential uncertainty, use task-specific context and evidence references, repair known failures directly, and stop at accepted completion. Exact intent/subject identity, required checks, scope disclosure, author-distinct freshness and independent final judgment remain required. Optional mechanics stay in existing references.

The four canonical files shrink from 4,102 to 2,740 whitespace-delimited words (about 33%). That measures source length, not proven savings in task tokens or cost. No CLI, CI or Makefile behavior changes.

Validation: the final full Bats suite, aggregate runner, regeneration checks, applicable gates and all required CI checks pass. Fresh author-distinct review passed every criterion and all 17 changed paths with no unchecked acceptance. Five failure-based reasoning scenarios preserved direct implementation, compact evidence handoff, direct repair, refusal to excuse failed acceptance, and respect for skills-only scope. These scenarios judge the guidance; they are not live runtime cost measurements. The initial rewrite broke existing literal contract-sentence and documented-invocation checks; the checked wording was restored, preserving the tests and the failure history.
