### PR TITLE
Find component-owned checks before implementation edits

### DIFF
--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -41,7 +41,9 @@ owns source changes and factual checks; the runtime derives identity and receipt
    stay explicit; do not invent parentage or a second tracker. The optional
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
-2. Run the first useful acceptance check. Behavioral changes preserve RED for
+2. Find nearby validation scripts and tests that consume the edited paths or
+   contract wording. Run the smallest applicable existing check before editing
+   and after the change. Behavioral changes preserve RED for
    the expected missing behavior; a pure refactor, relocation or documentation
    change may have an honest green baseline. Avoid building elaborate fixtures
    when an existing test or small discriminating probe answers the question.

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "6f62d8d6ccbaf2f03c4158607ef43ef0c00ac020fc7652125184ac726db3d732",
-      "generated_hash": "98fe63ece2adc8084e724f9fe54e72d3a4829d40903f0b0aab28ce73ac28090c"
+      "source_hash": "9f23e9a25fce5f74c0a12d6196e0cc0fda580e90f2d9ed92af7eccdc8f755690",
+      "generated_hash": "395cfbaac7a093dfedfe1ecdc9ca4083db39c4249f2f35fd44ff6d28f2cbda99"
     },
     {
       "name": "learn",

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "6f62d8d6ccbaf2f03c4158607ef43ef0c00ac020fc7652125184ac726db3d732",
-  "generated_hash": "98fe63ece2adc8084e724f9fe54e72d3a4829d40903f0b0aab28ce73ac28090c"
+  "source_hash": "9f23e9a25fce5f74c0a12d6196e0cc0fda580e90f2d9ed92af7eccdc8f755690",
+  "generated_hash": "395cfbaac7a093dfedfe1ecdc9ca4083db39c4249f2f35fd44ff6d28f2cbda99"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -18,7 +18,9 @@ owns source changes and factual checks; the runtime derives identity and receipt
    stay explicit; do not invent parentage or a second tracker. The optional
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
-2. Run the first useful acceptance check. Behavioral changes preserve RED for
+2. Find nearby validation scripts and tests that consume the edited paths or
+   contract wording. Run the smallest applicable existing check before editing
+   and after the change. Behavioral changes preserve RED for
    the expected missing behavior; a pure refactor, relocation or documentation
    change may have an honest green baseline. Avoid building elaborate fixtures
    when an existing test or small discriminating probe answers the question.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -41,7 +41,9 @@ owns source changes and factual checks; the runtime derives identity and receipt
    stay explicit; do not invent parentage or a second tracker. The optional
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
-2. Run the first useful acceptance check. Behavioral changes preserve RED for
+2. Find nearby validation scripts and tests that consume the edited paths or
+   contract wording. Run the smallest applicable existing check before editing
+   and after the change. Behavioral changes preserve RED for
    the expected missing behavior; a pure refactor, relocation or documentation
    change may have an honest green baseline. Avoid building elaborate fixtures
    when an existing test or small discriminating probe answers the question.


### PR DESCRIPTION
Implement previously told workers to choose a useful first check without explicitly finding the edited component's own validators or test consumers. During the preceding skill rewrite, the component validators were discovered only after the full integration suite reported contract-wording failures.

The skill now directs workers to find nearby validation scripts and tests consuming edited paths or contract wording, and run the smallest applicable existing check before and after editing. Required integration checks, RED/green baseline distinctions, acceptance and fresh final validation remain intact. Only Implement and its generated companions change.

Validation: the unchanged component validator passes on the original and edited skills, and rejects a controlled missing-contract fixture in under 0.02 seconds on the local host. This demonstrates the check's usefulness, not guaranteed future agent behavior or token savings. The aggregate runner, regeneration check, applicable gates, full CI (including Linux Bats) and fresh independent final review passed. The reviewer independently replayed the 0/1/0 probes, verified all five changed paths and found no unchecked acceptance.
