### PR TITLE
Tighten RPI handoffs and exercise them on a Go gate repair

### DIFF
--- a/cli/internal/gates/checks/native_inline.go
+++ b/cli/internal/gates/checks/native_inline.go
@@ -141,7 +141,10 @@ func runLearningCoherence(ctx context.Context, rc gates.RunContext) (ports.GateV
 		}
 		data, err := os.ReadFile(filepath.Join(rc.RepoRoot, f))
 		if err != nil {
-			continue // deleted
+			if os.IsNotExist(err) {
+				continue // deleted
+			}
+			return ports.GateVerdict{Status: ports.GateStatusFail, Reason: fmt.Sprintf("read learning %s: %v", f, err)}, nil
 		}
 		if !bytes.HasPrefix(data, []byte("---")) {
 			missing = append(missing, f)

--- a/cli/internal/gates/checks/native_inline_test.go
+++ b/cli/internal/gates/checks/native_inline_test.go
@@ -182,6 +182,51 @@ func TestRunLearningCoherence_ChecksCanonicalAoRoot(t *testing.T) {
 	}
 }
 
+func TestRunLearningCoherence_ReadFailureBlocks(t *testing.T) {
+	check, ok := gates.Default.Get("learning.coherence")
+	if !ok {
+		t.Fatal("learning.coherence is not registered")
+	}
+	for _, rel := range []string{".agents/ao/learnings/bad.md", ".agents/learnings/bad.md"} {
+		t.Run(rel, func(t *testing.T) {
+			root := t.TempDir()
+			// A directory reliably makes ReadFile fail without permission assumptions.
+			if err := os.MkdirAll(filepath.Join(root, rel), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			verdict, err := runLearningCoherence(context.Background(), gates.RunContext{
+				RepoRoot: root, Mode: gates.Fast, ChangedFiles: []string{rel},
+			})
+			if err != nil {
+				t.Fatalf("runLearningCoherence: %v", err)
+			}
+			if verdict.Status != ports.GateStatusFail {
+				t.Fatalf("status = %s, want FAIL for unreadable learning %q", verdict.Status, rel)
+			}
+			if !strings.Contains(verdict.Reason, rel) {
+				t.Fatalf("reason = %q, want unreadable learning path %q", verdict.Reason, rel)
+			}
+			report := gates.Report{Results: []gates.CheckResult{{Check: check, Verdict: verdict}}}
+			if got := report.ExitCode(); got != 1 {
+				t.Fatalf("Report.ExitCode() = %d, want 1 for unreadable learning", got)
+			}
+		})
+	}
+}
+
+func TestRunLearningCoherence_DeletedFileSkipped(t *testing.T) {
+	for _, rel := range []string{".agents/ao/learnings/deleted.md", ".agents/learnings/deleted.md"} {
+		t.Run(rel, func(t *testing.T) {
+			verdict, err := runLearningCoherence(context.Background(), gates.RunContext{
+				RepoRoot: t.TempDir(), Mode: gates.Fast, ChangedFiles: []string{rel},
+			})
+			if err != nil || verdict.Status != ports.GateStatusPass {
+				t.Fatalf("deleted learning = %+v, error = %v; want PASS", verdict, err)
+			}
+		})
+	}
+}
+
 // equalSetChecks reports whether a and b hold the same elements (order-independent).
 func equalSetChecks(a, b []string) bool {
 	if len(a) != len(b) {

--- a/docs/architecture/ports-and-adapters.md
+++ b/docs/architecture/ports-and-adapters.md
@@ -10,7 +10,7 @@ The core has four ports:
 | Port | Input | Output |
 |---|---|---|
 | Plan | Existing bead or caller intent | Same source refined in place, or a concise proposed amendment |
-| Implement | Resolved intent | Runtime-derived subject manifest and check receipts, or `NOT_BUILT` |
+| Implement | Resolved intent | Runtime-derived content identity and check facts; subject manifest at the judgment boundary, or `NOT_BUILT` |
 | Validate | Intent digest, exact subject, receipts, independent context identity | `PASS | FAIL | NOT_PROVEN`; optional `verdict.v2` |
 | Report | Phase outputs | Interactive result; optional `rpi-report.v1` |
 

--- a/docs/architecture/rpi-traversal.md
+++ b/docs/architecture/rpi-traversal.md
@@ -44,12 +44,19 @@ it. Run repository-required integration checks at the final integration boundary
 Valid exact-input receipts can establish routine facts; do not replay an expensive
 suite without an acceptance need, relevant new change or unresolved concern.
 
-The runtime derives actual changed paths, author context and `subject-manifest.v1`.
+The runtime derives actual changed paths, author context and content identity.
+A delegated increment awaiting integration supplies an exact commit or
+runtime-derived content digests with its check facts in the native handoff.
+The integrating caller derives `subject-manifest.v1` over the complete final
+subject before judgment. A separately judged increment requires its own
+manifest; delegation alone does not require duplicate evidence bundles.
 Where changed paths affect bound acceptance evidence, run
 `ao provenance evidence-orphans --root <repo-root>` with one `--changed <path>`
 per actual changed path and preserve its JSON receipt. Exit 0 means the scan
 completed, not that no orphan exists; exit 2 is incomplete. Recapture affected
 required evidence and refresh the receipt when repairs affect those bindings.
+This scan belongs to the same integration/judgment boundary; consolidating it
+does not omit any changed path, affected binding or required final check.
 
 `subject-manifest.v1` contains normalized relative paths, file/symlink/deletion
 kinds, executable bits, content/target digests, declared roots and exclusions,

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -9,7 +9,7 @@ hexagonal_role: driving-adapter
 consumes: []
 produces:
 - subject-manifest.v1
-output_contract: 'subject-manifest.v1 digest, author context ID, and exact acceptance-check receipts returned through the response or runtime channel'
+output_contract: 'content identity, author context ID and check facts through the native handoff; subject-manifest.v1 at the judgment boundary'
 context_rel:
 - kind: customer-of
   with: plan
@@ -42,33 +42,44 @@ owns source changes and factual checks; the runtime derives identity and receipt
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
 2. Find nearby validation scripts and tests that consume the edited paths or
-   contract wording. Run the smallest applicable existing check before editing
-   and after the change. Behavioral changes preserve RED for
+   contract wording. Keep their exact commands and the required integration
+   recipe in one short check list in the existing handoff; reuse it, updating
+   only when inputs or scope change. Run the smallest applicable check before
+   editing and after the change. Behavioral changes preserve RED for
    the expected missing behavior; a pure refactor, relocation or documentation
    change may have an honest green baseline. Avoid building elaborate fixtures
    when an existing test or small discriminating probe answers the question.
-3. Make the smallest in-scope change. Fix known failures directly, then rerun
-   the affected check. A disproved assumption may change the approach within
-   accepted outcome and scope; use Plan only for consequential uncertainty.
+3. Make the smallest in-scope change. When repairing discovery or checks,
+   preserve the consumer's existing input selection; fixing an error path does
+   not authorize a wider scan. Use a negative control when exclusion matters.
+   Fix known failures directly and rerun the affected check. A disproved
+   assumption may change the approach within accepted scope; use Plan only
+   for consequential uncertainty.
 4. Use targeted tests and applicable repository lint/static checks before
    broad integration. Read the repository's actual check recipe, including
    instrumentation and environment, rather than reconstructing it from memory.
    Run required full checks at integration, not after each small edit. Reuse
    exact-input receipts only while source, tool and relevant environment match.
+   Distinguish repository-mandated hook checks from discretionary repeats;
+   neither bypass required hooks nor replay a check just to rename its receipt.
 5. Refactor while acceptance remains green. Inspect changed tests, fixtures,
    goldens, tolerances, suppressions and specification text against original
    intent. Mocks, placeholders or weakened oracles cannot substitute for the
    requested behavior.
-6. Have the runtime derive actual changed paths and `subject-manifest.v1`. When changed paths
-   affect bound acceptance evidence, run `ao provenance evidence-orphans --root
-   <repo-root>` with one `--changed <path>` per derived path, and retain the
-   actual output for the validator. Repeat after repairs that change that
-   subject; do not hand-invent an orphan list.
-7. Return the manifest digest, author context ID, acceptance-check facts and
-   evidence references through the caller's response/runtime channel, then stop.
-   Include command, result and decision-relevant failures. Keep full output
-   accessible instead of pasting successful logs or repeated receipt inventories
-   into every handoff. Missing or truncated evidence must remain visible.
+6. Have the runtime derive actual changed paths and content identity. A delegated
+   increment awaiting integration returns an exact commit or runtime-derived
+   content digests, author context ID and check facts in the existing handoff.
+   The integrating caller derives `subject-manifest.v1` over the complete final
+   subject before judgment; an independently judged increment needs its own
+   manifest. Do not generate both merely because work was delegated.
+   At that boundary, when changed paths affect bound acceptance evidence, run
+   `ao provenance evidence-orphans --root <repo-root>` with one `--changed
+   <path>` per derived path and retain its actual output. Refresh affected
+   bindings after repairs; never invent or suppress the orphan list.
+7. Return identity, check commands/results, useful failures and accessible
+   evidence references through the native handoff, then stop. Full logs stay
+   at their source; do not copy them into another inventory or status document.
+   Missing or truncated evidence stays explicit.
 
 ## Scope and finish
 

--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -68,23 +68,26 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
 ## Context and handoffs
 
-Load required contracts once per context, then inspect the source or evidence
-needed for the next decision. A reference link is available context, not a
-reading list. Search before opening large files; retrieve relevant sections
-and expand when uncertainty requires it. Do not reread unchanged material or
-copy full logs into successive tool results and handoffs.
+Load required contracts once per context, then read only what the next decision
+needs. A reference link is available context, not a reading list. Search before
+opening large files; expand only for consequential uncertainty. Keep successful
+output compact at the tool boundary; retain full logs for inspection. Reuse the
+worker's component-check list and current receipts instead of rediscovering them.
 
-When delegation is authorized and useful, give each worker task-specific
-context: accepted intent and scope, exact subject, relevant evidence, remaining
-bounds and the requested result. Prefer a new task-only context for an
-independent subtask; resume the original worker for a direct repair when useful.
-Validators always receive fresh context, without the author's desired verdict.
-Use observed runtime capabilities; prompt wording does not prove isolation.
+When delegation is authorized and useful, select the runtime's task-only
+dispatch option for independent work; a short prompt in a full-history fork
+still carries full history. Supply accepted intent/scope, exact subject,
+relevant evidence, remaining bounds, result consumer and check ownership.
+Resume an author for direct repair when useful. Validators always receive fresh
+context without the author's desired verdict. Observe actual dispatch settings;
+prompt wording proves neither isolation nor smaller inherited context.
 
-Return concise findings, check facts and accessible evidence references. Keep
-full logs available, showing only decision-relevant excerpts; disclose truncation
-or missing evidence. Reuse one caller-owned handoff instead of multiplying
-plans, receipt summaries and status documents. Machine evidence such as `verdict.v2` is optional
+Return concise findings, check facts and evidence references in the existing
+handoff; disclose missing or truncated evidence. Derive the combined subject's
+manifest and applicable orphan scan at the integration/judgment boundary.
+Unjudged worker increments supply content identity and check facts, not duplicate
+final evidence bundles. A separately judged subject still needs complete proof.
+Machine evidence such as `verdict.v2` is optional
 unless requested or required by a declared consumer. When no machine
 artifact is requested or required, return the result without creating one.
 

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -501,8 +501,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "9f23e9a25fce5f74c0a12d6196e0cc0fda580e90f2d9ed92af7eccdc8f755690",
-      "generated_hash": "395cfbaac7a093dfedfe1ecdc9ca4083db39c4249f2f35fd44ff6d28f2cbda99"
+      "source_hash": "3595c7401ac6fc8c1de10d92799124897870f829bcae385a5a2aca06130ad7e3",
+      "generated_hash": "913621062d45dee471648a7946f235d6dad50e9b95219c037ac1817434a57872"
     },
     {
       "name": "learn",
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "d56324d3257f0ee5619ab6675052faa5207747bf39e465aca0ff94621aef2f90",
-      "generated_hash": "98322805a85787c8b7cf6880f9ce756a8573a062dc9219ab12a7d895be7679db"
+      "source_hash": "fd5a6deaff8240607040c50e75958f4ea94c9ce11e73628cac29d0b73771c2b6",
+      "generated_hash": "fa475c8695a6116f245788325c0f3098a1b8ddf2d131637de65b2331dd937652"
     },
     {
       "name": "sbh",

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "9f23e9a25fce5f74c0a12d6196e0cc0fda580e90f2d9ed92af7eccdc8f755690",
-  "generated_hash": "395cfbaac7a093dfedfe1ecdc9ca4083db39c4249f2f35fd44ff6d28f2cbda99"
+  "source_hash": "3595c7401ac6fc8c1de10d92799124897870f829bcae385a5a2aca06130ad7e3",
+  "generated_hash": "913621062d45dee471648a7946f235d6dad50e9b95219c037ac1817434a57872"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -19,33 +19,44 @@ owns source changes and factual checks; the runtime derives identity and receipt
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
 2. Find nearby validation scripts and tests that consume the edited paths or
-   contract wording. Run the smallest applicable existing check before editing
-   and after the change. Behavioral changes preserve RED for
+   contract wording. Keep their exact commands and the required integration
+   recipe in one short check list in the existing handoff; reuse it, updating
+   only when inputs or scope change. Run the smallest applicable check before
+   editing and after the change. Behavioral changes preserve RED for
    the expected missing behavior; a pure refactor, relocation or documentation
    change may have an honest green baseline. Avoid building elaborate fixtures
    when an existing test or small discriminating probe answers the question.
-3. Make the smallest in-scope change. Fix known failures directly, then rerun
-   the affected check. A disproved assumption may change the approach within
-   accepted outcome and scope; use Plan only for consequential uncertainty.
+3. Make the smallest in-scope change. When repairing discovery or checks,
+   preserve the consumer's existing input selection; fixing an error path does
+   not authorize a wider scan. Use a negative control when exclusion matters.
+   Fix known failures directly and rerun the affected check. A disproved
+   assumption may change the approach within accepted scope; use Plan only
+   for consequential uncertainty.
 4. Use targeted tests and applicable repository lint/static checks before
    broad integration. Read the repository's actual check recipe, including
    instrumentation and environment, rather than reconstructing it from memory.
    Run required full checks at integration, not after each small edit. Reuse
    exact-input receipts only while source, tool and relevant environment match.
+   Distinguish repository-mandated hook checks from discretionary repeats;
+   neither bypass required hooks nor replay a check just to rename its receipt.
 5. Refactor while acceptance remains green. Inspect changed tests, fixtures,
    goldens, tolerances, suppressions and specification text against original
    intent. Mocks, placeholders or weakened oracles cannot substitute for the
    requested behavior.
-6. Have the runtime derive actual changed paths and `subject-manifest.v1`. When changed paths
-   affect bound acceptance evidence, run `ao provenance evidence-orphans --root
-   <repo-root>` with one `--changed <path>` per derived path, and retain the
-   actual output for the validator. Repeat after repairs that change that
-   subject; do not hand-invent an orphan list.
-7. Return the manifest digest, author context ID, acceptance-check facts and
-   evidence references through the caller's response/runtime channel, then stop.
-   Include command, result and decision-relevant failures. Keep full output
-   accessible instead of pasting successful logs or repeated receipt inventories
-   into every handoff. Missing or truncated evidence must remain visible.
+6. Have the runtime derive actual changed paths and content identity. A delegated
+   increment awaiting integration returns an exact commit or runtime-derived
+   content digests, author context ID and check facts in the existing handoff.
+   The integrating caller derives `subject-manifest.v1` over the complete final
+   subject before judgment; an independently judged increment needs its own
+   manifest. Do not generate both merely because work was delegated.
+   At that boundary, when changed paths affect bound acceptance evidence, run
+   `ao provenance evidence-orphans --root <repo-root>` with one `--changed
+   <path>` per derived path and retain its actual output. Refresh affected
+   bindings after repairs; never invent or suppress the orphan list.
+7. Return identity, check commands/results, useful failures and accessible
+   evidence references through the native handoff, then stop. Full logs stay
+   at their source; do not copy them into another inventory or status document.
+   Missing or truncated evidence stays explicit.
 
 ## Scope and finish
 

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "d56324d3257f0ee5619ab6675052faa5207747bf39e465aca0ff94621aef2f90",
-  "generated_hash": "98322805a85787c8b7cf6880f9ce756a8573a062dc9219ab12a7d895be7679db"
+  "source_hash": "fd5a6deaff8240607040c50e75958f4ea94c9ce11e73628cac29d0b73771c2b6",
+  "generated_hash": "fa475c8695a6116f245788325c0f3098a1b8ddf2d131637de65b2331dd937652"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -38,23 +38,26 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
 ## Context and handoffs
 
-Load required contracts once per context, then inspect the source or evidence
-needed for the next decision. A reference link is available context, not a
-reading list. Search before opening large files; retrieve relevant sections
-and expand when uncertainty requires it. Do not reread unchanged material or
-copy full logs into successive tool results and handoffs.
+Load required contracts once per context, then read only what the next decision
+needs. A reference link is available context, not a reading list. Search before
+opening large files; expand only for consequential uncertainty. Keep successful
+output compact at the tool boundary; retain full logs for inspection. Reuse the
+worker's component-check list and current receipts instead of rediscovering them.
 
-When delegation is authorized and useful, give each worker task-specific
-context: accepted intent and scope, exact subject, relevant evidence, remaining
-bounds and the requested result. Prefer a new task-only context for an
-independent subtask; resume the original worker for a direct repair when useful.
-Validators always receive fresh context, without the author's desired verdict.
-Use observed runtime capabilities; prompt wording does not prove isolation.
+When delegation is authorized and useful, select the runtime's task-only
+dispatch option for independent work; a short prompt in a full-history fork
+still carries full history. Supply accepted intent/scope, exact subject,
+relevant evidence, remaining bounds, result consumer and check ownership.
+Resume an author for direct repair when useful. Validators always receive fresh
+context without the author's desired verdict. Observe actual dispatch settings;
+prompt wording proves neither isolation nor smaller inherited context.
 
-Return concise findings, check facts and accessible evidence references. Keep
-full logs available, showing only decision-relevant excerpts; disclose truncation
-or missing evidence. Reuse one caller-owned handoff instead of multiplying
-plans, receipt summaries and status documents. Machine evidence such as `verdict.v2` is optional
+Return concise findings, check facts and evidence references in the existing
+handoff; disclose missing or truncated evidence. Derive the combined subject's
+manifest and applicable orphan scan at the integration/judgment boundary.
+Unjudged worker increments supply content identity and check facts, not duplicate
+final evidence bundles. A separately judged subject still needs complete proof.
+Machine evidence such as `verdict.v2` is optional
 unless requested or required by a declared consumer. When no machine
 artifact is requested or required, return the result without creating one.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -9,7 +9,7 @@ hexagonal_role: driving-adapter
 consumes: []
 produces:
 - subject-manifest.v1
-output_contract: 'subject-manifest.v1 digest, author context ID, and exact acceptance-check receipts returned through the response or runtime channel'
+output_contract: 'content identity, author context ID and check facts through the native handoff; subject-manifest.v1 at the judgment boundary'
 context_rel:
 - kind: customer-of
   with: plan
@@ -42,33 +42,44 @@ owns source changes and factual checks; the runtime derives identity and receipt
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
 2. Find nearby validation scripts and tests that consume the edited paths or
-   contract wording. Run the smallest applicable existing check before editing
-   and after the change. Behavioral changes preserve RED for
+   contract wording. Keep their exact commands and the required integration
+   recipe in one short check list in the existing handoff; reuse it, updating
+   only when inputs or scope change. Run the smallest applicable check before
+   editing and after the change. Behavioral changes preserve RED for
    the expected missing behavior; a pure refactor, relocation or documentation
    change may have an honest green baseline. Avoid building elaborate fixtures
    when an existing test or small discriminating probe answers the question.
-3. Make the smallest in-scope change. Fix known failures directly, then rerun
-   the affected check. A disproved assumption may change the approach within
-   accepted outcome and scope; use Plan only for consequential uncertainty.
+3. Make the smallest in-scope change. When repairing discovery or checks,
+   preserve the consumer's existing input selection; fixing an error path does
+   not authorize a wider scan. Use a negative control when exclusion matters.
+   Fix known failures directly and rerun the affected check. A disproved
+   assumption may change the approach within accepted scope; use Plan only
+   for consequential uncertainty.
 4. Use targeted tests and applicable repository lint/static checks before
    broad integration. Read the repository's actual check recipe, including
    instrumentation and environment, rather than reconstructing it from memory.
    Run required full checks at integration, not after each small edit. Reuse
    exact-input receipts only while source, tool and relevant environment match.
+   Distinguish repository-mandated hook checks from discretionary repeats;
+   neither bypass required hooks nor replay a check just to rename its receipt.
 5. Refactor while acceptance remains green. Inspect changed tests, fixtures,
    goldens, tolerances, suppressions and specification text against original
    intent. Mocks, placeholders or weakened oracles cannot substitute for the
    requested behavior.
-6. Have the runtime derive actual changed paths and `subject-manifest.v1`. When changed paths
-   affect bound acceptance evidence, run `ao provenance evidence-orphans --root
-   <repo-root>` with one `--changed <path>` per derived path, and retain the
-   actual output for the validator. Repeat after repairs that change that
-   subject; do not hand-invent an orphan list.
-7. Return the manifest digest, author context ID, acceptance-check facts and
-   evidence references through the caller's response/runtime channel, then stop.
-   Include command, result and decision-relevant failures. Keep full output
-   accessible instead of pasting successful logs or repeated receipt inventories
-   into every handoff. Missing or truncated evidence must remain visible.
+6. Have the runtime derive actual changed paths and content identity. A delegated
+   increment awaiting integration returns an exact commit or runtime-derived
+   content digests, author context ID and check facts in the existing handoff.
+   The integrating caller derives `subject-manifest.v1` over the complete final
+   subject before judgment; an independently judged increment needs its own
+   manifest. Do not generate both merely because work was delegated.
+   At that boundary, when changed paths affect bound acceptance evidence, run
+   `ao provenance evidence-orphans --root <repo-root>` with one `--changed
+   <path>` per derived path and retain its actual output. Refresh affected
+   bindings after repairs; never invent or suppress the orphan list.
+7. Return identity, check commands/results, useful failures and accessible
+   evidence references through the native handoff, then stop. Full logs stay
+   at their source; do not copy them into another inventory or status document.
+   Missing or truncated evidence stays explicit.
 
 ## Scope and finish
 

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -68,23 +68,26 @@ delivery. AgentOps supplies a small charter and fresh judgment, not a scheduler.
 
 ## Context and handoffs
 
-Load required contracts once per context, then inspect the source or evidence
-needed for the next decision. A reference link is available context, not a
-reading list. Search before opening large files; retrieve relevant sections
-and expand when uncertainty requires it. Do not reread unchanged material or
-copy full logs into successive tool results and handoffs.
+Load required contracts once per context, then read only what the next decision
+needs. A reference link is available context, not a reading list. Search before
+opening large files; expand only for consequential uncertainty. Keep successful
+output compact at the tool boundary; retain full logs for inspection. Reuse the
+worker's component-check list and current receipts instead of rediscovering them.
 
-When delegation is authorized and useful, give each worker task-specific
-context: accepted intent and scope, exact subject, relevant evidence, remaining
-bounds and the requested result. Prefer a new task-only context for an
-independent subtask; resume the original worker for a direct repair when useful.
-Validators always receive fresh context, without the author's desired verdict.
-Use observed runtime capabilities; prompt wording does not prove isolation.
+When delegation is authorized and useful, select the runtime's task-only
+dispatch option for independent work; a short prompt in a full-history fork
+still carries full history. Supply accepted intent/scope, exact subject,
+relevant evidence, remaining bounds, result consumer and check ownership.
+Resume an author for direct repair when useful. Validators always receive fresh
+context without the author's desired verdict. Observe actual dispatch settings;
+prompt wording proves neither isolation nor smaller inherited context.
 
-Return concise findings, check facts and accessible evidence references. Keep
-full logs available, showing only decision-relevant excerpts; disclose truncation
-or missing evidence. Reuse one caller-owned handoff instead of multiplying
-plans, receipt summaries and status documents. Machine evidence such as `verdict.v2` is optional
+Return concise findings, check facts and evidence references in the existing
+handoff; disclose missing or truncated evidence. Derive the combined subject's
+manifest and applicable orphan scan at the integration/judgment boundary.
+Unjudged worker increments supply content identity and check facts, not duplicate
+final evidence bundles. A separately judged subject still needs complete proof.
+Machine evidence such as `verdict.v2` is optional
 unless requested or required by a declared consumer. When no machine
 artifact is requested or required, return the result without creating one.
 


### PR DESCRIPTION
## What

Clarify the existing RPI and Implement skills so delegated work preserves consumer input selection, carries a short check list, uses task-only runtime dispatch, and leaves final subject evidence to the integrating caller. Exact identity, required checks, affected evidence handling, and fresh independent judgment remain required.

Exercise the revised guidance on one real Go defect: learning-file read errors now fail the gate with the affected path, while genuinely deleted files retain their existing skip behavior. Routing, learning roots, exclusions, and frontmatter rules are preserved.

## Why

The prior repair run finished successfully but repeatedly loaded context and assembled overlapping evidence. This change refines existing skill instructions and their architecture/projections, then tests observable behavior with a bounded coding task. It adds no scheduler, skill, schema, or benchmark framework; one trial does not establish general token savings.

## How I tested

- Existing skill contract checks pass before and after; generated projections are current.
- Go regression is RED for unreadable learning paths under both roots; repaired tests and deletion controls pass.
- Combined Go build/race-shuffle coverage tests, coverage floor, complexity, and local aggregate pass. Exact-source worker lint and hook vet results are reused.
- All 52 selected gates pass. Authoritative CI passed after one unchanged rerun of a timeout-test fixture failure; the original failure and uncertain cause remain retained. No test tolerance or source change was used to obtain green.
- Fresh author-distinct Codex/OpenAI validation passed every criterion and all 13 changed paths at `dd7714ea4eee2f6525656fb70c2ac8b264a39a03`; no actionable findings or unchecked acceptance.

## Checklist

- [x] Go build and tests pass
- [x] No secrets or credentials added
- [x] Changed skill output boundary documented in architecture and generated copies
