### PR TITLE
Evaluate installed skills on isolated Go work

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,6 +76,7 @@ jobs:
           filters: |
             go:
               - 'cli/**'
+              - 'evals/skills-rpi/**'
               - 'go.mod'
               - 'go.sum'
               - 'tests/windows/**'
@@ -309,6 +310,27 @@ jobs:
         with:
           go-version: '1.27.1'
           cache-dependency-path: cli/go.sum
+
+      - name: Set up isolated Python for evaluator integrity tests
+        if: runner.os == 'Linux' && (needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true')
+        id: eval-python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+          update-environment: false
+
+      - name: Calibrate skill evaluator without model calls
+        if: runner.os == 'Linux' && (needs.changes.outputs.go == 'true' || needs.changes.outputs.ci == 'true')
+        env:
+          EVAL_PYTHON: ${{ steps.eval-python.outputs.python-path }}
+        run: |
+          "$EVAL_PYTHON" -m venv "$RUNNER_TEMP/skill-eval-venv"
+          EVAL_PYTHON="$RUNNER_TEMP/skill-eval-venv/bin/python"
+          "$EVAL_PYTHON" -m pip install -r evals/skills-rpi/requirements.txt -r evals/skills-rpi/requirements-readout.txt pytest==8.4.2
+          "$EVAL_PYTHON" -m unittest discover -s evals/skills-rpi -p test_receipts.py -q
+          "$EVAL_PYTHON" -m unittest discover -s evals/skills-rpi/taskbank -p test_verify.py -q
+          "$EVAL_PYTHON" -m pytest -q evals/skills-rpi/test_readout.py evals/_stats
+          "$EVAL_PYTHON" evals/skills-rpi/taskbank/calibrate.py --output "$RUNNER_TEMP/skill-eval-calibration"
 
       # ── go-build (Linux) ──────────────────────────────────────────────────
       - name: Build ao CLI

--- a/cli/cmd/skill-trial-report/main.go
+++ b/cli/cmd/skill-trial-report/main.go
@@ -1,0 +1,60 @@
+// skill-trial-report is a development-only reader for native Harbor outputs.
+// Run from cli: go run ./cmd/skill-trial-report --job control=/path/to/job
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/skilltrial"
+)
+
+type values []string
+
+func (v *values) String() string         { return strings.Join(*v, ", ") }
+func (v *values) Set(value string) error { *v = append(*v, value); return nil }
+
+func run(args []string, out, stderr io.Writer) error {
+	flags := flag.NewFlagSet("skill-trial-report", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var jobs, sessions values
+	var reward string
+	flags.Var(&jobs, "job", "explicit [arm=]Harbor job directory (repeatable; arm is a caller label)")
+	flags.Var(&sessions, "session", "additional explicit native Codex JSONL file (repeatable; never scans operator home)")
+	flags.StringVar(&reward, "reward-key", "reward", "native verifier reward key; only 1 and 0 classify success and failure")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments; use --job or --session")
+	}
+	inputs := make([]skilltrial.JobInput, 0, len(jobs))
+	for _, value := range jobs {
+		arm, dir, ok := strings.Cut(value, "=")
+		if !ok {
+			dir, arm = arm, ""
+		}
+		if dir == "" {
+			return fmt.Errorf("job directory must not be empty")
+		}
+		inputs = append(inputs, skilltrial.JobInput{Arm: arm, Directory: dir})
+	}
+	report, err := skilltrial.Build(inputs, sessions, reward)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cli/cmd/skill-trial-report/main_test.go
+++ b/cli/cmd/skill-trial-report/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandRequiresExplicitInputsAndWritesJSON(t *testing.T) {
+	var out, stderr bytes.Buffer
+	if err := run(nil, &out, &stderr); err == nil {
+		t.Fatal("missing input accepted")
+	}
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"session_meta","payload":{"id":"native"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"--session", path}, &out, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"id": "native"`) || !strings.Contains(out.String(), `"usage": null`) {
+		t.Fatalf("output: %s", out.String())
+	}
+}

--- a/cli/internal/parser/codex_accounting.go
+++ b/cli/internal/parser/codex_accounting.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 // CodexUsage retains native inclusive input and nullable counters. Reasoning is
@@ -33,26 +34,36 @@ type CodexProviderError struct {
 	Message string `json:"message"`
 }
 
+// CodexInheritedHeader retains a corroborated parent header copied into a
+// child's rollout. Metadata does not establish inherited token attribution or
+// review freshness, so InheritedUsage remains unknown even when Usage is present.
+type CodexInheritedHeader struct {
+	Line           int             `json:"line"`
+	Metadata       json.RawMessage `json:"metadata"`
+	InheritedUsage *CodexUsage     `json:"inherited_usage"`
+}
+
 // CodexAccounting is a read-only view of one native rollout. Metadata and the
 // last cumulative payload are retained verbatim, including unrecognized fields.
 // Raw content for other events remains in the evidence file at the stated line.
 type CodexAccounting struct {
-	ID                string                 `json:"id"`
-	ParentID          string                 `json:"parent_id"`
-	Metadata          json.RawMessage        `json:"metadata"`
-	FirstTimestamp    string                 `json:"first_timestamp"`
-	LastTimestamp     string                 `json:"last_timestamp"`
-	LatestTurnState   string                 `json:"latest_turn_state"`
-	LatestTurnPayload json.RawMessage        `json:"latest_turn_payload"`
-	ProviderError     *CodexProviderError    `json:"provider_error"`
-	Usage             *CodexUsage            `json:"usage"`
-	UsagePayload      json.RawMessage        `json:"usage_payload"`
-	UsageLine         int                    `json:"usage_line"`
-	UsageTimestamp    string                 `json:"usage_timestamp"`
-	UsageEvents       int                    `json:"usage_events"`
-	Lines             int                    `json:"lines"`
-	Uninterpreted     map[string]int         `json:"uninterpreted_event_counts"`
-	Diagnostics       []AccountingDiagnostic `json:"diagnostics"`
+	ID                     string                 `json:"id"`
+	ParentID               string                 `json:"parent_id"`
+	Metadata               json.RawMessage        `json:"metadata"`
+	InheritedParentHeaders []CodexInheritedHeader `json:"inherited_parent_headers"`
+	FirstTimestamp         string                 `json:"first_timestamp"`
+	LastTimestamp          string                 `json:"last_timestamp"`
+	LatestTurnState        string                 `json:"latest_turn_state"`
+	LatestTurnPayload      json.RawMessage        `json:"latest_turn_payload"`
+	ProviderError          *CodexProviderError    `json:"provider_error"`
+	Usage                  *CodexUsage            `json:"usage"`
+	UsagePayload           json.RawMessage        `json:"usage_payload"`
+	UsageLine              int                    `json:"usage_line"`
+	UsageTimestamp         string                 `json:"usage_timestamp"`
+	UsageEvents            int                    `json:"usage_events"`
+	Lines                  int                    `json:"lines"`
+	Uninterpreted          map[string]int         `json:"uninterpreted_event_counts"`
+	Diagnostics            []AccountingDiagnostic `json:"diagnostics"`
 }
 
 // ParseCodexAccounting never sums cumulative events. Missing usage remains nil;
@@ -144,12 +155,57 @@ func (a *CodexAccounting) readMetadata(raw json.RawMessage) {
 	}
 	id := coalesce(meta.ID, meta.SessionID)
 	if a.ID != "" && a.ID != id {
+		if a.isInheritedParentHeader(raw) {
+			a.InheritedParentHeaders = append(a.InheritedParentHeaders, CodexInheritedHeader{
+				Line: a.Lines, Metadata: append(json.RawMessage(nil), raw...),
+			})
+			return
+		}
 		a.diagnose("conflicting session_meta identities")
 		return
 	}
 	a.ID = id
 	a.ParentID = coalesce(meta.ParentID, meta.Source.Subagent.ThreadSpawn.ParentID)
 	a.Metadata = append(json.RawMessage(nil), raw...)
+}
+
+func (a *CodexAccounting) isInheritedParentHeader(raw json.RawMessage) bool {
+	var child, parent struct {
+		ID           string          `json:"id"`
+		SessionID    string          `json:"session_id"`
+		ParentID     string          `json:"parent_thread_id"`
+		ForkedFromID string          `json:"forked_from_id"`
+		Timestamp    string          `json:"timestamp"`
+		Source       json.RawMessage `json:"source"`
+	}
+	if json.Unmarshal(a.Metadata, &child) != nil || json.Unmarshal(raw, &parent) != nil {
+		return false
+	}
+	if a.ParentID == "" || child.ID != a.ID || child.ID == a.ParentID ||
+		child.SessionID != a.ParentID || child.ParentID != a.ParentID ||
+		(child.ForkedFromID != "" && child.ForkedFromID != a.ParentID) {
+		return false
+	}
+	var source struct {
+		Subagent struct {
+			ThreadSpawn struct {
+				ParentID string `json:"parent_thread_id"`
+			} `json:"thread_spawn"`
+		} `json:"subagent"`
+	}
+	if json.Unmarshal(child.Source, &source) != nil || source.Subagent.ThreadSpawn.ParentID != a.ParentID {
+		return false
+	}
+	var parentSource string
+	if json.Unmarshal(parent.Source, &parentSource) != nil || (parentSource != "exec" && parentSource != "cli") {
+		return false
+	}
+	if parent.ID != a.ParentID || parent.SessionID != a.ParentID || parent.ParentID != "" || parent.ForkedFromID != "" {
+		return false
+	}
+	childTime, childErr := time.Parse(time.RFC3339Nano, child.Timestamp)
+	parentTime, parentErr := time.Parse(time.RFC3339Nano, parent.Timestamp)
+	return childErr == nil && parentErr == nil && !parentTime.After(childTime)
 }
 
 func (a *CodexAccounting) readPayload(raw json.RawMessage, timestamp string) {

--- a/cli/internal/parser/codex_accounting.go
+++ b/cli/internal/parser/codex_accounting.go
@@ -1,0 +1,252 @@
+package parser
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// CodexUsage retains native inclusive input and nullable counters. Reasoning is
+// a subset of output; cached input is a subset of input. Neither is added twice.
+type CodexUsage struct {
+	Input     *int64 `json:"input_tokens"`
+	Cached    *int64 `json:"cached_input_tokens"`
+	Fresh     *int64 `json:"fresh_input_tokens"`
+	Output    *int64 `json:"output_tokens"`
+	Reasoning *int64 `json:"reasoning_output_tokens"`
+	Total     *int64 `json:"total_tokens"`
+}
+
+// AccountingDiagnostic identifies evidence that could not be interpreted.
+type AccountingDiagnostic struct {
+	Line    int    `json:"line"`
+	Message string `json:"message"`
+}
+
+// CodexProviderError is an HTTP error embedded by the runtime in a terminal
+// event. It is not inferred from an assistant's prose or tool output.
+type CodexProviderError struct {
+	Status  int    `json:"status"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// CodexAccounting is a read-only view of one native rollout. Metadata and the
+// last cumulative payload are retained verbatim, including unrecognized fields.
+// Raw content for other events remains in the evidence file at the stated line.
+type CodexAccounting struct {
+	ID                string                 `json:"id"`
+	ParentID          string                 `json:"parent_id"`
+	Metadata          json.RawMessage        `json:"metadata"`
+	FirstTimestamp    string                 `json:"first_timestamp"`
+	LastTimestamp     string                 `json:"last_timestamp"`
+	LatestTurnState   string                 `json:"latest_turn_state"`
+	LatestTurnPayload json.RawMessage        `json:"latest_turn_payload"`
+	ProviderError     *CodexProviderError    `json:"provider_error"`
+	Usage             *CodexUsage            `json:"usage"`
+	UsagePayload      json.RawMessage        `json:"usage_payload"`
+	UsageLine         int                    `json:"usage_line"`
+	UsageTimestamp    string                 `json:"usage_timestamp"`
+	UsageEvents       int                    `json:"usage_events"`
+	Lines             int                    `json:"lines"`
+	Uninterpreted     map[string]int         `json:"uninterpreted_event_counts"`
+	Diagnostics       []AccountingDiagnostic `json:"diagnostics"`
+}
+
+// ParseCodexAccounting never sums cumulative events. Missing usage remains nil;
+// malformed records are diagnosed without hiding the rest of an interrupted file.
+func ParseCodexAccounting(r io.Reader) (*CodexAccounting, error) {
+	a := &CodexAccounting{Uninterpreted: map[string]int{}, Diagnostics: []AccountingDiagnostic{}}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		a.Lines++
+		if strings.TrimSpace(scanner.Text()) != "" {
+			a.readEvent(scanner.Bytes())
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return a, fmt.Errorf("read Codex accounting at line %d: %w", a.Lines+1, err)
+	}
+	if a.ID == "" {
+		a.diagnose("missing session_meta identity")
+	}
+	return a, nil
+}
+
+func (a *CodexAccounting) diagnose(message string) {
+	a.Diagnostics = append(a.Diagnostics, AccountingDiagnostic{Line: a.Lines, Message: message})
+}
+
+func (a *CodexAccounting) readEvent(line []byte) {
+	var event struct {
+		Type      string          `json:"type"`
+		Timestamp string          `json:"timestamp"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(line, &event); err != nil {
+		a.diagnose("malformed event: " + err.Error())
+		return
+	}
+	if a.FirstTimestamp == "" {
+		a.FirstTimestamp = event.Timestamp
+	}
+	if event.Timestamp != "" {
+		a.LastTimestamp = event.Timestamp
+	}
+	switch event.Type {
+	case "session_meta":
+		a.readMetadata(event.Payload)
+	case "event_msg":
+		a.readPayload(event.Payload, event.Timestamp)
+	default:
+		a.Uninterpreted[event.Type]++
+	}
+}
+
+func (a *CodexAccounting) readMetadata(raw json.RawMessage) {
+	var meta struct {
+		ID        string `json:"id"`
+		SessionID string `json:"session_id"`
+		ParentID  string `json:"parent_thread_id"`
+		Source    struct {
+			Subagent struct {
+				ThreadSpawn struct {
+					ParentID string `json:"parent_thread_id"`
+				} `json:"thread_spawn"`
+			} `json:"subagent"`
+		} `json:"source"`
+	}
+	// source is either a string (CLI) or an object (subagent). Decode the common
+	// identity separately so the valid string variant cannot erase identity.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || fields == nil {
+		a.diagnose("malformed session_meta object")
+		return
+	}
+	source := fields["source"]
+	delete(fields, "source")
+	identity, err := json.Marshal(fields)
+	if err != nil {
+		a.diagnose("encode session_meta identity: " + err.Error())
+		return
+	}
+	if err := json.Unmarshal(identity, &meta); err != nil {
+		a.diagnose("malformed session_meta identity: " + err.Error())
+		return
+	}
+	if len(source) > 0 && source[0] == '{' {
+		if err := json.Unmarshal(source, &meta.Source); err != nil {
+			a.diagnose("unrecognized session_meta source: " + err.Error())
+		}
+	}
+	id := coalesce(meta.ID, meta.SessionID)
+	if a.ID != "" && a.ID != id {
+		a.diagnose("conflicting session_meta identities")
+		return
+	}
+	a.ID = id
+	a.ParentID = coalesce(meta.ParentID, meta.Source.Subagent.ThreadSpawn.ParentID)
+	a.Metadata = append(json.RawMessage(nil), raw...)
+}
+
+func (a *CodexAccounting) readPayload(raw json.RawMessage, timestamp string) {
+	var payload struct {
+		Type  string          `json:"type"`
+		Error json.RawMessage `json:"error"`
+		Info  *struct {
+			Total json.RawMessage `json:"total_token_usage"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		a.diagnose("malformed event_msg payload: " + err.Error())
+		return
+	}
+	switch payload.Type {
+	case "task_started", "task_complete", "task_aborted":
+		a.LatestTurnState = payload.Type
+		a.LatestTurnPayload = append(json.RawMessage(nil), raw...)
+		a.ProviderError = readProviderError(payload.Error)
+	case "token_count":
+		a.UsageEvents++
+		if payload.Info != nil && len(payload.Info.Total) > 0 && string(payload.Info.Total) != "null" {
+			a.readUsage(payload.Info.Total, raw, timestamp)
+		}
+	default:
+		a.Uninterpreted["event_msg/"+payload.Type]++
+	}
+}
+
+func readProviderError(raw json.RawMessage) *CodexProviderError {
+	var native struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &native); err != nil {
+		return nil
+	}
+	var provider struct {
+		Status int `json:"status"`
+		Error  struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(native.Message), &provider); err != nil {
+		return nil
+	}
+	if provider.Status < 400 || provider.Status > 599 || provider.Error.Type == "" {
+		return nil
+	}
+	return &CodexProviderError{Status: provider.Status, Type: provider.Error.Type, Message: provider.Error.Message}
+}
+
+func (a *CodexAccounting) readUsage(raw, payload json.RawMessage, timestamp string) {
+	a.UsagePayload = append(json.RawMessage(nil), payload...)
+	a.UsageLine, a.UsageTimestamp = a.Lines, timestamp
+	var usage CodexUsage
+	if err := json.Unmarshal(raw, &usage); err != nil {
+		a.Usage = nil
+		a.diagnose("malformed cumulative usage: " + err.Error())
+		return
+	}
+	// Fresh is derived, never accepted from a worker-authored extra field.
+	usage.Fresh = nil
+	if err := validateCodexUsage(usage); err != nil {
+		a.Usage = nil
+		a.diagnose(err.Error())
+		return
+	}
+	if usage.Input != nil && usage.Cached != nil {
+		fresh := *usage.Input - *usage.Cached
+		usage.Fresh = &fresh
+	}
+	if a.Usage != nil && countersDecrease(*a.Usage, usage) {
+		a.diagnose("cumulative counters decreased; last native snapshot retained, aggregation requires review")
+	}
+	a.Usage = &usage
+}
+
+func validateCodexUsage(u CodexUsage) error {
+	for _, value := range []*int64{u.Input, u.Cached, u.Output, u.Reasoning, u.Total} {
+		if value != nil && *value < 0 {
+			return fmt.Errorf("negative cumulative token counter")
+		}
+	}
+	if u.Input != nil && u.Cached != nil && *u.Cached > *u.Input {
+		return fmt.Errorf("cached input exceeds inclusive input")
+	}
+	if u.Output != nil && u.Reasoning != nil && *u.Reasoning > *u.Output {
+		return fmt.Errorf("reasoning tokens exceed inclusive output")
+	}
+	if u.Input != nil && u.Output != nil && u.Total != nil && (*u.Total < *u.Input || *u.Total-*u.Input != *u.Output) {
+		return fmt.Errorf("total tokens disagree with input plus output")
+	}
+	return nil
+}
+
+func countersDecrease(old, next CodexUsage) bool {
+	return (old.Input != nil && next.Input != nil && *next.Input < *old.Input) ||
+		(old.Output != nil && next.Output != nil && *next.Output < *old.Output)
+}

--- a/cli/internal/parser/codex_accounting_test.go
+++ b/cli/internal/parser/codex_accounting_test.go
@@ -1,0 +1,83 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCodexAccountingPreservesCumulativeAndUnknownFacts(t *testing.T) {
+	input := `{"type":"session_meta","payload":{"id":"worker","source":{"subagent":{"thread_spawn":{"parent_thread_id":"author"}}},"future_field":"retain"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":10}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"cached_input_tokens":90,"output_tokens":20,"reasoning_output_tokens":10,"total_tokens":320,"future_counter":42}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":300,"cached_input_tokens":90,"output_tokens":20,"reasoning_output_tokens":10,"total_tokens":320,"future_counter":42}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":null}}
+{"type":"new_native_event","payload":{}}
+{"type":"event_msg"
+`
+	a, err := ParseCodexAccounting(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.ID != "worker" || a.ParentID != "author" {
+		t.Fatalf("identity: %+v", a)
+	}
+	if a.Usage == nil || *a.Usage.Input != 300 || *a.Usage.Cached != 90 || *a.Usage.Fresh != 210 || *a.Usage.Output != 20 || *a.Usage.Total != 320 {
+		t.Fatalf("usage: %+v", a.Usage)
+	}
+	if a.UsageEvents != 4 || a.UsageLine != 4 {
+		t.Fatalf("usage source: %+v", a)
+	}
+	if len(a.Diagnostics) != 1 || a.Diagnostics[0].Line != 7 {
+		t.Fatalf("diagnostics: %+v", a.Diagnostics)
+	}
+	if a.Uninterpreted["new_native_event"] != 1 || !strings.Contains(string(a.Metadata), "future_field") || !strings.Contains(string(a.UsagePayload), "future_counter") {
+		t.Fatalf("unknown evidence dropped: %+v", a)
+	}
+}
+
+func TestCodexAccountingMissingAndInvalidUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name, input string
+		wantNil     bool
+		diagnostic  string
+	}{
+		{"missing", ``, true, ""},
+		{"null info", `{"type":"event_msg","payload":{"type":"token_count","info":null}}`, true, ""},
+		{"missing cache", `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":12,"output_tokens":0}}}}`, false, ""},
+		{"bad type", `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":"12"}}}}`, true, "malformed cumulative"},
+		{"negative", `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":-1}}}}`, true, "negative"},
+		{"impossible cache", `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1,"cached_input_tokens":2}}}}`, true, "exceeds"},
+		{"double reasoning", `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1,"output_tokens":2,"reasoning_output_tokens":3}}}}`, true, "exceed"},
+		{"wrong total", `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1,"output_tokens":2,"total_tokens":9}}}}`, true, "disagree"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := ParseCodexAccounting(strings.NewReader("{\"type\":\"session_meta\",\"payload\":{\"id\":\"session\",\"source\":\"cli\"}}\n" + tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (a.Usage == nil) != tc.wantNil {
+				t.Fatalf("usage = %+v", a.Usage)
+			}
+			if !tc.wantNil && (a.Usage.Cached != nil || a.Usage.Fresh != nil || a.Usage.Output == nil || *a.Usage.Output != 0) {
+				t.Fatalf("missing/zero conflation: %+v", a.Usage)
+			}
+			if tc.diagnostic != "" && (len(a.Diagnostics) == 0 || !strings.Contains(a.Diagnostics[0].Message, tc.diagnostic)) {
+				t.Fatalf("diagnostic: %+v", a.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestCodexAccountingRegressionAndIdentityConflict(t *testing.T) {
+	a, err := ParseCodexAccounting(strings.NewReader(`{"type":"session_meta","payload":{"session_id":"one","source":"cli"}}
+{"type":"session_meta","payload":{"id":"two"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":20}}}}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.ID != "one" || a.Usage == nil || *a.Usage.Input != 20 || len(a.Diagnostics) != 2 {
+		t.Fatalf("result: %+v", a)
+	}
+}

--- a/cli/internal/parser/codex_accounting_test.go
+++ b/cli/internal/parser/codex_accounting_test.go
@@ -81,3 +81,47 @@ func TestCodexAccountingRegressionAndIdentityConflict(t *testing.T) {
 		t.Fatalf("result: %+v", a)
 	}
 }
+
+func TestCodexAccountingInheritedParentHeader(t *testing.T) {
+	const child = `{"type":"session_meta","payload":{"id":"child","session_id":"parent","parent_thread_id":"parent","forked_from_id":"parent","timestamp":"2026-09-10T15:51:27.355Z","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}}}`
+	const parent = `{"type":"session_meta","payload":{"id":"parent","session_id":"parent","timestamp":"2026-09-10T15:49:48.395Z","source":"exec","future_field":"retained"}}`
+	a, err := ParseCodexAccounting(strings.NewReader(child + "\n" + parent + `
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":500,"output_tokens":20}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1100,"cached_input_tokens":550,"output_tokens":30}}}}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.ID != "child" || a.ParentID != "parent" || len(a.Diagnostics) != 0 {
+		t.Fatalf("corroborated inherited header changed child identity or was diagnosed as conflict: %+v", a)
+	}
+	if !strings.Contains(string(a.Metadata), `"id":"child"`) || a.Usage == nil || *a.Usage.Input != 1100 {
+		t.Fatalf("primary metadata or native cumulative usage changed: %+v", a)
+	}
+	if len(a.InheritedParentHeaders) != 1 || a.InheritedParentHeaders[0].Line != 2 || a.InheritedParentHeaders[0].InheritedUsage != nil || !strings.Contains(string(a.InheritedParentHeaders[0].Metadata), "future_field") {
+		t.Fatalf("inherited evidence lost or token attribution invented: %+v", a.InheritedParentHeaders)
+	}
+}
+
+func TestCodexAccountingUncorroboratedParentHeadersRemainConflicts(t *testing.T) {
+	const child = `{"type":"session_meta","payload":{"id":"child","session_id":"parent","parent_thread_id":"parent","forked_from_id":"parent","timestamp":"2026-09-10T15:51:27.355Z","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}}}`
+	const parent = `{"type":"session_meta","payload":{"id":"parent","session_id":"parent","timestamp":"2026-09-10T15:49:48.395Z","source":"exec"}}`
+	for _, tc := range []struct{ name, first, second string }{
+		{"unrelated identity", child, strings.ReplaceAll(parent, "parent", "unrelated")},
+		{"conflicting spawn parent", strings.Replace(child, `"thread_spawn":{"parent_thread_id":"parent"}`, `"thread_spawn":{"parent_thread_id":"other"}`, 1), parent},
+		{"conflicting fork parent", strings.Replace(child, `"forked_from_id":"parent"`, `"forked_from_id":"other"`, 1), parent},
+		{"newer alleged parent", child, strings.Replace(parent, "15:49:48.395Z", "15:52:48.395Z", 1)},
+		{"unknown parent source", child, strings.Replace(parent, `"source":"exec"`, `"source":"unknown"`, 1)},
+		{"root identity switch", `{"type":"session_meta","payload":{"id":"child","session_id":"child","source":"exec"}}`, parent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := ParseCodexAccounting(strings.NewReader(tc.first + "\n" + tc.second))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if a.ID != "child" || len(a.InheritedParentHeaders) != 0 || len(a.Diagnostics) != 1 || !strings.Contains(a.Diagnostics[0].Message, "conflicting session_meta") {
+				t.Fatalf("uncorroborated header accepted: %+v", a)
+			}
+		})
+	}
+}

--- a/cli/internal/parser/parser.go
+++ b/cli/internal/parser/parser.go
@@ -107,8 +107,9 @@ type codexEventPayload struct {
 // so the LAST one is the session total. input_tokens already includes cached
 // input, and total_tokens == input_tokens + output_tokens.
 type codexTokenUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens       int `json:"input_tokens"`
+	CachedInputTokens int `json:"cached_input_tokens"`
+	OutputTokens      int `json:"output_tokens"`
 }
 
 type codexResponseItem struct {
@@ -519,14 +520,19 @@ func (p *Parser) parseCodexEvent(raw rawMessage, lineNum int) (*types.Transcript
 		if payload.Info == nil || payload.Info.TotalTokenUsage == nil {
 			return nil, nil
 		}
+		usage := payload.Info.TotalTokenUsage
+		if usage.InputTokens < 0 || usage.OutputTokens < 0 || usage.CachedInputTokens < 0 || usage.CachedInputTokens > usage.InputTokens {
+			return nil, fmt.Errorf("invalid Codex cumulative token counters")
+		}
 		return &types.TranscriptMessage{
 			Type:         msgTypeCodexTokenCount,
 			Timestamp:    parseTimestamp(raw.Timestamp),
 			SessionID:    raw.SessionID,
 			MessageIndex: lineNum,
 			Usage: &types.TokenUsage{
-				InputTokens:  payload.Info.TotalTokenUsage.InputTokens,
-				OutputTokens: payload.Info.TotalTokenUsage.OutputTokens,
+				InputTokens:          usage.InputTokens - usage.CachedInputTokens,
+				CacheReadInputTokens: usage.CachedInputTokens,
+				OutputTokens:         usage.OutputTokens,
 			},
 		}, nil
 	default:

--- a/cli/internal/parser/parser_test.go
+++ b/cli/internal/parser/parser_test.go
@@ -201,6 +201,9 @@ func TestParser_Parse_CodexTokenCountTotals(t *testing.T) {
 	if result.FinalUsage == nil {
 		t.Fatal("FinalUsage is nil; Codex token_count total not captured")
 	}
+	if result.FinalUsage.InputTokens != 2100 || result.FinalUsage.CacheReadInputTokens != 900 {
+		t.Errorf("FinalUsage = %+v, want 2100 fresh and 900 cached input tokens", result.FinalUsage)
+	}
 	in, out := result.TokenTotals()
 	if in != 3000 || out != 120 {
 		t.Errorf("TokenTotals = (%d,%d), want (3000,120) — last cumulative total", in, out)

--- a/cli/internal/skilltrial/report.go
+++ b/cli/internal/skilltrial/report.go
@@ -173,7 +173,7 @@ func readEvidence(path string, document bool) (Evidence, []byte, error) {
 
 func readDocuments(dir string) (map[string]Evidence, []string) {
 	docs, diagnostics := map[string]Evidence{}, []string{}
-	for _, name := range []string{"config.json", "lock.json", "result.json"} {
+	for _, name := range []string{"config.json", "lock.json", "result.json", "verifier/grade.json"} {
 		path := filepath.Join(dir, name)
 		e, raw, err := readEvidence(path, true)
 		if os.IsNotExist(err) {

--- a/cli/internal/skilltrial/report.go
+++ b/cli/internal/skilltrial/report.go
@@ -1,0 +1,323 @@
+// Package skilltrial reads explicitly selected Harbor job outputs for repository
+// development. It does not launch trials, grade work, or write lifecycle state.
+package skilltrial
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/boshu2/agentops/cli/internal/parser"
+)
+
+type JobInput struct {
+	Arm       string
+	Directory string
+}
+
+type Evidence struct {
+	Path   string          `json:"path"`
+	SHA256 string          `json:"sha256"`
+	Data   json.RawMessage `json:"data,omitempty"`
+}
+
+type Counts struct {
+	Expected        *int `json:"expected"`
+	Observed        int  `json:"observed"`
+	Started         int  `json:"started"`
+	Completed       int  `json:"completed"`
+	NotStarted      *int `json:"not_started"`
+	Created         int  `json:"created"`
+	Unfinished      int  `json:"unfinished"`
+	Success         int  `json:"success"`
+	Failed          int  `json:"failed"`
+	Infrastructure  int  `json:"infrastructure_error"`
+	ExecutionErrors int  `json:"execution_error"`
+	Unknown         int  `json:"unknown_outcome"`
+}
+
+type Timing struct {
+	StartedAt      string   `json:"started_at"`
+	FinishedAt     string   `json:"finished_at"`
+	ElapsedSeconds *float64 `json:"elapsed_seconds"`
+}
+
+type Trial struct {
+	Directory    string              `json:"directory"`
+	ID           string              `json:"id"`
+	Name         string              `json:"name"`
+	TaskName     string              `json:"task_name"`
+	TaskChecksum string              `json:"task_checksum"`
+	Arm          string              `json:"arm"`
+	Started      bool                `json:"started"`
+	Completed    bool                `json:"completed"`
+	Outcome      string              `json:"outcome"`
+	Timing       Timing              `json:"timing"`
+	Documents    map[string]Evidence `json:"documents"`
+	SessionIDs   []string            `json:"session_ids"`
+	Diagnostics  []string            `json:"diagnostics"`
+}
+
+type Job struct {
+	Directory   string              `json:"directory"`
+	ID          string              `json:"id"`
+	Arm         string              `json:"arm"`
+	Counts      Counts              `json:"counts"`
+	Timing      Timing              `json:"timing"`
+	Documents   map[string]Evidence `json:"documents"`
+	Trials      []Trial             `json:"trials"`
+	Diagnostics []string            `json:"diagnostics"`
+}
+
+// SessionCopy retains every supplied copy. No copy's cumulative usage is added
+// to another, and no parent/child aggregate is inferred from native identity.
+type SessionCopy struct {
+	Evidence   Evidence                `json:"evidence"`
+	Trial      string                  `json:"trial"`
+	Accounting *parser.CodexAccounting `json:"accounting"`
+}
+
+type Session struct {
+	ID          string        `json:"id"`
+	Copies      []SessionCopy `json:"copies"`
+	Diagnostics []string      `json:"diagnostics"`
+}
+
+type Report struct {
+	RewardKey string    `json:"reward_key"`
+	Jobs      []Job     `json:"jobs"`
+	Sessions  []Session `json:"sessions"`
+	Limits    []string  `json:"limits"`
+}
+
+type builder struct {
+	reward   string
+	sessions map[string]*Session
+}
+
+// Build produces deterministic JSON-ready data from the current source bytes.
+// Unknown fields remain in raw native documents; missing facts remain nullable.
+func Build(inputs []JobInput, sessionFiles []string, rewardKey string) (*Report, error) {
+	if len(inputs) == 0 && len(sessionFiles) == 0 {
+		return nil, fmt.Errorf("supply at least one job directory or native session file")
+	}
+	if rewardKey == "" {
+		return nil, fmt.Errorf("reward key must not be empty")
+	}
+	b := builder{reward: rewardKey, sessions: map[string]*Session{}}
+	report := &Report{RewardKey: rewardKey, Jobs: []Job{}, Sessions: []Session{}, Limits: []string{
+		"Outcome uses only the selected native verifier reward: 1 success, 0 failed; other or missing values are unknown. This is endpoint grading, not semantic acceptance or comparison validity.",
+		"Expected is native n_total_trials or lock.trials length. Started requires trial config, result timestamp, or native sessions; unstarted and unfinished attempts stay visible. Harbor may overwrite retries on resume; unavailable historical attempts cannot be reconstructed.",
+		"Native cumulative usage is reported per identity and per evidence copy, never summed across copies, parents, children, or Harbor agent_result. Parent counters may include inherited history; billing and phase allocation are unknown.",
+		"Harbor documents retain their native metrics as source data; they are not trusted as all-session totals. Worker-authored claims are not extracted as measurements.",
+		"Timing uses recorded endpoints only; absent timezone remains unspecified. No current clock, file modification time, or missing usage is substituted. Setup and grader phase times remain in native documents.",
+	}}
+	seen := map[string]string{}
+	for _, input := range inputs {
+		dir, err := canonical(input.Directory)
+		if err != nil {
+			return nil, err
+		}
+		if arm, ok := seen[dir]; ok {
+			if arm != input.Arm {
+				return nil, fmt.Errorf("job %s supplied under conflicting arms", dir)
+			}
+			continue
+		}
+		seen[dir] = input.Arm
+		job, err := b.readJob(dir, input.Arm)
+		if err != nil {
+			return nil, err
+		}
+		report.Jobs = append(report.Jobs, job)
+	}
+	for _, path := range sessionFiles {
+		if _, err := b.addSession(path, ""); err != nil {
+			return nil, err
+		}
+	}
+	for _, session := range b.sessions {
+		sort.Slice(session.Copies, func(i, j int) bool { return session.Copies[i].Evidence.Path < session.Copies[j].Evidence.Path })
+		report.Sessions = append(report.Sessions, *session)
+	}
+	sort.Slice(report.Jobs, func(i, j int) bool { return report.Jobs[i].Directory < report.Jobs[j].Directory })
+	sort.Slice(report.Sessions, func(i, j int) bool { return report.Sessions[i].ID < report.Sessions[j].ID })
+	return report, nil
+}
+
+func canonical(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+func readEvidence(path string, document bool) (Evidence, []byte, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Evidence{}, nil, err
+	}
+	e := Evidence{Path: path, SHA256: fmt.Sprintf("%x", sha256.Sum256(content))}
+	if document && json.Valid(content) {
+		e.Data = content
+	}
+	return e, content, nil
+}
+
+func readDocuments(dir string) (map[string]Evidence, []string) {
+	docs, diagnostics := map[string]Evidence{}, []string{}
+	for _, name := range []string{"config.json", "lock.json", "result.json"} {
+		path := filepath.Join(dir, name)
+		e, raw, err := readEvidence(path, true)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			diagnostics = append(diagnostics, path+": "+err.Error())
+			continue
+		}
+		docs[name] = e
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+			diagnostics = append(diagnostics, path+": malformed native JSON object; raw evidence retained by path and hash")
+		}
+	}
+	return docs, diagnostics
+}
+
+func decodeDocument(docs map[string]Evidence, name string, target any, diagnostics *[]string) bool {
+	doc, ok := docs[name]
+	if !ok || len(doc.Data) == 0 || bytes.Equal(bytes.TrimSpace(doc.Data), []byte("null")) {
+		return false
+	}
+	if err := json.Unmarshal(doc.Data, target); err != nil {
+		*diagnostics = append(*diagnostics, doc.Path+": unsupported native fields: "+err.Error())
+		return false
+	}
+	return true
+}
+
+func (b *builder) readJob(dir, arm string) (Job, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return Job{}, err
+	}
+	j := Job{Directory: dir, Arm: arm, Trials: []Trial{}}
+	j.Documents, j.Diagnostics = readDocuments(dir)
+	var result struct {
+		ID         string `json:"id"`
+		Expected   *int   `json:"n_total_trials"`
+		StartedAt  string `json:"started_at"`
+		FinishedAt string `json:"finished_at"`
+	}
+	if decodeDocument(j.Documents, "result.json", &result, &j.Diagnostics) {
+		j.ID, j.Counts.Expected = result.ID, result.Expected
+		j.Timing = timing(result.StartedAt, result.FinishedAt, &j.Diagnostics)
+	}
+	var lock struct {
+		Trials []json.RawMessage `json:"trials"`
+	}
+	if decodeDocument(j.Documents, "lock.json", &lock, &j.Diagnostics) && lock.Trials != nil {
+		expected := len(lock.Trials)
+		if j.Counts.Expected == nil {
+			j.Counts.Expected = &expected
+		} else if *j.Counts.Expected != expected {
+			j.Diagnostics = append(j.Diagnostics, "native result and lock disagree on expected trials")
+		}
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		trialDir := filepath.Join(dir, entry.Name())
+		if !looksLikeTrial(trialDir) {
+			j.Diagnostics = append(j.Diagnostics, "unrecognized directory: "+trialDir)
+			continue
+		}
+		trial := b.readTrial(trialDir, arm)
+		j.Trials = append(j.Trials, trial)
+		j.Counts.count(trial)
+	}
+	j.Counts.finish(&j.Diagnostics)
+	if j.Counts.Expected == nil {
+		j.Diagnostics = append(j.Diagnostics, "expected trial count unknown: no native total or resolved lock")
+	}
+	return j, nil
+}
+
+func looksLikeTrial(dir string) bool {
+	for _, name := range []string{"config.json", "result.json", "lock.json", "trial.log", "agent", "steps", "exception.txt"} {
+		if _, err := os.Lstat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func timing(start, finish string, diagnostics *[]string) Timing {
+	t := Timing{StartedAt: start, FinishedAt: finish}
+	if start == "" || finish == "" {
+		return t
+	}
+	for _, format := range []string{time.RFC3339Nano, "2006-01-02T15:04:05.999999999"} {
+		s, e1 := time.Parse(format, start)
+		f, e2 := time.Parse(format, finish)
+		if e1 == nil && e2 == nil && !f.Before(s) {
+			duration := f.Sub(s).Seconds()
+			t.ElapsedSeconds = &duration
+			return t
+		}
+	}
+	*diagnostics = append(*diagnostics, "invalid, reversed, or incompatible timing endpoints")
+	return t
+}
+
+func (c *Counts) count(t Trial) {
+	c.Observed++
+	if t.Started {
+		c.Started++
+	}
+	if t.Completed {
+		c.Completed++
+	}
+	switch t.Outcome {
+	case "created":
+		c.Created++
+	case "unfinished":
+		c.Unfinished++
+	case "success":
+		c.Success++
+	case "failed":
+		c.Failed++
+	case "infrastructure_error":
+		c.Infrastructure++
+	case "execution_error":
+		c.ExecutionErrors++
+	default:
+		c.Unknown++
+	}
+}
+
+func (c *Counts) finish(diagnostics *[]string) {
+	if c.Expected == nil {
+		return
+	}
+	if *c.Expected < 0 {
+		*diagnostics = append(*diagnostics, "invalid negative native expected count")
+		c.Expected = nil
+		return
+	}
+	if c.Started > *c.Expected {
+		*diagnostics = append(*diagnostics, "started exceeds expected; retries or conflicting evidence require review")
+		return
+	}
+	n := *c.Expected - c.Started
+	c.NotStarted = &n
+}

--- a/cli/internal/skilltrial/report_test.go
+++ b/cli/internal/skilltrial/report_test.go
@@ -166,3 +166,34 @@ func TestReportRetainsIndependentGradeForFailedEndpoint(t *testing.T) {
 		t.Fatalf("independent failed-case grade lost: %+v", e)
 	}
 }
+
+func TestVerifierStartupFailureIsNotAModelFailure(t *testing.T) {
+	base := `{"started_at":"2026-09-10T14:00:00Z","finished_at":"2026-09-10T14:00:05Z","agent_execution":{"started_at":"2026-09-10T14:00:01Z","finished_at":"2026-09-10T14:00:02Z"},"verifier":{"started_at":"2026-09-10T14:00:03Z","finished_at":"2026-09-10T14:00:04Z"},"verifier_environment_mode":"separate","exception_info":{"exception_type":"RuntimeError","occurred_at":"2026-09-10T14:00:04.01Z"},"verifier_result":null}`
+	cases := []struct{ name, raw, want string }{
+		{"separate verifier startup", base, "infrastructure_error"},
+		{"agent timeout stays execution", strings.Replace(base, "RuntimeError", "AgentTimeoutError", 1), "execution_error"},
+		{"agent error before verifier", strings.Replace(base, "14:00:04.01Z", "14:00:02Z", 1), "execution_error"},
+		{"unfinished worker", strings.Replace(base, `"finished_at":"2026-09-10T14:00:02Z"`, `"finished_at":null`, 1), "execution_error"},
+		{"shared verifier", strings.Replace(base, `"separate"`, `"shared"`, 1), "execution_error"},
+		{"no phase timestamp", strings.Replace(base, "14:00:04.01Z", "bad-time", 1), "execution_error"},
+		{"exception after trial end", strings.Replace(base, "14:00:04.01Z", "14:00:06Z", 1), "execution_error"},
+		{"grade with later exception", strings.Replace(base, `"verifier_result":null`, `"verifier_result":{"rewards":{"reward":1}}`, 1), "execution_error"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			put(t, filepath.Join(dir, "trial", "result.json"), tt.raw)
+			report, err := Build([]JobInput{{Directory: dir}}, nil, "reward")
+			if err != nil {
+				t.Fatal(err)
+			}
+			trial := report.Jobs[0].Trials[0]
+			if trial.Outcome != tt.want {
+				t.Fatalf("outcome %q, want %q", trial.Outcome, tt.want)
+			}
+			if string(trial.Documents["result.json"].Data) != tt.raw {
+				t.Fatal("native evidence changed")
+			}
+		})
+	}
+}

--- a/cli/internal/skilltrial/report_test.go
+++ b/cli/internal/skilltrial/report_test.go
@@ -1,0 +1,148 @@
+package skilltrial
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func put(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReportIncludesFailedAndInterruptedAttempts(t *testing.T) {
+	dir := t.TempDir()
+	put(t, filepath.Join(dir, "result.json"), `{"id":"job","n_total_trials":8,"started_at":"2026-09-10T10:00:00","finished_at":null,"future_job_field":17,"stats":{"n_completed_trials":99}}`)
+	base := `"started_at":"2026-09-10T14:00:00Z","finished_at":"2026-09-10T14:00:05Z","task_name":"repair","task_checksum":"frozen-task","agent_result":{"n_input_tokens":999999},`
+	cases := map[string]string{
+		"success":   base + `"id":"s","verifier_result":{"rewards":{"reward":1}}`,
+		"failed":    base + `"id":"f","verifier_result":{"rewards":{"reward":0}}`,
+		"infra":     base + `"id":"i","exception_info":{"exception_type":"RuntimeError"},"environment_setup":{"started_at":"2026-09-10T14:00:00Z"},"agent_execution":null,"verifier_result":null`,
+		"execution": base + `"id":"e","exception_info":{"exception_type":"AgentTimeoutError"},"agent_execution":{"started_at":"2026-09-10T14:00:01Z"},"verifier_result":null`,
+		"unknown":   base + `"id":"u","verifier_result":null`,
+	}
+	for name, content := range cases {
+		put(t, filepath.Join(dir, name, "result.json"), "{"+content+"}")
+	}
+	put(t, filepath.Join(dir, "interrupted", "config.json"), `{"task":{"path":"/tasks/repair"},"agent":{"model_name":"native-model"},"future_config":"retained"}`)
+	put(t, filepath.Join(dir, "created", "trial.log"), "")
+	put(t, filepath.Join(dir, "irrelevant", "notes.txt"), "not a trial")
+	r, err := Build([]JobInput{{Arm: "treatment", Directory: dir}}, nil, "reward")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := r.Jobs[0].Counts
+	if c.Expected == nil || *c.Expected != 8 || c.Observed != 7 || c.Started != 6 || c.Completed != 5 || c.NotStarted == nil || *c.NotStarted != 2 || c.Success != 1 || c.Failed != 1 || c.Infrastructure != 1 || c.ExecutionErrors != 1 || c.Unknown != 1 || c.Unfinished != 1 || c.Created != 1 {
+		t.Fatalf("counts: %+v", c)
+	}
+	for _, trial := range r.Jobs[0].Trials {
+		if trial.Arm != "treatment" {
+			t.Fatal("arm missing")
+		}
+		if trial.Completed && (trial.Timing.ElapsedSeconds == nil || *trial.Timing.ElapsedSeconds != 5) {
+			t.Fatalf("timing: %+v", trial.Timing)
+		}
+	}
+	if !strings.Contains(string(r.Jobs[0].Documents["result.json"].Data), "future_job_field") {
+		t.Fatal("unknown field lost")
+	}
+	if len(r.Sessions) != 0 {
+		t.Fatal("fabricated native usage")
+	}
+}
+
+func TestReportNativeIdentityAndStableReplay(t *testing.T) {
+	dir := t.TempDir()
+	put(t, filepath.Join(dir, "lock.json"), `{"trials":[{},{}],"harbor":{"version":"0.22.0"}}`)
+	put(t, filepath.Join(dir, "one", "config.json"), `{"task":{"path":"/task/one"}}`)
+	put(t, filepath.Join(dir, "two", "config.json"), `{"task":{"path":"/task/two"}}`)
+	rollout := `{"type":"session_meta","payload":{"id":"author","source":"cli"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":5}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":5}}}}
+`
+	p1 := filepath.Join(dir, "one", "agent", "sessions", "2026", "rollout.jsonl")
+	put(t, p1, rollout)
+	put(t, filepath.Join(dir, "two", "steps", "review", "agent", "sessions", "review.jsonl"), strings.ReplaceAll(rollout, `"id":"author","source":"cli"`, `"id":"reviewer","parent_thread_id":"author"`))
+	put(t, filepath.Join(dir, "two", "agent", "sessions", "copy.jsonl"), rollout)
+	put(t, filepath.Join(dir, "two", "artifacts", "sessions", "fake.jsonl"), strings.ReplaceAll(rollout, "author", "fake"))
+	r1, err := Build([]JobInput{{Directory: dir}, {Directory: dir}}, []string{p1}, "reward")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := Build([]JobInput{{Directory: dir}}, nil, "reward")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b1, e1 := json.Marshal(r1)
+	b2, e2 := json.Marshal(r2)
+	if e1 != nil || e2 != nil || !bytes.Equal(b1, b2) {
+		t.Fatalf("replay differs: %v %v", e1, e2)
+	}
+	if len(r1.Jobs) != 1 || len(r1.Sessions) != 2 || len(r1.Sessions[0].Copies) != 2 || len(r1.Sessions[1].Copies) != 1 {
+		t.Fatalf("identities: %+v", r1.Sessions)
+	}
+	for _, session := range r1.Sessions {
+		for _, copy := range session.Copies {
+			if *copy.Accounting.Usage.Input != 100 || *copy.Accounting.Usage.Fresh != 90 || len(copy.Evidence.SHA256) != 64 {
+				t.Fatalf("usage/evidence: %+v", copy)
+			}
+		}
+	}
+	if r1.Sessions[1].Copies[0].Accounting.ParentID != "author" {
+		t.Fatal("reviewer parent lost")
+	}
+}
+
+func TestReportMalformedAndMissingEvidence(t *testing.T) {
+	dir := t.TempDir()
+	put(t, filepath.Join(dir, "config.json"), `{"tasks":[{"path":"unknown"}]}`)
+	put(t, filepath.Join(dir, "broken", "config.json"), `{`)
+	put(t, filepath.Join(dir, "broken", "result.json"), `{"finished_at":true}`)
+	put(t, filepath.Join(dir, "broken", "agent", "sessions", "partial.jsonl"), `{"type":"session_meta","payload":{"id":"broken"}}`+"\n{")
+	r, err := Build([]JobInput{{Directory: dir}}, nil, "reward")
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := r.Jobs[0]
+	if j.Counts.Expected != nil || j.Counts.NotStarted != nil || j.Counts.Unfinished != 1 || len(j.Trials[0].Diagnostics) < 2 {
+		t.Fatalf("missing accounting: %+v", j)
+	}
+	if r.Sessions[0].Copies[0].Accounting.Usage != nil || len(r.Sessions[0].Copies[0].Accounting.Diagnostics) != 1 {
+		t.Fatal("malformed session hidden or missing usage set to zero")
+	}
+	if _, err := Build([]JobInput{{Arm: "a", Directory: dir}, {Arm: "b", Directory: dir}}, nil, "reward"); err == nil {
+		t.Fatal("conflicting arms accepted")
+	}
+	if _, err := Build(nil, nil, "reward"); err == nil {
+		t.Fatal("unscoped scan accepted")
+	}
+}
+
+func TestNativeProviderRejectionIsNotAZeroQualityScore(t *testing.T) {
+	dir := t.TempDir()
+	put(t, filepath.Join(dir, "result.json"), `{"n_total_trials":1}`)
+	put(t, filepath.Join(dir, "trial", "result.json"), `{"started_at":"2026-09-10T15:32:23Z","finished_at":"2026-09-10T15:32:26Z","agent_execution":{"started_at":"2026-09-10T15:32:23Z"},"exception_info":{"exception_type":"NonZeroAgentExitCodeError"},"verifier_result":{"rewards":{"reward":0}}}`)
+	put(t, filepath.Join(dir, "trial", "agent", "sessions", "rollout.jsonl"), `{"type":"session_meta","payload":{"id":"root","source":"cli"}}
+{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":null,"error":{"message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The selected model requires a newer version of Codex.\"}}","codex_error_info":"other"}}}
+`)
+	r, err := Build([]JobInput{{Directory: dir}}, nil, "reward")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Jobs[0].Counts.Infrastructure != 1 || r.Jobs[0].Counts.Failed != 0 {
+		t.Fatalf("counts: %+v", r.Jobs[0].Counts)
+	}
+	a := r.Sessions[0].Copies[0].Accounting
+	if a.Usage != nil || a.ProviderError == nil || a.ProviderError.Status != 400 || !strings.Contains(string(a.LatestTurnPayload), "newer version") {
+		t.Fatalf("native error: %+v", a)
+	}
+}

--- a/cli/internal/skilltrial/report_test.go
+++ b/cli/internal/skilltrial/report_test.go
@@ -146,3 +146,23 @@ func TestNativeProviderRejectionIsNotAZeroQualityScore(t *testing.T) {
 		t.Fatalf("native error: %+v", a)
 	}
 }
+
+func TestReportRetainsIndependentGradeForFailedEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	put(t, filepath.Join(dir, "trial", "result.json"), `{"id":"trial","started_at":"2026-09-10T14:00:00Z","finished_at":"2026-09-10T14:00:05Z","verifier_result":{"rewards":{"reward":0}}}`)
+	grade := `{"endpoint_pass":false,"case_results":[{"case_id":"clean","expected":"PASS","actual":"FAIL","classification":"false_blocker"}],"not_checked":["fresh review"]}`
+	path := filepath.Join(dir, "trial", "verifier", "grade.json")
+	put(t, path, grade)
+	r, err := Build([]JobInput{{Arm: "control", Directory: dir}}, nil, "reward")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := r.Jobs[0].Trials[0].Documents["verifier/grade.json"]
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Path != resolvedPath || len(e.SHA256) != 64 || string(e.Data) != grade || r.Jobs[0].Counts.Failed != 1 {
+		t.Fatalf("independent failed-case grade lost: %+v", e)
+	}
+}

--- a/cli/internal/skilltrial/trial.go
+++ b/cli/internal/skilltrial/trial.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/boshu2/agentops/cli/internal/parser"
 )
@@ -23,8 +24,11 @@ type nativeTrial struct {
 	AgentSetup       *nativePhase    `json:"agent_setup"`
 	AgentExecution   *nativePhase    `json:"agent_execution"`
 	StepResults      json.RawMessage `json:"step_results"`
+	VerifierPhase    *nativePhase    `json:"verifier"`
+	VerifierMode     string          `json:"verifier_environment_mode"`
 	Exception        *struct {
-		Type string `json:"exception_type"`
+		Type       string `json:"exception_type"`
+		OccurredAt string `json:"occurred_at"`
 	} `json:"exception_info"`
 	Verifier *struct {
 		Rewards map[string]*float64 `json:"rewards"`
@@ -32,7 +36,8 @@ type nativeTrial struct {
 }
 
 type nativePhase struct {
-	StartedAt string `json:"started_at"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at"`
 }
 
 func (b *builder) readTrial(dir, arm string) Trial {
@@ -106,6 +111,9 @@ func classifyOutcome(result nativeTrial, rewardKey string) string {
 		if result.AgentExecution == nil && noSteps && (result.EnvironmentSetup != nil || result.AgentSetup != nil) {
 			return "infrastructure_error"
 		}
+		if verifierInfrastructureFailure(result) {
+			return "infrastructure_error"
+		}
 		switch result.Exception.Type {
 		case "AgentAuthenticationError", "ModelNotFoundError", "ApiUsageLimitError", "EnvironmentStartError", "EnvironmentBuildError",
 			"RewardFileNotFoundError", "RewardFileEmptyError", "VerifierOutputParseError", "VerifierTimeoutError":
@@ -125,6 +133,27 @@ func classifyOutcome(result nativeTrial, rewardKey string) string {
 	default:
 		return "unknown_outcome"
 	}
+}
+
+// Harbor can wrap separate-verifier startup failures in RuntimeError after the
+// worker has finished. A missing evaluator result is not a failed model grade.
+func verifierInfrastructureFailure(result nativeTrial) bool {
+	if result.Exception == nil || result.Exception.Type != "RuntimeError" ||
+		result.VerifierMode != "separate" || result.Verifier != nil ||
+		result.AgentExecution == nil || result.VerifierPhase == nil {
+		return false
+	}
+	values := []string{result.AgentExecution.FinishedAt, result.VerifierPhase.StartedAt,
+		result.Exception.OccurredAt, result.FinishedAt}
+	var previous time.Time
+	for _, value := range values {
+		current, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil || (!previous.IsZero() && current.Before(previous)) {
+			return false
+		}
+		previous = current
+	}
+	return true
 }
 
 func sessionRoots(dir string, diagnostics *[]string) []string {

--- a/cli/internal/skilltrial/trial.go
+++ b/cli/internal/skilltrial/trial.go
@@ -1,0 +1,218 @@
+package skilltrial
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/boshu2/agentops/cli/internal/parser"
+)
+
+type nativeTrial struct {
+	ID               string          `json:"id"`
+	Name             string          `json:"trial_name"`
+	TaskName         string          `json:"task_name"`
+	TaskChecksum     string          `json:"task_checksum"`
+	StartedAt        string          `json:"started_at"`
+	FinishedAt       string          `json:"finished_at"`
+	EnvironmentSetup *nativePhase    `json:"environment_setup"`
+	AgentSetup       *nativePhase    `json:"agent_setup"`
+	AgentExecution   *nativePhase    `json:"agent_execution"`
+	StepResults      json.RawMessage `json:"step_results"`
+	Exception        *struct {
+		Type string `json:"exception_type"`
+	} `json:"exception_info"`
+	Verifier *struct {
+		Rewards map[string]*float64 `json:"rewards"`
+	} `json:"verifier_result"`
+}
+
+type nativePhase struct {
+	StartedAt string `json:"started_at"`
+}
+
+func (b *builder) readTrial(dir, arm string) Trial {
+	t := Trial{Directory: dir, Arm: arm, Name: filepath.Base(dir), Outcome: "created", SessionIDs: []string{}}
+	t.Documents, t.Diagnostics = readDocuments(dir)
+	_, t.Started = t.Documents["config.json"]
+	var result nativeTrial
+	if decodeDocument(t.Documents, "result.json", &result, &t.Diagnostics) {
+		t.ID, t.TaskName, t.TaskChecksum = result.ID, result.TaskName, result.TaskChecksum
+		if result.Name != "" {
+			t.Name = result.Name
+		}
+		t.Started = t.Started || result.StartedAt != ""
+		t.Timing = timing(result.StartedAt, result.FinishedAt, &t.Diagnostics)
+		t.Completed = t.Timing.ElapsedSeconds != nil
+		if t.Completed {
+			t.Outcome = classifyOutcome(result, b.reward)
+		}
+	}
+	if t.TaskName == "" {
+		var config struct {
+			Task struct {
+				Path string `json:"path"`
+				Name string `json:"name"`
+			} `json:"task"`
+		}
+		if decodeDocument(t.Documents, "config.json", &config, &t.Diagnostics) {
+			t.TaskName = config.Task.Name
+			if t.TaskName == "" && config.Task.Path != "" {
+				t.TaskName = filepath.Base(config.Task.Path)
+			}
+		}
+	}
+	for _, root := range sessionRoots(dir, &t.Diagnostics) {
+		b.scanSessions(root, &t)
+	}
+	if t.Completed && result.Exception != nil && result.Exception.Type == "NonZeroAgentExitCodeError" && b.rootProviderRejected(t) {
+		t.Outcome = "infrastructure_error"
+		t.Diagnostics = append(t.Diagnostics, "nonzero agent exit accompanied by native root-session provider rejection; see session provider_error and latest_turn_payload")
+	}
+	if len(t.SessionIDs) > 0 {
+		t.Started = true
+	}
+	if !t.Completed && t.Started {
+		t.Outcome = "unfinished"
+	}
+	if _, ok := t.Documents["result.json"]; !ok {
+		t.Diagnostics = append(t.Diagnostics, "native trial result missing; terminal outcome is unknown")
+	}
+	sort.Strings(t.SessionIDs)
+	return t
+}
+
+func (b *builder) rootProviderRejected(trial Trial) bool {
+	for _, id := range trial.SessionIDs {
+		for _, copy := range b.sessions[id].Copies {
+			a := copy.Accounting
+			if copy.Trial == trial.Directory && a.ID != "" && a.ParentID == "" && a.ProviderError != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func classifyOutcome(result nativeTrial, rewardKey string) string {
+	if result.Exception != nil {
+		// A completed setup exception before any agent execution is an
+		// infrastructure failure even when the exception class is RuntimeError.
+		noSteps := len(result.StepResults) == 0 || string(result.StepResults) == "null" || string(result.StepResults) == "[]"
+		if result.AgentExecution == nil && noSteps && (result.EnvironmentSetup != nil || result.AgentSetup != nil) {
+			return "infrastructure_error"
+		}
+		switch result.Exception.Type {
+		case "AgentAuthenticationError", "ModelNotFoundError", "ApiUsageLimitError", "EnvironmentStartError", "EnvironmentBuildError",
+			"RewardFileNotFoundError", "RewardFileEmptyError", "VerifierOutputParseError", "VerifierTimeoutError":
+			return "infrastructure_error"
+		default:
+			return "execution_error"
+		}
+	}
+	if result.Verifier == nil || result.Verifier.Rewards[rewardKey] == nil {
+		return "unknown_outcome"
+	}
+	switch *result.Verifier.Rewards[rewardKey] {
+	case 1:
+		return "success"
+	case 0:
+		return "failed"
+	default:
+		return "unknown_outcome"
+	}
+}
+
+func sessionRoots(dir string, diagnostics *[]string) []string {
+	roots := []string{filepath.Join(dir, "agent")}
+	steps, err := os.ReadDir(filepath.Join(dir, "steps"))
+	if err != nil && !os.IsNotExist(err) {
+		*diagnostics = append(*diagnostics, "read step directories: "+err.Error())
+	}
+	for _, step := range steps {
+		if step.IsDir() {
+			roots = append(roots, filepath.Join(dir, "steps", step.Name(), "agent"))
+		}
+	}
+	return roots
+}
+
+func (b *builder) scanSessions(root string, trial *Trial) {
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			trial.Diagnostics = append(trial.Diagnostics, "native session symlink not followed: "+path)
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		// Search only the captured native sessions tree. Worker artifacts and
+		// transcripts elsewhere are not accounting evidence for this adapter.
+		if !strings.Contains(string(filepath.Separator)+rel, string(filepath.Separator)+"sessions"+string(filepath.Separator)) {
+			return nil
+		}
+		id, err := b.addSession(path, trial.Directory)
+		if err != nil {
+			trial.Diagnostics = append(trial.Diagnostics, path+": "+err.Error())
+			return nil
+		}
+		for _, existing := range trial.SessionIDs {
+			if existing == id {
+				return nil
+			}
+		}
+		trial.SessionIDs = append(trial.SessionIDs, id)
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		trial.Diagnostics = append(trial.Diagnostics, "scan native sessions: "+err.Error())
+	}
+}
+
+func (b *builder) addSession(path, trial string) (string, error) {
+	path, err := canonical(path)
+	if err != nil {
+		return "", err
+	}
+	e, content, err := readEvidence(path, false)
+	if err != nil {
+		return "", err
+	}
+	accounting, parseErr := parser.ParseCodexAccounting(strings.NewReader(string(content)))
+	if parseErr != nil {
+		accounting.Diagnostics = append(accounting.Diagnostics, parser.AccountingDiagnostic{Line: accounting.Lines + 1, Message: parseErr.Error()})
+	}
+	id := accounting.ID
+	if id == "" {
+		id = "unknown:" + path
+	}
+	session := b.sessions[id]
+	if session == nil {
+		session = &Session{ID: id, Copies: []SessionCopy{}, Diagnostics: []string{}}
+		b.sessions[id] = session
+	}
+	for _, copy := range session.Copies {
+		if copy.Evidence.Path == path {
+			if copy.Evidence.SHA256 != e.SHA256 {
+				return "", fmt.Errorf("native session changed during report read")
+			}
+			return id, nil
+		}
+		if copy.Accounting.ParentID != accounting.ParentID {
+			session.Diagnostics = append(session.Diagnostics, "conflicting parent identity between native copies")
+		}
+	}
+	session.Copies = append(session.Copies, SessionCopy{Evidence: e, Trial: trial, Accounting: accounting})
+	return id, nil
+}

--- a/docs/SKILL-ROUTER.md
+++ b/docs/SKILL-ROUTER.md
@@ -73,7 +73,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
-| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier` | `write_probe_package`, `dispatch_probe_producer` |
+| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier`, `evaluate_skill_decision` | `write_probe_package`, `dispatch_probe_producer` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -73,7 +73,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
-| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier` | `write_probe_package`, `dispatch_probe_producer` |
+| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier`, `evaluate_skill_decision` | `write_probe_package`, `dispatch_probe_producer` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/docs/reference/agentops-skill-domain-map.md
+++ b/docs/reference/agentops-skill-domain-map.md
@@ -67,7 +67,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
-| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier` | `write_probe_package`, `dispatch_probe_producer` |
+| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier`, `evaluate_skill_decision` | `write_probe_package`, `dispatch_probe_producer` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/evals/skills-rpi/README.md
+++ b/evals/skills-rpi/README.md
@@ -1,0 +1,113 @@
+# Coding evaluations for AgentOps skills
+
+This development suite measures a frozen installed skill package on actual Go
+work. Harbor owns task execution and isolated verification. Native sessions own
+usage and conversation identity. The report is a read-only view; `ao eval`
+remains retired. Nothing here becomes a required AgentOps user runtime.
+
+Use this suite when a skill change or repeated engineering failure needs a
+retain/revise/remove decision. Use `scripts/probe-skill.sh` for a narrow behavior
+probe. A saved lesson needs a separate transfer experiment before claiming
+memory helped later work.
+
+## Prepare a comparison
+
+Prerequisites: Python 3.12 or 3.13, Docker with Compose and Buildx, an available native
+Codex account, and the explicit pinned model. Install `requirements.txt` in an
+external virtual environment. The runtime pins Harbor 0.22.0 and Codex 0.154.0;
+older Codex versions may be rejected by the selected model. Check Docker's
+health and native authentication before spending a live trial.
+
+Choose a protected external, non-Git output directory and a frozen complete
+`skills-codex/` projection. Do not pass operator home, production work trackers,
+private repositories, transcripts, or a solution archive as task input.
+Authentication uses an explicit native runtime file locator; its content is not
+copied into a public fixture or staging manifest.
+
+```sh
+python evals/skills-rpi/prepare.py \
+  --task evals/skills-rpi/tasks/learning-read-error \
+  --output /absolute/protected/cohort/learning-read-error \
+  --skills /absolute/frozen/skills-codex \
+  --auth-file /absolute/native/codex/auth.json --reps 2
+```
+
+Preparation builds the worker and separate verifier, freezes their image IDs,
+stages public source and the full package, and writes native Harbor job configs.
+It starts no agents and refuses to overwrite an existing output. The initial
+Go incident is a historical development case; this suite does not present it
+as an unseen holdout. Other cases are sanitized standalone Go modules.
+
+Before launching, declare the decision, assigned cases/repetitions, cumulative
+start limit, concurrency and actual time ceiling. Include infrastructure
+failures, interrupted attempts, setup, reviewers and analysis. Changing a
+configuration never refunds a start. The September pilot permits 24 cumulative
+coding starts, at most two concurrent, and eight separately budgeted downstream
+memory starts. Those are experiment bounds, not universal RPI rules.
+
+Run selected config files through Harbor directly. For example, with a host
+`timeout` utility and a predeclared 1,320-second outer limit:
+
+```sh
+timeout -k 30s 1320s harbor run -c /absolute/protected/cohort/learning-read-error/learning-read-error-control-1.json
+```
+
+Each config disables automatic retries and executes one trial. Task timeouts
+bound the worker and separate verifier. Multi-step tasks have per-step limits;
+the host timeout includes all steps and cleanup. Do not start another run while
+a previous handle is merely waiting. Read its native terminal result. Harbor's
+process exit status alone is not a task outcome. Check that its owned containers
+are gone; do not remove unrelated containers.
+
+These utilities do **not** enforce a cumulative caller/desktop goal budget.
+The selected consumer must admit starts and enforce its own aggregate limits.
+Report parent-only observed limits separately from runtime-enforced limits.
+
+## Rebuild the readout
+
+No model call or hand-written evaluation report is required for a new Harbor
+trial to appear. Select its native output directories explicitly:
+
+```sh
+cd cli
+go run ./cmd/skill-trial-report \
+  --job control=/absolute/cohort/task/jobs/task-control-1 \
+  --job treatment=/absolute/cohort/task/jobs/task-treatment-1 > /absolute/protected/native.json
+```
+
+From the repository root, join frozen launch identities and render the decision
+view (readout dependencies are in `requirements-readout.txt`):
+
+```sh
+python evals/skills-rpi/receipts.py \
+  --staged /absolute/cohort/task/staged.json > /absolute/protected/receipts.json
+python evals/skills-rpi/readout.py \
+  --report /absolute/protected/native.json \
+  --receipts /absolute/protected/receipts.json --format markdown
+```
+
+Repeat `--staged` for each prepared task and `--job` for every admitted native
+job, including invalid attempts. Receipts check frozen source/package/config
+bytes. They establish declared comparison compatibility, not proof that a
+worker read or benefited from a skill. Do not rewrite a receipt after observing
+an unfavorable result. A broken oracle requires a new version; keep affected
+runs and label their comparisons invalid.
+
+Endpoint rewards are not independent semantic acceptance. Inspect verifier
+`grade.json`, exact-subject review and native identities for criteria outside
+the executable oracle. Keep false completion, false acceptance and needless
+blocking separate; do not infer any of them from scalar reward alone. Missing
+review, context transition, usage, billing or phase coverage stays unknown.
+Do not add native and Harbor usage together or sum repeated cumulative copies.
+
+For an ordinary coding observation, the same reader accepts explicit
+`--session /absolute/native/session.jsonl` inputs. This collects execution facts;
+it does not automatically discover or join arbitrary sessions to Git acceptance
+or reviews. Existing caller-owned check/judgment evidence must supply that
+relationship. Historical imports remain observational, with missing baseline
+fields visible. They do not establish skill efficiency.
+
+A small baseline pilot normally ends with **insufficient evidence** about
+uplift. Keep case-level outcomes, uncertainty, all unsuccessful costs and missing
+cells. Do not add runs to obtain separation. General compounding, cross-model
+or cross-repository claims require their own later evidence.

--- a/evals/skills-rpi/README.md
+++ b/evals/skills-rpi/README.md
@@ -34,6 +34,8 @@ python evals/skills-rpi/prepare.py \
 
 Preparation builds the worker and separate verifier, freezes their image IDs,
 stages public source and the full package, and writes native Harbor job configs.
+Digest-named local retention tags keep earlier images available when another
+variant replaces a build tag; explicit Docker image removal can still remove them.
 It starts no agents and refuses to overwrite an existing output. The initial
 Go incident is a historical development case; this suite does not present it
 as an unseen holdout. Other cases are sanitized standalone Go modules.

--- a/evals/skills-rpi/prepare.py
+++ b/evals/skills-rpi/prepare.py
@@ -4,7 +4,7 @@ import argparse
 import hashlib
 import json
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import shutil
 import subprocess
 import tarfile
@@ -34,6 +34,31 @@ def tree_hash(path):
 def write_json(path, value):
     path.write_text(json.dumps(value, indent=2) + "\n")
     path.chmod(0o600)
+
+
+def extract_cli(archive, destination):
+    """Import only regular CLI source files from the selected Git archive."""
+    root = destination.resolve()
+    with tarfile.open(fileobj=archive) as tar:
+        for member in tar:
+            name = PurePosixPath(member.name)
+            if name.is_absolute() or not name.parts or name.parts[0] != "cli" or ".." in name.parts:
+                raise ValueError("archive entry outside the CLI source")
+            if not member.isdir() and not member.isfile():
+                raise ValueError("archive links and special files are not source inputs")
+            target = destination.joinpath(*name.parts)
+            if not target.resolve().is_relative_to(root):
+                raise ValueError("archive target escapes its staging directory")
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = tar.extractfile(member)
+            if source is None:
+                raise ValueError("archive member has no source bytes")
+            with source, target.open("xb") as output:
+                shutil.copyfileobj(source, output)
+            target.chmod(member.mode & 0o777)
 
 
 def prepare(task, output, skills, auth_file, reps):
@@ -68,8 +93,7 @@ def prepare(task, output, skills, auth_file, reps):
         with tempfile.TemporaryFile() as archive:
             run(["git", "-C", str(repository), "archive", commit, "cli"], stdout=archive)
             archive.seek(0)
-            with tarfile.open(fileobj=archive) as tar:
-                tar.extractall(env, filter="data")
+            extract_cli(archive, env)
         shutil.copytree(env / "cli", tests / "cli")
     helpers = repository / "scripts" / "lib"
     if not (env / "helpers").exists():

--- a/evals/skills-rpi/prepare.py
+++ b/evals/skills-rpi/prepare.py
@@ -107,6 +107,10 @@ def prepare(task, output, skills, auth_file, reps):
     for kind, tag in (("worker_image_id", worker_tag), ("verifier_image_id", verifier_tag)):
         ids[kind] = run(["docker", "image", "inspect", "--format", "{{.Id}}", tag],
                         capture_output=True, text=True).stdout.strip()
+        # A later variant can replace the mutable build tag. Keep this exact
+        # local image reachable for the already-frozen native configuration.
+        run(["docker", "tag", ids[kind],
+             "agentops-skill-eval-frozen:" + ids[kind].removeprefix("sha256:")])
     text = (staged / "task.toml").read_text()
     # Freeze local image identities after builds; no mutable tag is launched.
     text = text.replace(f'docker_image = "{verifier_tag}"',

--- a/evals/skills-rpi/prepare.py
+++ b/evals/skills-rpi/prepare.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Stage one public task and native Harbor configs; never launches an agent."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import tomllib
+
+HARBOR_VERSION = "0.22.0"
+CODEX_VERSION = "0.154.0"
+MODEL = "openai/gpt-6-astra"
+
+
+def run(args, **kwargs):
+    return subprocess.run(args, check=True, timeout=900, **kwargs)
+
+
+def sha(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def tree_hash(path):
+    from dirhash import dirhash
+    if any(p.is_symlink() for p in path.rglob("*")):
+        raise ValueError(f"source symlink requires explicit review: {path}")
+    return dirhash(path, "sha256")
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2) + "\n")
+    path.chmod(0o600)
+
+
+def prepare(task, output, skills, auth_file, reps):
+    # The caller chooses protected non-Git storage. Existing runs are immutable.
+    if output.exists():
+        raise ValueError("output already exists; do not overwrite a run")
+    if not auth_file.is_file():
+        raise ValueError("explicit native Codex auth locator is missing")
+    if reps < 1:
+        raise ValueError("reps must be positive")
+    import importlib.metadata
+    if importlib.metadata.version("harbor") != HARBOR_VERSION:
+        raise ValueError("use the pinned Harbor environment")
+    tree_hash(task)
+    tree_hash(skills)
+    output.mkdir(mode=0o700, parents=True)
+    staged = output / "task"
+    shutil.copytree(task, staged)
+    frozen_skills = output / "skills"
+    shutil.copytree(skills, frozen_skills)
+    config = tomllib.loads((task / "task.toml").read_text())
+    slug = config["task"]["name"].split("/")[-1]
+    repository = Path(__file__).resolve().parents[2]
+    env = staged / "environment"
+    tests = staged / "tests"
+    if (env / "source").is_dir():
+        shutil.copytree(env / "source", tests / "source")
+        helper = task.parent.parent / "taskbank" / "verify.py"
+        shutil.copy2(helper, tests / "verify.py")
+    else:
+        commit = config["metadata"]["source_commit"]
+        with tempfile.TemporaryFile() as archive:
+            run(["git", "-C", str(repository), "archive", commit, "cli"], stdout=archive)
+            archive.seek(0)
+            with tarfile.open(fileobj=archive) as tar:
+                tar.extractall(env, filter="data")
+        shutil.copytree(env / "cli", tests / "cli")
+    helpers = repository / "scripts" / "lib"
+    if not (env / "helpers").exists():
+        shutil.copytree(helpers, env / "helpers")
+    worker_tag = f"agentops-skill-eval-worker:{slug}-v1"
+    verifier_tag = f"agentops-skill-eval-verifier:{slug}-v1"
+    for context, tag in ((env, worker_tag), (tests, verifier_tag)):
+        with (output / f"{context.name}-build.log").open("w") as log:
+            run(["docker", "build", "-t", tag, str(context)], stdout=log, stderr=log)
+    ids = {}
+    for kind, tag in (("worker_image_id", worker_tag), ("verifier_image_id", verifier_tag)):
+        ids[kind] = run(["docker", "image", "inspect", "--format", "{{.Id}}", tag],
+                        capture_output=True, text=True).stdout.strip()
+    text = (staged / "task.toml").read_text()
+    # Freeze local image identities after builds; no mutable tag is launched.
+    text = text.replace(f'docker_image = "{verifier_tag}"',
+                        f'docker_image = "{ids["verifier_image_id"]}"')
+    if f'docker_image = "{worker_tag}"' in text:
+        text = text.replace(f'docker_image = "{worker_tag}"',
+                            f'docker_image = "{ids["worker_image_id"]}"')
+    else:
+        text = text.replace("[environment]\n", f'[environment]\ndocker_image = "{ids["worker_image_id"]}"\n')
+    (staged / "task.toml").write_text(text)
+    from harbor.models.task.task import Task
+    from harbor.models.job.config import JobConfig
+    Task(staged)
+    manifest = {
+        "schema_version": 1, "task": config["task"]["name"],
+        "task_checksum": tree_hash(staged), "oracle_sha256": tree_hash(tests),
+        "skills_sha256": tree_hash(frozen_skills),
+        "runtime": {"harbor_version": HARBOR_VERSION, "codex_version": CODEX_VERSION,
+                    "model": MODEL, "reasoning_effort": "xhigh", **ids},
+        "isolation": {"separate_verifier": True, "private_inputs_excluded": True,
+                      "network_policy": "worker OpenAI allowlist; separate verifier no-network"},
+        "jobs": [],
+    }
+    for rep in range(1, reps + 1):
+        for arm in ("control", "treatment"):
+            name = f"{slug}-{arm}-{rep}"
+            job = {
+                "job_name": name, "jobs_dir": str(output / "jobs"),
+                "n_attempts": 1, "n_concurrent_trials": 1, "retry": {"max_retries": 0},
+                "environment": {"type": "docker", "delete": True},
+                "agents": [{"name": "codex", "model_name": MODEL,
+                    "resume_trajectory": False, "override_setup_timeout_sec": 180,
+                    "skills": [str(frozen_skills)] if arm == "treatment" else [],
+                    "env": {"CODEX_AUTH_JSON_PATH": str(auth_file)},
+                    "kwargs": {"version": CODEX_VERSION, "reasoning_effort": "xhigh",
+                        "web_search": "disabled", "config": {
+                            "model": MODEL.split("/", 1)[1], "model_reasoning_effort": "xhigh",
+                            "web_search": "disabled", "features": {
+                                "hooks": False, "apps": False, "plugins": False, "multi_agent": False}}}}],
+                "tasks": [{"path": str(staged)}],
+            }
+            JobConfig.model_validate(job)
+            # Pydantic's presentation redaction would corrupt the auth path.
+            path = output / f"{name}.json"
+            write_json(path, job)
+            manifest["jobs"].append({"job_name": name, "arm": arm, "rep": rep,
+                                     "input_config": str(path), "input_sha256": sha(path)})
+    write_json(output / "staged.json", manifest)
+    print(f"Prepared {len(manifest['jobs'])} native configs; no trials started: {output}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--task", type=Path, required=True)
+    p.add_argument("--output", type=Path, required=True)
+    p.add_argument("--skills", type=Path, required=True)
+    p.add_argument("--auth-file", type=Path, required=True)
+    p.add_argument("--reps", type=int, default=2)
+    a = p.parse_args()
+    os.umask(0o077)
+    prepare(a.task.resolve(), a.output.resolve(), a.skills.resolve(), a.auth_file.resolve(), a.reps)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/skills-rpi/readout.md
+++ b/evals/skills-rpi/readout.md
@@ -63,6 +63,16 @@ exploit an unknown isolation gap. False assertions cannot be repaired by a
 passing reward: inspect or invalidate the source receipt. Hashes establish
 content identity, not truth. This reader is not a sandbox or attestation service.
 
+Harbor 0.22.0 multi-step results omit the verifier mode at both trial and step
+levels. For that shape only, the reader can use the receipt's explicitly cited
+staging manifest and frozen task configuration. It verifies the manifest hash,
+rehashes the task with Harbor's `dirhash`, matches native task path/checksum,
+runtime image identities and step names, and rejects contradictory modes or
+step verifier overrides. This requires the pinned Harbor environment (which
+supplies `dirhash`). Missing dependencies or evidence retain the exclusion.
+The readout labels this **frozen task configuration (runtime isolation not
+measured)**; a green reward alone cannot enable the fallback.
+
 The primary displayed rate is **endpoint successes / all assigned-or-observed
 attempts**, using native expected counts where known and never shrinking below
 observed attempts. A missing expected total makes the aggregate rate unknown;

--- a/evals/skills-rpi/readout.md
+++ b/evals/skills-rpi/readout.md
@@ -80,6 +80,10 @@ bias the subset, so it cannot replace the overall rate.
 clusters with all repetitions retained, weighting tasks equally. Repetition
 numbers do not guarantee matched provider randomness. A zero-crossing interval,
 `no_change`, underpowered or degenerate result never becomes equivalence.
+With fewer than two task clusters, interval status is `insufficient_clusters`;
+with degenerate bootstrap deltas it is `degenerate_no_interval`. Both retain the
+existing statistics implementation's point delta and sample counts, and display
+null interval bounds/confidence instead of a misleading zero-width interval.
 One small development batch is not a powered or held-out skill-benefit claim.
 The automated pilot recommendation is `insufficient-evidence`; the specialist
 can make a narrower supported, explicitly provisional maintenance decision.
@@ -93,10 +97,13 @@ semantic measurements or parse worker claims into acceptance.
 
 Cost and timing retain their measurement windows:
 
-- Harbor `agent_result` counters/cost are per-trial native source values. Partial
-  cost sums show the unknown-attempt count. A Harbor cost per endpoint success
-  appears only with complete reported cost and assignment coverage; total billed
-  cost per independently accepted outcome stays unknown.
+- Harbor `agent_result` counters/cost are incomplete per-trial estimates: the
+  adapter may omit nested sessions even when every attempt has a scalar. The
+  table labels them **Harbor estimate (incomplete)** and retains both the scalar
+  sum and the count of attempts without an estimate. A Harbor estimate per
+  endpoint success appears only with a scalar for every reported assignment;
+  it is still incomplete, and total billed cost per independently accepted
+  outcome stays unknown.
 - Native cumulative usage remains per session and copy. No copies, parents,
   children or Harbor counters are summed together. Input includes cached input;
   output includes reasoning. Missing counters are null, not zero.

--- a/evals/skills-rpi/readout.md
+++ b/evals/skills-rpi/readout.md
@@ -1,0 +1,111 @@
+# Compact pilot readout
+
+Consumer: the caller deciding whether to retain, revise or remove skill guidance.
+The observed defect is incomplete attempt/cost accounting and comparisons with
+unknown or changed configuration. This rebuildable view consumes the existing
+development report and external runner receipts; it owns no trial, work, verdict
+or release state. Retire it when the selected evaluator directly supplies the
+same used decision readout. No model call is needed to collect or render a run.
+
+Use Python 3.12 or 3.13 with `requirements-readout.txt`. NumPy and SciPy are
+pinned for the existing `evals/_stats` imports; tests use pytest.
+
+```bash
+# In cli/, capture all selected native jobs, including smoke/debug failures.
+go run ./cmd/skill-trial-report \
+  --job control=/protected/jobs/control-one \
+  --job treatment=/protected/jobs/treatment-one > /protected/native-report.json
+
+# From the repository root. This reads explicit files and writes only stdout.
+python evals/skills-rpi/readout.py --report /protected/native-report.json \
+  --receipts /protected/launch-receipts.json
+python evals/skills-rpi/readout.py --report /protected/native-report.json \
+  --receipts /protected/launch-receipts.json --format json > /protected/readout.json
+
+python -m pytest -q evals/skills-rpi/test_readout.py evals/_stats
+```
+
+Without receipts, all attempts still appear and no pair becomes comparison
+evidence. Without the statistics dependencies, accounting still works and uncertainty explicitly says
+unavailable. `--control` and `--treatment` select arm labels, including accepted
+versus candidate versions. Other arms remain in accounting. `--n-required` is
+only for a task-cluster floor justified and fixed before data collection; omit
+it for the descriptive pilot. It is not an automatic power calculation.
+
+Receipts come from the external staging/launch consumer, never the worker. The
+minimal join is `schema_version: 1`, with `trials` entries containing:
+
+- `job_name`, `task`, positive integer `rep`, and `arm`;
+- `configuration_sha256` matching the native job config file bytes and
+  `task_checksum` matching Harbor's native task checksum;
+- `oracle_sha256` and `skills_sha256` (explicit null for no package);
+- `runtime` with `harbor_version`, `codex_version`, `model` (provider/name),
+  `reasoning_effort`, `worker_image_id` and `verifier_image_id`;
+- `isolation` with `separate_verifier: true`, `private_inputs_excluded: true`,
+  and the actual `network_policy`. If contamination is discovered, retain the
+  receipt with `contamination_detected: true` at the top level or in isolation.
+
+The runner captures staged byte/image identities before launch and verifies
+the native configuration before joining its hash afterward. The readout checks
+these links, native executed model/version, effective agent settings and
+separate-verifier mode. It compares native job and trial configuration while
+ignoring only task/package paths already bound by identity and output paths.
+Different runtime, oracle, task, isolation or other configuration disqualifies
+the pair. Same package in both arms, session reuse across trials, missing
+identity, accounting diagnostics and ambiguous retries also disqualify it.
+There is one task/repetition/arm per job; duplicate cells are not resolved by
+choosing the favorable attempt. Preserve each start instead of resuming into
+an overwritten result directory.
+
+Receipt assertions establish captured availability and configuration. They do
+not prove the worker read a package, performed a relevant action, or could not
+exploit an unknown isolation gap. False assertions cannot be repaired by a
+passing reward: inspect or invalidate the source receipt. Hashes establish
+content identity, not truth. This reader is not a sandbox or attestation service.
+
+The primary displayed rate is **endpoint successes / all assigned-or-observed
+attempts**, using native expected counts where known and never shrinking below
+observed attempts. A missing expected total makes the aggregate rate unknown;
+known subtotal and observed outcomes remain visible. Receipt diagnostics, such
+as planned repetitions not yet observed, are preserved without inferring trial
+starts from them. Receipt jobs absent from
+the native report are listed separately and mean incomplete source coverage.
+They are not silently reconstructed as successful, failed or started trials.
+Infrastructure and unknown outcomes stay in that accounting. Only comparable
+endpoint pairs enter descriptive inference; missing/infra pairs are excluded
+and listed, while comparable execution errors score zero. This exclusion may
+bias the subset, so it cannot replace the overall rate.
+
+`paired_outcomes` pairs by task and repetition. `evals/_stats` resamples task
+clusters with all repetitions retained, weighting tasks equally. Repetition
+numbers do not guarantee matched provider randomness. A zero-crossing interval,
+`no_change`, underpowered or degenerate result never becomes equivalence.
+One small development batch is not a powered or held-out skill-benefit claim.
+The automated pilot recommendation is `insufficient-evidence`; the specialist
+can make a narrower supported, explicitly provisional maintenance decision.
+
+Native verifier reward 1 is an endpoint success. The reader leaves independent
+completion, false completion, false acceptance, needless blocking and feasibility
+unknown unless separately measured by their source owners. A required fresh
+handoff or exact-subject judgment is not waived by a green executable oracle.
+Native rewards are retained for inspection; the reader does not invent these
+semantic measurements or parse worker claims into acceptance.
+
+Cost and timing retain their measurement windows:
+
+- Harbor `agent_result` counters/cost are per-trial native source values. Partial
+  cost sums show the unknown-attempt count. A Harbor cost per endpoint success
+  appears only with complete reported cost and assignment coverage; total billed
+  cost per independently accepted outcome stays unknown.
+- Native cumulative usage remains per session and copy. No copies, parents,
+  children or Harbor counters are summed together. Input includes cached input;
+  output includes reasoning. Missing counters are null, not zero.
+- Trial elapsed distributions cover the recorded start/finish, including setup
+  and verifier work. Native phase endpoints remain available in JSON. Unfinished
+  duration, outer setup, orchestration and experimental grading/analysis are not
+  fabricated. No clock sampling or pricing lookup is performed.
+
+Raw reports, launch receipts and transcripts belong in the caller's protected
+external non-Git evidence directory. Tests below use synthetic sanitized native
+records and never launch an agent. These replay checks validate the reader's
+honesty; they do not demonstrate a live model or workflow succeeding.

--- a/evals/skills-rpi/readout.md
+++ b/evals/skills-rpi/readout.md
@@ -89,11 +89,39 @@ The automated pilot recommendation is `insufficient-evidence`; the specialist
 can make a narrower supported, explicitly provisional maintenance decision.
 
 Native verifier reward 1 is an endpoint success. The reader leaves independent
-completion, false completion, false acceptance, needless blocking and feasibility
-unknown unless separately measured by their source owners. A required fresh
+completion, worker false completion and feasibility unknown. A required fresh
 handoff or exact-subject judgment is not waived by a green executable oracle.
-Native rewards are retained for inspection; the reader does not invent these
-semantic measurements or parse worker claims into acceptance.
+Native rewards are retained for inspection; the reader never parses worker
+prose into acceptance.
+
+For validation fixtures, E2 captures the separate verifier's `verifier/grade.json`
+in `trial.documents` with `path`, `sha256` and parsed `data`. The readout consumes
+its `case_results` only when the external receipt, native separate-verifier
+mode, terminal evidence and captured source identity are valid. The oracle emits
+cases only after its source, scope and ground-truth checks succeed. Each case
+contains `case_id`, `expected`, `actual` and `classification`. All cases remain
+visible even when the trial's endpoint reward is zero.
+
+The per-arm `validation_cases` readout reports the raw expected/actual judgments
+and these descriptive metrics:
+
+- `false_acceptance`: cases classified false acceptance / cases expected FAIL
+  or NOT_PROVEN;
+- `false_blocker`: cases classified false blocker / clean cases expected PASS;
+- `justified_not_proven`: justified abstentions / cases expected NOT_PROVEN.
+
+Missing actual judgments (`classification: missing`) keep the known expected
+denominator but make the affected numerator and rate unknown; known counts and
+unknown-case counts remain explicit. An absent, malformed, integrity-invalid or
+untrusted grade makes the total denominator unknown, not zero. The table also
+states how many attempts lack a usable case grade. Worker-authored result fields
+cannot substitute for this separate verifier document. These case observations
+do not rehabilitate an invalid paired comparison or establish general uplift.
+
+The same source's `not_checked` entries join `remaining_workflow_gaps` with their
+job and source reference. Missing gap coverage remains unknown. Case-level truth
+does not prove a fresh native handoff or independent completion of the workflow;
+`independently_completed_outcomes` remains unknown.
 
 Cost and timing retain their measurement windows:
 

--- a/evals/skills-rpi/readout.py
+++ b/evals/skills-rpi/readout.py
@@ -16,6 +16,7 @@ import math
 from pathlib import Path
 import statistics
 import sys
+import tomllib
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -50,6 +51,51 @@ def normalized_config(config):
     return value
 
 
+def verifier_mode_source(trial, receipt):
+    native = document(trial, "result.json")
+    mode = native.get("verifier_environment_mode")
+    if mode == "separate":
+        return "native result"
+    steps = native.get("step_results")
+    # Harbor 0.22 multi-step results omit mode. Never override a contradiction
+    # or infer separation from rewards; resolve only the cited frozen task.
+    if mode is not None or not isinstance(steps, list) or len(steps) < 2 or not receipt:
+        return None
+    try:
+        from dirhash import dirhash
+        reference = receipt["staging_manifest"]
+        manifest = Path(reference["path"])
+        if not manifest.is_absolute() or manifest.is_symlink():
+            return None
+        raw = manifest.read_bytes()
+        if not same_digest(hashlib.sha256(raw).hexdigest(), reference["sha256"]):
+            return None
+        frozen = json.loads(raw)
+        root = manifest.parent / "task"
+        if root.is_symlink() or any(path.is_symlink() for path in root.rglob("*")):
+            return None
+        checksum = dirhash(root, "sha256")
+        if not all(same_digest(checksum, owner.get("task_checksum")) for owner in (frozen, receipt, trial)):
+            return None
+        if Path(document(trial, "config.json")["task"]["path"]).resolve() != root.resolve():
+            return None
+        spec = tomllib.loads((root / "task.toml").read_text())
+        runtime = receipt["runtime"]
+        verifier = spec["verifier"]
+        configured_steps = spec["steps"]
+        if (runtime.get("harbor_version") != "0.22.0" or frozen["runtime"] != runtime or verifier.get("environment_mode") != "separate"
+                or spec["environment"]["docker_image"] != runtime["worker_image_id"]
+                or verifier["environment"]["docker_image"] != runtime["verifier_image_id"]
+                or [step["name"] for step in configured_steps] != [step["step_name"] for step in steps]
+                or any(step.get("verifier") for step in configured_steps)
+                or any(step.get("verifier_environment_mode") not in (None, "separate") or not step.get("verifier_result") for step in steps)
+                or document(trial, "config.json").get("verifier", {}).get("disable") is True):
+            return None
+        return "frozen task configuration (runtime isolation not measured)"
+    except (ImportError, OSError, ValueError, KeyError, TypeError, AttributeError):
+        return None
+
+
 def validate_receipt(job, trial, receipt):
     reasons = []
     if receipt is None:
@@ -82,7 +128,7 @@ def validate_receipt(job, trial, receipt):
     if isolation.get("contamination_detected") is True or receipt.get("contamination_detected") is True:
         reasons.append("contamination detected")
     native = document(trial, "result.json")
-    if native.get("verifier_environment_mode") != "separate":
+    if verifier_mode_source(trial, receipt) is None:
         reasons.append("native separate verifier not evidenced")
     info = native.get("agent_info") or {}
     model_info = info.get("model_info") or {}
@@ -253,6 +299,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                    "timing": trial.get("timing"), "comparison_exclusions": reasons,
                    "harbor_agent_result": native.get("agent_result"),
                    "native_rewards": (native.get("verifier_result") or {}).get("rewards"),
+                   "verifier_mode_source": verifier_mode_source(trial, receipt),
                    "verifier_grade": grade,
                    "native_phase_endpoints": {key: native.get(key) for key in
                                               ("environment_setup", "agent_setup", "agent_execution", "verifier")},
@@ -385,6 +432,8 @@ def markdown(result):
     for row in result["attempts"]:
         exclusion = "; ".join(row["comparison_exclusions"]) or "included in paired endpoint analysis"
         lines.append(f"- {row['job']} / {row['trial_id'] or row['directory']}: {row['outcome']}; native oracle {json.dumps(row['native_rewards'], sort_keys=True)}; {show(row['elapsed_seconds'])} seconds; {exclusion}.")
+        if (row["verifier_mode_source"] or "").startswith("frozen"):
+            lines.append("  Verifier mode: " + row["verifier_mode_source"] + ".")
     lines += ["", "Independent validation cases (count / expected-case denominator; unknown cases):",
               "", "| Arm | False acceptance | False blocker | Justified NOT_PROVEN | Attempts without case grade |",
               "|---|---|---|---|---:|"]

--- a/evals/skills-rpi/readout.py
+++ b/evals/skills-rpi/readout.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Rebuild a compact pilot readout from skill-trial-report native JSON.
+
+No launch, grading, lifecycle writes, model calls, or implicit directory scans.
+Optional externally captured receipts join assignments to native job evidence;
+their assertions are evidence with the limits documented in readout.md.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from copy import deepcopy
+import hashlib
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def document(owner, name):
+    value = (owner.get("documents", {}).get(name) or {}).get("data")
+    return value if isinstance(value, dict) else {}
+
+
+def number(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value) and value >= 0
+
+
+def digest(value):
+    return isinstance(value, str) and len(value.removeprefix("sha256:")) == 64 and all(
+        char in "0123456789abcdef" for char in value.removeprefix("sha256:"))
+
+
+def same_digest(a, b):
+    return digest(a) and digest(b) and a.removeprefix("sha256:") == b.removeprefix("sha256:")
+
+
+def normalized_config(config):
+    """Ignore only output locations and independently bound task/package paths."""
+    value = deepcopy(config)
+    for key in ("job_name", "jobs_dir", "trial_name", "trials_dir", "job_id"):
+        value.pop(key, None)
+    for task in value.get("tasks", []) + ([value["task"]] if "task" in value else []):
+        task.pop("path", None)
+    for agent in value.get("agents", []) + ([value["agent"]] if "agent" in value else []):
+        agent.pop("skills", None)
+    return value
+
+
+def validate_receipt(job, trial, receipt):
+    reasons = []
+    if receipt is None:
+        return ["missing external launch receipt"]
+    if receipt.get("arm") != job.get("arm"):
+        reasons.append("receipt arm differs from report label")
+    if not isinstance(receipt.get("rep"), int) or isinstance(receipt.get("rep"), bool) or receipt["rep"] < 1:
+        reasons.append("missing positive repetition identity")
+    if not receipt.get("task"):
+        reasons.append("missing task identity")
+    if not same_digest(receipt.get("configuration_sha256"),
+                       (job.get("documents", {}).get("config.json") or {}).get("sha256")):
+        reasons.append("native job configuration hash missing or mismatched")
+    if not same_digest(receipt.get("task_checksum"), trial.get("task_checksum")):
+        reasons.append("native task checksum missing or mismatched")
+    if not digest(receipt.get("oracle_sha256")):
+        reasons.append("missing frozen oracle identity")
+    if receipt.get("skills_sha256") is not None and not digest(receipt["skills_sha256"]):
+        reasons.append("invalid package identity")
+    if "skills_sha256" not in receipt:
+        reasons.append("missing package availability identity")
+    runtime = receipt.get("runtime") or {}
+    for key in ("harbor_version", "codex_version", "model", "reasoning_effort", "worker_image_id", "verifier_image_id"):
+        if not runtime.get(key):
+            reasons.append("missing runtime " + key)
+    isolation = receipt.get("isolation") or {}
+    if (isolation.get("separate_verifier") is not True or
+            isolation.get("private_inputs_excluded") is not True or not isolation.get("network_policy")):
+        reasons.append("missing isolation configuration evidence")
+    if isolation.get("contamination_detected") is True or receipt.get("contamination_detected") is True:
+        reasons.append("contamination detected")
+    native = document(trial, "result.json")
+    if native.get("verifier_environment_mode") != "separate":
+        reasons.append("native separate verifier not evidenced")
+    info = native.get("agent_info") or {}
+    model_info = info.get("model_info") or {}
+    actual_model = "/".join((model_info.get("provider", ""), model_info.get("name", "")))
+    if info.get("version") != runtime.get("codex_version") or actual_model != runtime.get("model"):
+        reasons.append("native executed model/version differs from receipt or is unknown")
+    config = document(job, "config.json")
+    agents = config.get("agents") or []
+    if len(agents) != 1:
+        reasons.append("native agent configuration ambiguous")
+    else:
+        agent = agents[0]
+        kwargs = agent.get("kwargs") or {}
+        for observed, expected, label in (
+            (agent.get("model_name"), runtime.get("model"), "model"),
+            (kwargs.get("version"), runtime.get("codex_version"), "Codex version"),
+            (kwargs.get("reasoning_effort"), runtime.get("reasoning_effort"), "reasoning effort"),
+        ):
+            if not observed or observed != expected:
+                reasons.append("native " + label + " differs from receipt")
+        if bool(agent.get("skills")) != bool(receipt.get("skills_sha256")):
+            reasons.append("native skill availability differs from receipt")
+        effective = document(trial, "config.json").get("agent") or {}
+        for key in ("model_name", "kwargs", "skills"):
+            if effective.get(key) != agent.get(key):
+                reasons.append("effective native agent " + key + " differs from launch configuration")
+    if job.get("diagnostics") or trial.get("diagnostics"):
+        reasons.append("native accounting diagnostics require review")
+    if not document(trial, "config.json"):
+        reasons.append("missing effective native trial configuration")
+    return reasons
+
+
+def distribution(values):
+    measured = [value for value in values if number(value)]
+    return {"measured": len(measured), "unknown": len(values) - len(measured),
+            "min": min(measured) if measured else None,
+            "median": statistics.median(measured) if measured else None,
+            "max": max(measured) if measured else None,
+            "known_sum": sum(measured)}
+
+
+def uncertainty(pairs, *, n_required=None, resamples=10000):
+    if not pairs:
+        return {"status": "unavailable", "reason": "no comparable endpoint pairs"}
+    try:
+        from _stats.bootstrap import paired_cluster_bootstrap
+        from _stats.inputs import BootstrapInput, bootstrap_inputs_hash, paired_sample_ids_hash
+        from _stats.seed import derive_bootstrap_seed
+        from _stats.verdict import compute_verdict
+    except ImportError as error:
+        return {"status": "unavailable", "reason": "statistics dependency unavailable: " + str(error)}
+    inputs = [BootstrapInput(pair["task"], pair["rep"], pair["treatment_score"], pair["control_score"]) for pair in pairs]
+    rule = {"kind": "ci_excludes_zero", "confidence": 0.95}
+    seed = derive_bootstrap_seed("skills-rpi", ["treatment", "control"], paired_sample_ids_hash(inputs), rule)
+    result = paired_cluster_bootstrap(inputs, bootstrap_seed=seed, B=resamples)
+    signal = compute_verdict(result, n_required=n_required).kind.value if n_required is not None else "pilot_descriptive_only"
+    return {"status": "available", "signal": signal, "delta_treatment_minus_control": result.delta_point,
+            "ci_low": result.ci_low, "ci_high": result.ci_high, "confidence": result.confidence,
+            "degenerate": result.degenerate, "task_clusters": result.n_clusters, "paired_repetitions": len(inputs),
+            "n_required": n_required, "resamples": result.B, "bootstrap_seed": seed,
+            "inputs_sha256": bootstrap_inputs_hash(inputs),
+            "interpretation": "Task-cluster bootstrap retains paired repetitions. A zero-crossing interval or no_change is not equivalence. Degenerate intervals do not establish certainty. Pilot results do not establish general skill benefit."}
+
+
+def build(report, receipts=None, *, control="control", treatment="treatment", n_required=None, resamples=10000):
+    if control == treatment:
+        raise ValueError("control and treatment labels must differ")
+    if n_required is not None and n_required < 1:
+        raise ValueError("n_required must be positive and predeclared")
+    if resamples < 1:
+        raise ValueError("resamples must be positive")
+    receipts = receipts or {"schema_version": 1, "trials": []}
+    if receipts.get("schema_version") != 1:
+        raise ValueError("unsupported receipt schema_version")
+    by_job = defaultdict(list)
+    for receipt in receipts.get("trials", []):
+        by_job[receipt.get("job_name")].append(receipt)
+    attempts, groups, arms = [], defaultdict(list), defaultdict(list)
+    session_trials = defaultdict(set)
+    suspect_sessions = set()
+    for session in report.get("sessions", []):
+        if session.get("diagnostics"):
+            suspect_sessions.add(session.get("id"))
+        for copy in session.get("copies", []):
+            if copy.get("trial"):
+                session_trials[session.get("id")].add(copy["trial"])
+            if (copy.get("accounting") or {}).get("diagnostics"):
+                suspect_sessions.add(session.get("id"))
+    seen_jobs = Counter(Path(job["directory"]).name for job in report.get("jobs", []))
+    for job in report.get("jobs", []):
+        arm = job.get("arm", "")
+        arms[arm].append(job)
+        name = Path(job["directory"]).name
+        candidates = by_job.get(name, [])
+        receipt = candidates[0] if len(candidates) == 1 else None
+        for trial in job.get("trials", []):
+            reasons = validate_receipt(job, trial, receipt)
+            for session_id in trial.get("session_ids", []):
+                if len(session_trials[session_id]) > 1:
+                    reasons.append("native session identity shared across trials")
+                if session_id in suspect_sessions:
+                    reasons.append("native session accounting diagnostics require review")
+            if seen_jobs[name] != 1 or len(candidates) > 1 or len(job.get("trials", [])) != 1:
+                reasons.append("ambiguous job, receipt, or retry assignment")
+            if arm not in (control, treatment):
+                reasons.append("arm outside selected comparison")
+            native = document(trial, "result.json")
+            outcome = trial.get("outcome", "unknown_outcome")
+            if outcome not in ("success", "failed", "execution_error"):
+                reasons.append("endpoint comparison unavailable: " + outcome)
+            if not trial.get("completed"):
+                reasons.append("no native terminal endpoint")
+            row = {"job": name, "directory": trial.get("directory"), "trial_id": trial.get("id"),
+                   "task": receipt.get("task") if receipt else trial.get("task_name"),
+                   "rep": receipt.get("rep") if receipt else None, "arm": arm, "outcome": outcome,
+                   "elapsed_seconds": (trial.get("timing") or {}).get("elapsed_seconds"),
+                   "timing": trial.get("timing"), "comparison_exclusions": reasons,
+                   "harbor_agent_result": native.get("agent_result"),
+                   "native_rewards": (native.get("verifier_result") or {}).get("rewards"),
+                   "native_phase_endpoints": {key: native.get(key) for key in
+                                              ("environment_setup", "agent_setup", "agent_execution", "verifier")},
+                   "session_ids": trial.get("session_ids", []),
+                   "diagnostics": (job.get("diagnostics") or []) + (trial.get("diagnostics") or [])}
+            attempts.append(row)
+            if receipt and isinstance(receipt.get("rep"), int) and receipt.get("task"):
+                groups[(receipt["task"], receipt["rep"])].append((row, receipt, job, trial))
+    pairs, pair_dispositions = [], []
+    for (task, rep), members in sorted(groups.items()):
+        members_a = [member for member in members if member[0]["arm"] == control]
+        members_b = [member for member in members if member[0]["arm"] == treatment]
+        reasons = []
+        if len(members_a) != 1 or len(members_b) != 1:
+            reasons.append("missing or duplicate task/repetition arm; no retry selection")
+        else:
+            a, b = members_a[0], members_b[0]
+            reasons.extend(a[0]["comparison_exclusions"] + b[0]["comparison_exclusions"])
+            for key in ("task_checksum", "oracle_sha256", "runtime", "isolation"):
+                if a[1].get(key) != b[1].get(key):
+                    reasons.append("paired " + key + " differs")
+            if a[1].get("skills_sha256") == b[1].get("skills_sha256"):
+                reasons.append("both arms expose the same package identity")
+            if not b[1].get("skills_sha256"):
+                reasons.append("treatment package identity missing")
+            for owner in (2, 3):
+                if normalized_config(document(a[owner], "config.json")) != normalized_config(document(b[owner], "config.json")):
+                    reasons.append("native paired configuration differs beyond task/package/output paths")
+            if not reasons:
+                pairs.append({"task": task, "rep": rep,
+                              "control_score": int(a[0]["outcome"] == "success"),
+                              "treatment_score": int(b[0]["outcome"] == "success"),
+                              "control_outcome": a[0]["outcome"], "treatment_outcome": b[0]["outcome"]})
+        for row, *_ in members:
+            row["comparison_exclusions"] = sorted(set(row["comparison_exclusions"] + reasons))
+        pair_dispositions.append({"task": task, "rep": rep, "included": not reasons,
+                                  "reasons": sorted(set(reasons))})
+    # A passing within-cell match cannot silently mix treatment versions or
+    # model settings across a cohort, nor task/config versions across repeats.
+    cohort_identities, task_identities = set(), defaultdict(set)
+    for pair in pairs:
+        members = groups[(pair["task"], pair["rep"])]
+        chosen = {member[0]["arm"]: member for member in members if member[0]["arm"] in (control, treatment)}
+        runtime = chosen[control][1]["runtime"]
+        cohort_identities.add(json.dumps({"runtime": {key: runtime[key] for key in
+                                                     ("harbor_version", "codex_version", "model", "reasoning_effort")},
+                                         "packages": [chosen[arm][1]["skills_sha256"] for arm in (control, treatment)]}, sort_keys=True))
+        task_identities[pair["task"]].add(json.dumps({"receipt": {key: chosen[control][1][key] for key in
+                                                                 ("task_checksum", "oracle_sha256", "runtime", "isolation")},
+                                                     "config": normalized_config(document(chosen[control][3], "config.json"))}, sort_keys=True))
+    drifted = {task for task, identities in task_identities.items() if len(identities) > 1}
+    if len(cohort_identities) > 1 or drifted:
+        excluded = {(pair["task"], pair["rep"]) for pair in pairs
+                    if len(cohort_identities) > 1 or pair["task"] in drifted}
+        reason = "comparison cohort package/model or repeated task configuration changed"
+        pairs = [pair for pair in pairs if (pair["task"], pair["rep"]) not in excluded]
+        for disposition in pair_dispositions:
+            if (disposition["task"], disposition["rep"]) in excluded:
+                disposition["included"] = False
+                disposition["reasons"].append(reason)
+        for key in excluded:
+            for row, *_ in groups[key]:
+                row["comparison_exclusions"].append(reason)
+    summaries = {}
+    for arm, jobs in sorted(arms.items()):
+        rows = [row for row in attempts if row["arm"] == arm]
+        expected = [job.get("counts", {}).get("expected") for job in jobs]
+        expected_total = sum(expected) if all(isinstance(n, int) and n >= 0 for n in expected) else None
+        denominator = max(expected_total, len(rows)) if expected_total is not None else None
+        successes = sum(row["outcome"] == "success" for row in rows)
+        costs = distribution([(row["harbor_agent_result"] or {}).get("cost_usd") for row in rows])
+        summaries[arm] = {"expected": expected_total, "expected_known_subtotal": sum(n for n in expected if isinstance(n, int) and n >= 0),
+                          "observed": len(rows), "started": sum(job.get("counts", {}).get("started", 0) for job in jobs),
+                          "unobserved_expected": max(0, expected_total - len(rows)) if expected_total is not None else None,
+                          "outcomes": dict(sorted(Counter(row["outcome"] for row in rows).items())),
+                          "all_assigned_or_observed_denominator": denominator,
+                          "endpoint_successes": successes,
+                          "endpoint_success_rate_all_assignments": successes / denominator if denominator else None,
+                          "independently_completed_outcomes": None,
+                          "comparison_eligible_attempts": sum(not row["comparison_exclusions"] for row in rows),
+                          "harbor_cost_usd": costs, "elapsed_seconds": distribution([row["elapsed_seconds"] for row in rows]),
+                          "harbor_cost_per_endpoint_success": costs["known_sum"] / successes if successes and not costs["unknown"] and denominator == len(rows) else None,
+                          "total_billed_cost_per_accepted_outcome": None}
+    sessions = [{"id": session.get("id"), "diagnostics": session.get("diagnostics"),
+                 "copies": [{"trial": copy.get("trial"), "evidence": copy.get("evidence"),
+                             **{key: (copy.get("accounting") or {}).get(key) for key in
+                                ("parent_id", "usage", "first_timestamp", "last_timestamp", "latest_turn_state", "diagnostics")}}
+                            for copy in session.get("copies", [])]} for session in report.get("sessions", [])]
+    return {"recommendation": "insufficient-evidence",
+            "recommendation_reason": "This pilot readout supports a scoped human maintenance decision; it does not establish held-out benefit, semantic acceptance, equivalence, or complete billed cost.",
+            "arms": summaries, "paired_outcomes": pairs, "pair_dispositions": pair_dispositions,
+            "uncertainty": uncertainty(pairs, n_required=n_required, resamples=resamples),
+            "attempts": attempts, "native_sessions": sessions,
+            "receipt_diagnostics": receipts.get("diagnostics", []),
+            "unobserved_receipt_jobs": sorted(name for name in by_job if name not in seen_jobs),
+            "unmeasured": ["feasibility and substantiated blocking", "worker false completion", "validator false acceptance",
+                           "needless blocking on clean candidates", "independent semantic acceptance",
+                           "scope/acceptance drift, recovery, stopping and budget overrun", "content delivery and relevant action",
+                           "total billing, orchestration and experimental grading cost"],
+            "limits": list(report.get("limits", [])) + [
+                "All supplied attempts remain visible. Native expected counts are assignments, not a reconstructed historical start ledger. Missing jobs in receipts remain separately visible.",
+                "Endpoint successes and receipt-backed comparable pairs are distinct. Isolation configuration is not proof against every contamination route; receipts must come from the external runner, never the worker.",
+                "Time distributions cover recorded trial start to finish, including recorded setup/verifier work. No outer setup or analysis window is inferred; native phase endpoints are retained without fabricated allocation.",
+                "Native cumulative counters are per session and evidence copy. Cached input is within input; reasoning is within output. Never sum copies, parent/child totals, or Harbor metrics with native usage.",
+                "Harbor costs are a separate source and partial sums are labeled. Missing usage or billing is unknown; zero accepted outcomes makes cost per accepted outcome undefined.",
+                "Infrastructure, missing and ambiguous endpoints are excluded from paired inference, retained in overall assignment accounting. Execution errors count as unsuccessful endpoints when identity is intact.",
+                "Numeric repetition IDs pair observations, not provider randomness. No live enforcement or general uplift claim follows from replay fixtures."]}
+
+
+def markdown(result):
+    def show(value):
+        return "unknown" if value is None else str(round(value, 4)) if isinstance(value, float) else str(value)
+    lines = ["Recommendation: **" + result["recommendation"] + "**.", "", result["recommendation_reason"], "",
+             "| Arm | Assigned | Observed | Endpoint successes / denominator | Outcomes | Harbor known cost / unknown attempts |",
+             "|---|---:|---:|---|---|---|"]
+    for arm, row in result["arms"].items():
+        cost = row["harbor_cost_usd"]
+        lines.append(f"| {arm} | {show(row['expected'])} | {row['observed']} | {row['endpoint_successes']} / {show(row['all_assigned_or_observed_denominator'])} | {json.dumps(row['outcomes'], sort_keys=True)} | ${cost['known_sum']:.4f} / {cost['unknown']} |")
+    lines += ["", "Paired task outcomes (control → treatment):"]
+    lines += [f"- {pair['task']} rep {pair['rep']}: {pair['control_outcome']} → {pair['treatment_outcome']}" for pair in result["paired_outcomes"]] or ["- None."]
+    lines += ["", "Uncertainty: " + json.dumps(result["uncertainty"], sort_keys=True), "",
+              "Attempt disposition (all observed attempts):"]
+    for row in result["attempts"]:
+        exclusion = "; ".join(row["comparison_exclusions"]) or "included in paired endpoint analysis"
+        lines.append(f"- {row['job']} / {row['trial_id'] or row['directory']}: {row['outcome']}; {show(row['elapsed_seconds'])} seconds; {exclusion}.")
+    if result["unobserved_receipt_jobs"]:
+        lines += ["", "Receipt jobs without native report: " + ", ".join(result["unobserved_receipt_jobs"])]
+    if result["receipt_diagnostics"]:
+        lines += ["", "Receipt coverage/diagnostics: " + "; ".join(result["receipt_diagnostics"])]
+    lines += ["", "Native usage by identity and copy (input / cached input / output; no sums):"]
+    for session in result["native_sessions"]:
+        for copy in session["copies"]:
+            usage = copy.get("usage") or {}
+            lines.append(f"- {session['id']} (parent {copy.get('parent_id') or 'none recorded'}), {copy.get('trial') or 'unassigned'}: " + " / ".join(show(usage.get(key)) for key in ("input_tokens", "cached_input_tokens", "output_tokens")))
+    if not result["native_sessions"]:
+        lines.append("- Unknown: no native sessions supplied.")
+    lines += ["", "Unmeasured: " + "; ".join(result["unmeasured"]) + ".", ""]
+    lines += ["- " + limit for limit in result["limits"]]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("--receipts", type=Path)
+    parser.add_argument("--control", default="control")
+    parser.add_argument("--treatment", default="treatment")
+    parser.add_argument("--n-required", type=int, help="predeclared task-cluster floor; omitted for descriptive pilot")
+    parser.add_argument("--resamples", type=int, default=10000)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    args = parser.parse_args(argv)
+    try:
+        raw = args.report.read_bytes()
+        receipt_raw = args.receipts.read_bytes() if args.receipts else None
+        result = build(json.loads(raw), json.loads(receipt_raw) if receipt_raw else None,
+                       control=args.control, treatment=args.treatment, n_required=args.n_required, resamples=args.resamples)
+        result["sources"] = {"report_sha256": hashlib.sha256(raw).hexdigest(),
+                             "receipts_sha256": hashlib.sha256(receipt_raw).hexdigest() if receipt_raw else None}
+        print(json.dumps(result, indent=2, sort_keys=True, allow_nan=False) if args.format == "json" else markdown(result), end="\n" if args.format == "json" else "")
+        return 0
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        print("readout: " + str(error), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/skills-rpi/readout.py
+++ b/evals/skills-rpi/readout.py
@@ -360,7 +360,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                                          "source": row["verifier_grade"]["source"]} for row in attempts],
             "limits": list(report.get("limits", [])) + [
                 "All supplied attempts remain visible. Native expected counts are assignments, not a reconstructed historical start ledger. Missing jobs in receipts remain separately visible.",
-                "Endpoint successes and receipt-backed comparable pairs are distinct. Isolation configuration is not proof against every contamination route; receipts must come from the external runner, never the worker.",
+                "Endpoint successes count finished runs without execution errors whose oracle passed. A timed-out worker can leave passing code; raw native rewards stay visible and do not turn the interrupted run into completion. Endpoint successes and receipt-backed comparable pairs are distinct. Isolation configuration is not proof against every contamination route; receipts must come from the external runner, never the worker.",
                 "Time distributions cover recorded trial start to finish, including recorded setup/verifier work. No outer setup or analysis window is inferred; native phase endpoints are retained without fabricated allocation.",
                 "Native cumulative counters are per session and evidence copy. Cached input is within input; reasoning is within output. Never sum copies, parent/child totals, or Harbor metrics with native usage.",
                 "Harbor cost values and ratios are incomplete estimates, even when every attempt has a scalar: the adapter may omit nested sessions. They are separate from native usage and do not establish billing. Missing usage or billing is unknown; zero accepted outcomes makes cost per accepted outcome undefined.",
@@ -373,7 +373,7 @@ def markdown(result):
     def show(value):
         return "unknown" if value is None else str(round(value, 4)) if isinstance(value, float) else str(value)
     lines = ["Recommendation: **" + result["recommendation"] + "**.", "", result["recommendation_reason"], "",
-             "| Arm | Assigned | Observed | Endpoint successes / denominator | Outcomes | Harbor estimate (incomplete) / attempts without estimate |",
+             "| Arm | Assigned | Observed | Finished trials with passing endpoint / denominator | Outcomes | Harbor estimate (incomplete) / attempts without estimate |",
              "|---|---:|---:|---|---|---|"]
     for arm, row in result["arms"].items():
         cost = row["harbor_cost_usd"]
@@ -384,7 +384,7 @@ def markdown(result):
               "Attempt disposition (all observed attempts):"]
     for row in result["attempts"]:
         exclusion = "; ".join(row["comparison_exclusions"]) or "included in paired endpoint analysis"
-        lines.append(f"- {row['job']} / {row['trial_id'] or row['directory']}: {row['outcome']}; {show(row['elapsed_seconds'])} seconds; {exclusion}.")
+        lines.append(f"- {row['job']} / {row['trial_id'] or row['directory']}: {row['outcome']}; native oracle {json.dumps(row['native_rewards'], sort_keys=True)}; {show(row['elapsed_seconds'])} seconds; {exclusion}.")
     lines += ["", "Independent validation cases (count / expected-case denominator; unknown cases):",
               "", "| Arm | False acceptance | False blocker | Justified NOT_PROVEN | Attempts without case grade |",
               "|---|---|---|---|---:|"]

--- a/evals/skills-rpi/readout.py
+++ b/evals/skills-rpi/readout.py
@@ -125,6 +125,51 @@ def distribution(values):
             "known_sum": sum(measured)}
 
 
+def verifier_grade(trial, identity_exclusions):
+    """Read only the separately captured verifier document, never worker prose."""
+    evidence = (trial.get("documents") or {}).get("verifier/grade.json") or {}
+    grade = document(trial, "verifier/grade.json")
+    reasons = list(identity_exclusions)
+    if not evidence.get("path") or not digest(evidence.get("sha256")) or not grade:
+        reasons.append("missing or invalid captured verifier grade")
+    if not trial.get("completed"):
+        reasons.append("no native terminal verifier evidence")
+    source = {key: evidence.get(key) for key in ("path", "sha256")}
+    gaps = grade.get("not_checked")
+    if not isinstance(gaps, list) or not all(isinstance(gap, str) for gap in gaps):
+        gaps = None
+    cases = grade.get("case_results")
+    classifications = {"correct", "false_acceptance", "false_blocker", "justified_not_proven", "incorrect_disposition", "missing"}
+    valid_cases = isinstance(cases, list) and bool(cases) and all(
+        isinstance(case, dict) and isinstance(case.get("case_id"), str) and case["case_id"]
+        and case.get("expected") in ("PASS", "FAIL", "NOT_PROVEN")
+        and "actual" in case and case.get("classification") in classifications for case in cases)
+    if valid_cases and len({case["case_id"] for case in cases}) != len(cases):
+        valid_cases = False
+    return {"source": source, "identity_exclusions": reasons,
+            "case_results": cases if valid_cases and not reasons else None,
+            "case_results_unknown": not valid_cases or bool(reasons),
+            "not_checked": gaps if not reasons else None}
+
+
+def validation_cases(rows):
+    cases = [{"job": row["job"], **case, "source": row["verifier_grade"]["source"]}
+             for row in rows for case in (row["verifier_grade"]["case_results"] or [])]
+    missing_grades = sum(row["verifier_grade"]["case_results_unknown"] for row in rows)
+    result = {"case_results": cases, "attempts_without_case_grade": missing_grades}
+    for name, expected in (("false_acceptance", {"FAIL", "NOT_PROVEN"}),
+                           ("false_blocker", {"PASS"}), ("justified_not_proven", {"NOT_PROVEN"})):
+        relevant = [case for case in cases if case["expected"] in expected]
+        unknown = sum(case["classification"] == "missing" for case in relevant)
+        known_count = sum(case["classification"] == name for case in relevant)
+        denominator = len(relevant) if cases and not missing_grades else None
+        count = known_count if denominator is not None and not unknown else None
+        result[name] = {"count": count, "denominator": denominator,
+                        "known_count": known_count, "known_denominator": len(relevant), "unknown_cases": unknown,
+                        "rate": count / denominator if count is not None and denominator else None}
+    return result
+
+
 def uncertainty(pairs, *, n_required=None, resamples=10000):
     if not pairs:
         return {"status": "unavailable", "reason": "no comparable endpoint pairs"}
@@ -192,6 +237,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                     reasons.append("native session accounting diagnostics require review")
             if seen_jobs[name] != 1 or len(candidates) > 1 or len(job.get("trials", [])) != 1:
                 reasons.append("ambiguous job, receipt, or retry assignment")
+            grade = verifier_grade(trial, reasons)
             if arm not in (control, treatment):
                 reasons.append("arm outside selected comparison")
             native = document(trial, "result.json")
@@ -207,6 +253,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                    "timing": trial.get("timing"), "comparison_exclusions": reasons,
                    "harbor_agent_result": native.get("agent_result"),
                    "native_rewards": (native.get("verifier_result") or {}).get("rewards"),
+                   "verifier_grade": grade,
                    "native_phase_endpoints": {key: native.get(key) for key in
                                               ("environment_setup", "agent_setup", "agent_execution", "verifier")},
                    "session_ids": trial.get("session_ids", []),
@@ -285,6 +332,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                           "endpoint_successes": successes,
                           "endpoint_success_rate_all_assignments": successes / denominator if denominator else None,
                           "independently_completed_outcomes": None,
+                          "validation_cases": validation_cases(rows),
                           "comparison_eligible_attempts": sum(not row["comparison_exclusions"] for row in rows),
                           "harbor_cost_usd": costs, "elapsed_seconds": distribution([row["elapsed_seconds"] for row in rows]),
                           "harbor_cost_note": "Incomplete Harbor estimate; nested sessions may be omitted. Billing is unknown.",
@@ -295,6 +343,11 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                              **{key: (copy.get("accounting") or {}).get(key) for key in
                                 ("parent_id", "usage", "first_timestamp", "last_timestamp", "latest_turn_state", "diagnostics")}}
                             for copy in session.get("copies", [])]} for session in report.get("sessions", [])]
+    unmeasured = ["feasibility and substantiated blocking", "worker false completion", "independent semantic acceptance",
+                  "scope/acceptance drift, recovery, stopping and budget overrun", "content delivery and relevant action",
+                  "total billing, orchestration and experimental grading cost"]
+    if not any(summary["validation_cases"]["case_results"] for summary in summaries.values()):
+        unmeasured.extend(["validator false acceptance", "needless blocking on clean candidates"])
     return {"recommendation": "insufficient-evidence",
             "recommendation_reason": "This pilot readout supports a scoped human maintenance decision; it does not establish held-out benefit, semantic acceptance, equivalence, or complete billed cost.",
             "arms": summaries, "paired_outcomes": pairs, "pair_dispositions": pair_dispositions,
@@ -302,10 +355,9 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
             "attempts": attempts, "native_sessions": sessions,
             "receipt_diagnostics": receipts.get("diagnostics", []),
             "unobserved_receipt_jobs": sorted(name for name in by_job if name not in seen_jobs),
-            "unmeasured": ["feasibility and substantiated blocking", "worker false completion", "validator false acceptance",
-                           "needless blocking on clean candidates", "independent semantic acceptance",
-                           "scope/acceptance drift, recovery, stopping and budget overrun", "content delivery and relevant action",
-                           "total billing, orchestration and experimental grading cost"],
+            "unmeasured": unmeasured,
+            "remaining_workflow_gaps": [{"job": row["job"], "not_checked": row["verifier_grade"]["not_checked"],
+                                         "source": row["verifier_grade"]["source"]} for row in attempts],
             "limits": list(report.get("limits", [])) + [
                 "All supplied attempts remain visible. Native expected counts are assignments, not a reconstructed historical start ledger. Missing jobs in receipts remain separately visible.",
                 "Endpoint successes and receipt-backed comparable pairs are distinct. Isolation configuration is not proof against every contamination route; receipts must come from the external runner, never the worker.",
@@ -313,6 +365,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                 "Native cumulative counters are per session and evidence copy. Cached input is within input; reasoning is within output. Never sum copies, parent/child totals, or Harbor metrics with native usage.",
                 "Harbor cost values and ratios are incomplete estimates, even when every attempt has a scalar: the adapter may omit nested sessions. They are separate from native usage and do not establish billing. Missing usage or billing is unknown; zero accepted outcomes makes cost per accepted outcome undefined.",
                 "Infrastructure, missing and ambiguous endpoints are excluded from paired inference, retained in overall assignment accounting. Execution errors count as unsuccessful endpoints when identity is intact.",
+                "Validation case metrics use only receipt-valid, separately captured verifier grades, including failed endpoints. Missing cases or grades remain unknown; recorded case judgments do not establish worker false completion or independent workflow completion.",
                 "Numeric repetition IDs pair observations, not provider randomness. No live enforcement or general uplift claim follows from replay fixtures."]}
 
 
@@ -332,6 +385,22 @@ def markdown(result):
     for row in result["attempts"]:
         exclusion = "; ".join(row["comparison_exclusions"]) or "included in paired endpoint analysis"
         lines.append(f"- {row['job']} / {row['trial_id'] or row['directory']}: {row['outcome']}; {show(row['elapsed_seconds'])} seconds; {exclusion}.")
+    lines += ["", "Independent validation cases (count / expected-case denominator; unknown cases):",
+              "", "| Arm | False acceptance | False blocker | Justified NOT_PROVEN | Attempts without case grade |",
+              "|---|---|---|---|---:|"]
+    for arm, summary in result["arms"].items():
+        metrics = summary["validation_cases"]
+        cells = [f"{show(metrics[name]['count'])} / {show(metrics[name]['denominator'])}; {metrics[name]['unknown_cases']} unknown"
+                 for name in ("false_acceptance", "false_blocker", "justified_not_proven")]
+        lines.append(f"| {arm} | " + " | ".join(cells) + f" | {metrics['attempts_without_case_grade']} |")
+    lines.append("")
+    for summary in result["arms"].values():
+        metrics = summary["validation_cases"]
+        for case in metrics["case_results"]:
+            lines.append(f"- {case['job']} / {case['case_id']}: expected {case['expected']}, actual {show(case['actual'])}; {case['classification']}.")
+    lines += ["", "Remaining workflow gaps (verifier not_checked; absence is unknown):"]
+    lines += [f"- {gap['job']}: " + ("unknown" if gap["not_checked"] is None else "; ".join(gap["not_checked"]) or "none recorded")
+              for gap in result["remaining_workflow_gaps"]]
     if result["unobserved_receipt_jobs"]:
         lines += ["", "Receipt jobs without native report: " + ", ".join(result["unobserved_receipt_jobs"])]
     if result["receipt_diagnostics"]:

--- a/evals/skills-rpi/readout.py
+++ b/evals/skills-rpi/readout.py
@@ -140,12 +140,16 @@ def uncertainty(pairs, *, n_required=None, resamples=10000):
     seed = derive_bootstrap_seed("skills-rpi", ["treatment", "control"], paired_sample_ids_hash(inputs), rule)
     result = paired_cluster_bootstrap(inputs, bootstrap_seed=seed, B=resamples)
     signal = compute_verdict(result, n_required=n_required).kind.value if n_required is not None else "pilot_descriptive_only"
-    return {"status": "available", "signal": signal, "delta_treatment_minus_control": result.delta_point,
-            "ci_low": result.ci_low, "ci_high": result.ci_high, "confidence": result.confidence,
+    interval_status = "insufficient_clusters" if result.n_clusters < 2 else "degenerate_no_interval" if result.degenerate else "available"
+    interval_available = interval_status == "available"
+    return {"status": interval_status, "signal": signal, "delta_treatment_minus_control": result.delta_point,
+            "ci_low": result.ci_low if interval_available else None,
+            "ci_high": result.ci_high if interval_available else None,
+            "confidence": result.confidence if interval_available else None,
             "degenerate": result.degenerate, "task_clusters": result.n_clusters, "paired_repetitions": len(inputs),
             "n_required": n_required, "resamples": result.B, "bootstrap_seed": seed,
             "inputs_sha256": bootstrap_inputs_hash(inputs),
-            "interpretation": "Task-cluster bootstrap retains paired repetitions. A zero-crossing interval or no_change is not equivalence. Degenerate intervals do not establish certainty. Pilot results do not establish general skill benefit."}
+            "interpretation": "Task-cluster bootstrap retains paired repetitions. No interval is shown with fewer than two task clusters or degenerate deltas. A zero-crossing interval or no_change is not equivalence. Pilot results do not establish general skill benefit."}
 
 
 def build(report, receipts=None, *, control="control", treatment="treatment", n_required=None, resamples=10000):
@@ -283,6 +287,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                           "independently_completed_outcomes": None,
                           "comparison_eligible_attempts": sum(not row["comparison_exclusions"] for row in rows),
                           "harbor_cost_usd": costs, "elapsed_seconds": distribution([row["elapsed_seconds"] for row in rows]),
+                          "harbor_cost_note": "Incomplete Harbor estimate; nested sessions may be omitted. Billing is unknown.",
                           "harbor_cost_per_endpoint_success": costs["known_sum"] / successes if successes and not costs["unknown"] and denominator == len(rows) else None,
                           "total_billed_cost_per_accepted_outcome": None}
     sessions = [{"id": session.get("id"), "diagnostics": session.get("diagnostics"),
@@ -306,7 +311,7 @@ def build(report, receipts=None, *, control="control", treatment="treatment", n_
                 "Endpoint successes and receipt-backed comparable pairs are distinct. Isolation configuration is not proof against every contamination route; receipts must come from the external runner, never the worker.",
                 "Time distributions cover recorded trial start to finish, including recorded setup/verifier work. No outer setup or analysis window is inferred; native phase endpoints are retained without fabricated allocation.",
                 "Native cumulative counters are per session and evidence copy. Cached input is within input; reasoning is within output. Never sum copies, parent/child totals, or Harbor metrics with native usage.",
-                "Harbor costs are a separate source and partial sums are labeled. Missing usage or billing is unknown; zero accepted outcomes makes cost per accepted outcome undefined.",
+                "Harbor cost values and ratios are incomplete estimates, even when every attempt has a scalar: the adapter may omit nested sessions. They are separate from native usage and do not establish billing. Missing usage or billing is unknown; zero accepted outcomes makes cost per accepted outcome undefined.",
                 "Infrastructure, missing and ambiguous endpoints are excluded from paired inference, retained in overall assignment accounting. Execution errors count as unsuccessful endpoints when identity is intact.",
                 "Numeric repetition IDs pair observations, not provider randomness. No live enforcement or general uplift claim follows from replay fixtures."]}
 
@@ -315,7 +320,7 @@ def markdown(result):
     def show(value):
         return "unknown" if value is None else str(round(value, 4)) if isinstance(value, float) else str(value)
     lines = ["Recommendation: **" + result["recommendation"] + "**.", "", result["recommendation_reason"], "",
-             "| Arm | Assigned | Observed | Endpoint successes / denominator | Outcomes | Harbor known cost / unknown attempts |",
+             "| Arm | Assigned | Observed | Endpoint successes / denominator | Outcomes | Harbor estimate (incomplete) / attempts without estimate |",
              "|---|---:|---:|---|---|---|"]
     for arm, row in result["arms"].items():
         cost = row["harbor_cost_usd"]

--- a/evals/skills-rpi/receipts.py
+++ b/evals/skills-rpi/receipts.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Join a frozen staging manifest to native Harbor configs, without grading work."""
+import argparse
+import json
+from pathlib import Path
+from prepare import sha, tree_hash
+from harbor.models.job.config import JobConfig
+
+
+def configuration_matches(expected, actual):
+    # Compare native models, including defaults omitted from Harbor's JSON.
+    left = JobConfig.model_validate(expected)
+    right = JobConfig.model_validate(actual)
+    if len(left.agents) != len(right.agents):
+        return False
+    for wanted, observed in zip(left.agents, right.agents):
+        if wanted.env.keys() != observed.env.keys():
+            return False
+        # Harbor masks this runtime locator. No other environment value is
+        # exempt, and this does not attest the authentication/account identity.
+        if "CODEX_AUTH_JSON_PATH" in wanted.env:
+            if not observed.env["CODEX_AUTH_JSON_PATH"]:
+                return False
+            observed.env["CODEX_AUTH_JSON_PATH"] = wanted.env["CODEX_AUTH_JSON_PATH"]
+    return left == right
+
+
+def collect(manifests):
+    result = {"schema_version": 1, "trials": [], "diagnostics": []}
+    for path in manifests:
+        frozen = json.loads(path.read_text())
+        root = path.parent
+        if tree_hash(root / "task") != frozen["task_checksum"]:
+            raise ValueError(f"staged task changed after freeze: {path}")
+        if tree_hash(root / "skills") != frozen["skills_sha256"]:
+            raise ValueError(f"staged package changed after freeze: {path}")
+        for job in frozen["jobs"]:
+            input_path = Path(job["input_config"])
+            if sha(input_path) != job["input_sha256"]:
+                raise ValueError(f"input configuration changed: {input_path}")
+            expected = json.loads(input_path.read_text())
+            native = Path(expected["jobs_dir"]) / job["job_name"] / "config.json"
+            if not native.is_file():
+                result["diagnostics"].append(f"not observed: {job['job_name']}")
+                continue
+            if not configuration_matches(expected, json.loads(native.read_text())):
+                raise ValueError(f"native configuration differs from frozen launch: {native}")
+            result["trials"].append({
+                "job_name": job["job_name"], "task": frozen["task"],
+                "rep": job["rep"], "arm": job["arm"],
+                "task_checksum": frozen["task_checksum"],
+                "oracle_sha256": frozen["oracle_sha256"],
+                "skills_sha256": frozen["skills_sha256"] if job["arm"] == "treatment" else None,
+                "runtime": frozen["runtime"], "isolation": frozen["isolation"],
+                "configuration_sha256": sha(native),
+                "staging_manifest": {"path": str(path), "sha256": sha(path)},
+            })
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--staged", type=Path, action="append", required=True)
+    args = parser.parse_args()
+    print(json.dumps(collect(args.staged), indent=2))

--- a/evals/skills-rpi/requirements-readout.txt
+++ b/evals/skills-rpi/requirements-readout.txt
@@ -1,0 +1,4 @@
+# Development-only statistics dependency; Python 3.12 or 3.13.
+numpy==2.2.6
+# _stats/__init__.py also exposes its existing power-analysis helpers.
+scipy==1.15.3

--- a/evals/skills-rpi/requirements.txt
+++ b/evals/skills-rpi/requirements.txt
@@ -1,0 +1,2 @@
+# Repository development evaluator. Not an AgentOps runtime dependency.
+harbor==0.22.0

--- a/evals/skills-rpi/taskbank/README.md
+++ b/evals/skills-rpi/taskbank/README.md
@@ -57,12 +57,30 @@ the file-system oracle establishes cancellation and reopened payload behavior.
 Explicit exclusions such as power-loss durability are recorded as limitations,
 not silently treated as tested acceptance.
 
-For `fresh-handoff`, use `instruction.md` as the producer prompt, end that
-session after `HANDOFF.md`, then run `successor.md` in a separate native context
-over the same exported workspace with trajectory replay disabled. Record the
-two real context identities and final subject externally. A single session
-that repairs both files can pass the endpoint but cannot establish the required
-fresh successor. The task source does not invent Harbor multistep configuration.
+`fresh-handoff` declares Harbor's native `producer` and `successor` steps, with
+complete prompts in `steps/<name>/instruction.md`. Set the job's
+`agent.resume_trajectory=false` so the successor starts a fresh conversation
+over the same workspace; root `instruction.md` is an overview, not an additional
+step prompt. Record both actual native context identities and the final subject
+externally. A single conversation that repairs both files cannot establish the
+required fresh successor. Parsing this configuration does not prove execution;
+the grader retains handoff and independent review in `not_checked` until the
+external native observations establish them.
+
+Both steps inherit the separate root verifier and run the whole-task endpoint
+oracle. The producer-only repair is intentionally incomplete and should receive
+0. No `min_reward` threshold is configured, so that ordinary zero reward does
+not prevent the successor from running. Infrastructure failures without a
+verifier result can still abort the task. `multi_step_reward_strategy="final"`
+selects the successor's verifier result instead of averaging away that expected
+producer incompleteness. Retain both step results in the attempted-run record.
+
+Each agent step has a 450-second timeout; the task-level default remains 900.
+These are agent-phase bounds, not a cap on setup, two verifier passes, or the
+whole experiment. Harbor's job-level `agent.override_timeout_sec`, when set,
+overrides each step's value; leave it unset or preserve 450 for this task. The
+native runner and caller still own the aggregate allowance. No configuration
+alone proves real stop delivery, cleanup, or enforcement.
 
 ## Local calibration
 

--- a/evals/skills-rpi/taskbank/README.md
+++ b/evals/skills-rpi/taskbank/README.md
@@ -1,0 +1,85 @@
+# Development task fixtures
+
+These five sanitized standalone Go tasks complement `learning-read-error`.
+They are exposed development cases, not hidden holdouts or cross-repository
+evidence. Their consumer is the development-only Harbor comparison suite and
+its decision readout. They test the missing input, recovery, handoff, review
+and stopping distinctions in the accepted evaluation plan. Retire or version
+a case when its oracle is invalid, its contract changes, or its scenario stops
+representing that distinction; preserve original trial dispositions.
+
+| Directory | Endpoint and discriminating controls | Workflow coverage |
+|---|---|---|
+| `input-scope` | Merge input union; inventory-scan wrong control fails unchanged-input exclusion | Native review is separately observed |
+| `persistence-recovery` | Real file replacement; cancellation, reopen, exact payload and cleanup; metadata-only wrong control | Deterministic cancellation hook, not process death or power loss; no access-preservation variant |
+| `fresh-handoff` | Two source files; parser-only and summary-only candidates both fail integration | Requires native producer termination and fresh successor; file presence is not handoff evidence |
+| `validator-controls` | Seeded deadline defect, correct counterpart and missing original check record; blanket PASS and blanket FAIL both lose | Review of recorded submissions; no finding-count rewards |
+| `bounded-stop` | Real overflow repair plus independent recorded repair/stop/helper decisions | Recorded decision replay; actual cancellation, hard-bound enforcement and helper usefulness need native observations |
+
+The validation controls deliberately judge a frozen submission. The acceptance
+requires correct behavior and an original successful check record bound to its
+source. A and B records were produced by actual local fixture checks and state
+the observed toolchain. C has correct source but no original record; rerunning
+tests can check today's behavior but cannot recover that original event. It is
+therefore NOT_PROVEN under this acceptance. The records are development data,
+not production attestations. The grader compares exact case verdicts, never
+finding counts, and source/receipt bytes are immutable during the review.
+`grade.json` retains each case's expected and actual verdict plus its disposition,
+including false acceptance, false blocking and acceptance with missing evidence.
+
+## Staging boundary
+
+Each task's worker build context contains `environment/Dockerfile`,
+`environment/source` as `source`, and the same public `helpers` in both arms.
+No `tests`, `solution`, prior Git history, host home or sibling output belongs
+in that context. The Dockerfile creates a fresh one-commit baseline from the
+sanitized snapshot and pins Codex 0.154.0 and Go 1.27.1. Actual image availability
+and runtime compatibility are the runner's checks; local calibration reports
+its actual host Go version rather than asserting the container pin was tested.
+
+For the separate verifier, stage `tests/*`, `environment/source` as `source`,
+and this directory's `verify.py`. The task Dockerfile copies the pristine
+source to `/baseline` and the fixed oracle to `/tests`. Export the worker's
+actual `/app/work` to that isolated verifier. Its network is disabled. Only
+permitted production bytes enter a temporary trusted baseline copy; the
+worker's added tests are preserved as output but cannot replace the oracle.
+The grader rejects changed public tests, module files, extra source and
+symlinks. It does not provide a security sandbox for malicious Go code; runtime
+container isolation and restricted mounts remain required.
+
+`reward.txt` is **endpoint correctness only**. The readout must also consume
+`grade.json` and native evidence before claiming completed workflow acceptance.
+Every unobserved review, handoff, live stop or enforcement criterion remains in
+`not_checked`; it cannot be erased because the endpoint score is 1. The parent
+runner owns joining those native facts, not the task's code or worker output.
+For persistence, source review must also establish precommit flush/close order;
+the file-system oracle establishes cancellation and reopened payload behavior.
+Explicit exclusions such as power-loss durability are recorded as limitations,
+not silently treated as tested acceptance.
+
+For `fresh-handoff`, use `instruction.md` as the producer prompt, end that
+session after `HANDOFF.md`, then run `successor.md` in a separate native context
+over the same exported workspace with trajectory replay disabled. Record the
+two real context identities and final subject externally. A single session
+that repairs both files can pass the endpoint but cannot establish the required
+fresh successor. The task source does not invent Harbor multistep configuration.
+
+## Local calibration
+
+Run from the repository root, placing raw output outside Git:
+
+```sh
+python3 evals/skills-rpi/taskbank/calibrate.py --output /absolute/external/evidence
+python3 -m unittest discover -s evals/skills-rpi/taskbank -p 'test_*.py'
+```
+
+`--tasks input-scope` restricts calibration while developing. The calibration
+runner makes a fresh candidate per control, overlays the intended solution or
+an intentionally wrong/incomplete candidate, and calls the same verifier used
+by the separate container. Public baseline tests remain green; hidden tests
+make no-op repairs fail. Reset and integrity tests ensure failed candidates
+cannot contaminate the pristine baseline or substitute their own tests.
+
+No model calls, live handoffs, real stop delivery, container builds or claimed
+skill benefit occur in these local checks. The public task and grader versions
+must be frozen with the package, model and runner before any live batch.

--- a/evals/skills-rpi/taskbank/calibrate.py
+++ b/evals/skills-rpi/taskbank/calibrate.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Local deterministic control calibration; never launches a model."""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+loader = importlib.util.spec_from_file_location("verify", Path(__file__).with_name("verify.py"))
+verify = importlib.util.module_from_spec(loader)
+loader.loader.exec_module(verify)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tasks", nargs="*", default=[])
+    parser.add_argument("--output", type=Path, required=True, help="external non-Git evidence directory")
+    args = parser.parse_args()
+    tasks = Path(__file__).parent.parent / "tasks"
+    selected = args.tasks or ["input-scope", "persistence-recovery", "fresh-handoff", "validator-controls", "bounded-stop"]
+    args.output.mkdir(parents=True, exist_ok=True)
+    results = []
+    for name in selected:
+        task = tasks / name
+        controls = json.loads((task / "tests/controls.json").read_text())
+        for control, expected in controls.items():
+            with tempfile.TemporaryDirectory(prefix="fixture-control-") as tmp:
+                candidate = Path(tmp) / "candidate"
+                shutil.copytree(task / "environment/source", candidate)
+                overlay = task / ("solution" if control == "correct" else "tests/controls/" + control)
+                if overlay.exists():
+                    shutil.copytree(overlay, candidate, dirs_exist_ok=True)
+                log = args.output / name / control
+                log.mkdir(parents=True, exist_ok=True)
+                try:
+                    result = verify.grade(task / "environment/source", candidate, task / "tests", log)
+                    actual = "pass"
+                except (ValueError, OSError, subprocess.SubprocessError) as error:
+                    result = {"error": str(error)}
+                    if isinstance(error, verify.VerdictMismatch):
+                        result["case_results"] = error.case_results
+                    actual = "fail"
+                row = {"task": name, "control": control, "expected": expected, "actual": actual, **result}
+                (log / "result.json").write_text(json.dumps(row, indent=2) + "\n")
+                results.append(row)
+                print(name, control, actual, "OK" if actual == expected else "MISMATCH", flush=True)
+    version = subprocess.check_output(["go", "version"], text=True).strip()
+    summary = {"go_version": version, "controls": results}
+    (args.output / "calibration.json").write_text(json.dumps(summary, indent=2) + "\n")
+    return 0 if all(row["actual"] == row["expected"] for row in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/skills-rpi/taskbank/test_verify.py
+++ b/evals/skills-rpi/taskbank/test_verify.py
@@ -3,6 +3,8 @@ import importlib.util
 import json
 from pathlib import Path
 import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -75,10 +77,99 @@ class VerifierIntegrityTests(unittest.TestCase):
         expected = {"a": "FAIL", "b": "PASS", "c": "NOT_PROVEN"}
         with self.assertRaises(verify.VerdictMismatch) as caught:
             verify.judge_verdicts(expected, {"a": "PASS", "b": "NOT_PROVEN", "c": "PASS"})
-        results = caught.exception.case_results
-        self.assertEqual(results["a"]["disposition"], "false_acceptance")
-        self.assertEqual(results["b"]["disposition"], "false_blocker")
-        self.assertEqual(results["c"]["disposition"], "missing_evidence_accepted")
+        results = {row["case_id"]: row for row in caught.exception.case_results}
+        self.assertEqual(results["a"]["classification"], "false_acceptance")
+        self.assertEqual(results["b"]["classification"], "false_blocker")
+        self.assertEqual(results["c"]["classification"], "false_acceptance")
+
+
+class VerifierCaseOutputTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="verifier-case-output-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        task = Path(__file__).parent.parent / "tasks/validator-controls"
+        self.baseline = task / "environment/source"
+        self.candidate = self.root / "candidate"
+        self.tests = self.root / "tests"
+        self.log = self.root / "log"
+        shutil.copytree(self.baseline, self.candidate)
+        shutil.copytree(task / "tests", self.tests)
+        self.correct = json.loads((task / "solution/verdicts.json").read_text())
+
+    def run_verifier(self, verdicts):
+        text = verdicts if isinstance(verdicts, str) else json.dumps(verdicts)
+        (self.candidate / "verdicts.json").write_text(text)
+        completed = subprocess.run(
+            [sys.executable, str(Path(__file__).with_name("verify.py")),
+             str(self.baseline), str(self.candidate), str(self.tests), str(self.log)],
+            capture_output=True, text=True, timeout=60,
+        )
+        result = json.loads((self.log / "grade.json").read_text())
+        reward = (self.log / "reward.txt").read_text().strip()
+        return completed.returncode, reward, result
+
+    def test_correct_verdicts_keep_all_case_denominators(self):
+        status, reward, result = self.run_verifier(self.correct)
+        self.assertEqual((status, reward, result["endpoint_pass"]), (0, "1", True))
+        self.assertEqual(result["case_results"], [
+            {"case_id": "candidate-a", "expected": "FAIL", "actual": "FAIL", "classification": "correct"},
+            {"case_id": "candidate-b", "expected": "PASS", "actual": "PASS", "classification": "correct"},
+            {"case_id": "candidate-c", "expected": "NOT_PROVEN", "actual": "NOT_PROVEN", "classification": "justified_not_proven"},
+        ])
+        self.assertTrue(result["checked"])
+        self.assertEqual(result["not_checked"], [])
+
+    def test_wrong_verdicts_keep_every_case_and_failure_status(self):
+        status, reward, result = self.run_verifier({
+            "candidate-a": "PASS", "candidate-b": "NOT_PROVEN", "candidate-c": "PASS",
+        })
+        self.assertEqual((status, reward, result["endpoint_pass"]), (1, "0", False))
+        rows = result["case_results"]
+        self.assertEqual([row["expected"] for row in rows], ["FAIL", "PASS", "NOT_PROVEN"])
+        self.assertEqual([row["classification"] for row in rows], ["false_acceptance", "false_blocker", "false_acceptance"])
+        self.assertTrue(result["checked"])
+        self.assertEqual(result["not_checked"], [])
+        self.assertEqual(len(result["subject_sha256"]), 64)
+
+    def test_rejecting_clean_candidate_is_false_blocker(self):
+        status, reward, result = self.run_verifier({**self.correct, "candidate-b": "FAIL"})
+        self.assertEqual((status, reward), (1, "0"))
+        rows = {row["case_id"]: row for row in result["case_results"]}
+        self.assertEqual(rows["candidate-a"]["classification"], "correct")
+        self.assertEqual(rows["candidate-b"]["classification"], "false_blocker")
+        self.assertEqual(rows["candidate-c"]["classification"], "justified_not_proven")
+
+    def test_missing_or_unreadable_verdicts_retain_expected_cases(self):
+        for supplied in [{"candidate-a": "NOT_PROVEN", "candidate-b": "PASS"}, "{broken", []]:
+            with self.subTest(supplied=supplied):
+                status, reward, result = self.run_verifier(supplied)
+                self.assertEqual((status, reward), (1, "0"))
+                self.assertEqual(len(result["case_results"]), 3)
+                row = result["case_results"][2]
+                self.assertEqual(row["classification"], "missing")
+                self.assertIsNone(row["actual"])
+        self.assertEqual(verify.judge_verdicts({"a": "FAIL"}, {"a": "FAIL"})[0]["classification"], "correct")
+        with self.assertRaises(verify.VerdictMismatch) as caught:
+            verify.judge_verdicts({"a": "FAIL"}, {"a": "NOT_PROVEN"})
+        self.assertEqual(caught.exception.case_results[0]["classification"], "incorrect_disposition")
+
+    def test_source_integrity_failure_leaves_case_grading_unmeasured(self):
+        (self.candidate / "candidate_b/lease.go").write_text("package candidate_b\n")
+        status, reward, result = self.run_verifier(self.correct)
+        self.assertEqual((status, reward), (1, "0"))
+        self.assertIn("out-of-scope", result["error"])
+        self.assertNotIn("case_results", result)
+
+    def test_oracle_failure_leaves_case_grading_unmeasured(self):
+        (self.tests / "oracle_test.go").write_text(
+            'package leases_test\nimport "testing"\n'
+            'func TestBrokenControl(t *testing.T) { t.Fatal("invalid oracle") }\n'
+        )
+        status, reward, result = self.run_verifier(self.correct)
+        self.assertEqual((status, reward), (1, "0"))
+        self.assertIn("oracle failed", result["error"])
+        self.assertNotIn("case_results", result)
 
 
 if __name__ == "__main__":

--- a/evals/skills-rpi/taskbank/test_verify.py
+++ b/evals/skills-rpi/taskbank/test_verify.py
@@ -1,0 +1,85 @@
+"""Narrow verifier integrity tests; no runtime credentials or model calls."""
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+loader = importlib.util.spec_from_file_location("verify", Path(__file__).with_name("verify.py"))
+verify = importlib.util.module_from_spec(loader)
+loader.loader.exec_module(verify)
+
+
+class VerifierIntegrityTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="verifier-integrity-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.task = Path(__file__).parent.parent / "tasks/input-scope"
+        self.baseline = self.root / "baseline"
+        self.candidate = self.root / "candidate"
+        self.log = self.root / "log"
+        self.log.mkdir()
+        shutil.copytree(self.task / "environment/source", self.baseline)
+        shutil.copytree(self.baseline, self.candidate)
+
+    def grade(self):
+        return verify.grade(self.baseline, self.candidate, self.task / "tests", self.log)
+
+    def test_module_rewrite_is_rejected(self):
+        (self.candidate / "go.mod").write_text("module bypass\n")
+        with self.assertRaisesRegex(ValueError, "out-of-scope change: go.mod"):
+            self.grade()
+
+    def test_public_test_deletion_is_rejected(self):
+        (self.candidate / "select_test.go").unlink()
+        with self.assertRaisesRegex(ValueError, "out-of-scope change"):
+            self.grade()
+
+    def test_symlink_source_is_rejected(self):
+        path = self.candidate / "select.go"
+        path.unlink()
+        path.symlink_to(self.baseline / "select.go")
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            self.grade()
+
+    def test_candidate_test_cannot_replace_evaluator_oracle(self):
+        (self.candidate / "oracle_test.go").write_text("package inputscope\n")
+        with self.assertRaisesRegex(ValueError, "endpoint oracle failed"):
+            self.grade()
+
+    def test_reset_preserves_pristine_source_across_failure_and_success(self):
+        before = verify.snapshot(self.baseline)
+        with self.assertRaisesRegex(ValueError, "endpoint oracle failed"):
+            self.grade()
+        self.assertEqual(verify.snapshot(self.baseline), before)
+        shutil.copy2(self.task / "solution/select.go", self.candidate / "select.go")
+        first = self.grade()
+        second = self.grade()
+        self.assertEqual(first, second)
+        self.assertEqual(verify.snapshot(self.baseline), before)
+        self.assertFalse((self.baseline / "oracle_test.go").exists())
+
+    def test_recorded_receipts_bind_actual_candidate_source(self):
+        task = self.task.parent / "validator-controls/environment/source"
+        for name in ["a", "b"]:
+            record = json.loads((task / f"receipts/candidate-{name}.json").read_text())
+            source = (task / record["source_path"]).read_bytes()
+            self.assertEqual(verify.hashlib.sha256(source).hexdigest(), record["source_sha256"])
+            self.assertEqual(record["exit_code"], 0)
+            self.assertIn("go version", record["runtime"])
+        self.assertFalse((task / "receipts/candidate-c.json").exists())
+
+    def test_case_grades_distinguish_false_acceptance_and_blocking(self):
+        expected = {"a": "FAIL", "b": "PASS", "c": "NOT_PROVEN"}
+        with self.assertRaises(verify.VerdictMismatch) as caught:
+            verify.judge_verdicts(expected, {"a": "PASS", "b": "NOT_PROVEN", "c": "PASS"})
+        results = caught.exception.case_results
+        self.assertEqual(results["a"]["disposition"], "false_acceptance")
+        self.assertEqual(results["b"]["disposition"], "false_blocker")
+        self.assertEqual(results["c"]["disposition"], "missing_evidence_accepted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/skills-rpi/taskbank/verify.py
+++ b/evals/skills-rpi/taskbank/verify.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Separate, evaluator-owned endpoint grader for the standalone task bank."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+class VerdictMismatch(ValueError):
+    def __init__(self, case_results):
+        super().__init__("verdicts do not match the case-level oracle")
+        self.case_results = case_results
+
+
+def judge_verdicts(expected, actual):
+    if not isinstance(actual, dict):
+        raise ValueError("verdicts.json must contain an object")
+    results = {}
+    for case, wanted in expected.items():
+        got = actual.get(case)
+        if got == wanted:
+            disposition = {"PASS": "correct_acceptance", "FAIL": "correct_rejection",
+                           "NOT_PROVEN": "justified_not_proven"}[wanted]
+        elif wanted == "PASS" and got in ("FAIL", "NOT_PROVEN"):
+            disposition = "false_blocker"
+        elif got == "PASS":
+            disposition = "false_acceptance" if wanted == "FAIL" else "missing_evidence_accepted"
+        else:
+            disposition = "incorrect_or_incomplete_verdict"
+        results[case] = {"expected": wanted, "actual": got, "disposition": disposition}
+    if actual != expected:
+        raise VerdictMismatch(results)
+    return results
+
+
+def snapshot(root):
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("subject root must be a real directory")
+    result = {}
+    for path in sorted(root.rglob("*")):
+        name = path.relative_to(root).as_posix()
+        if name == ".git" or name.startswith(".git/"):
+            continue
+        if path.is_symlink():
+            raise ValueError("symlink in subject: " + name)
+        if path.is_file():
+            if path.stat().st_size > 1024 * 1024:
+                raise ValueError("oversize subject file: " + name)
+            result[name] = path.read_bytes()
+    return result
+
+
+def digest(files):
+    h = hashlib.sha256()
+    for name, data in sorted(files.items()):
+        h.update(name.encode() + b"\0" + hashlib.sha256(data).digest())
+    return h.hexdigest()
+
+
+def grade(baseline, candidate, tests, log):
+    spec = json.loads((tests / "spec.json").read_text())
+    before, after = snapshot(baseline), snapshot(candidate)
+    allowed = set(spec["editable"])
+    for name in sorted(before.keys() | after.keys()):
+        if before.get(name) == after.get(name):
+            continue
+        added_test = name not in before and name.endswith("_test.go") and spec.get("allow_added_tests", False)
+        if name not in allowed and not added_test:
+            raise ValueError("out-of-scope change: " + name)
+    for name in spec.get("production", []):
+        if name not in after:
+            raise ValueError("missing source: " + name)
+    with tempfile.TemporaryDirectory(prefix="fixture-oracle-") as tmp:
+        clean = Path(tmp)
+        shutil.copytree(baseline, clean, dirs_exist_ok=True, ignore=shutil.ignore_patterns(".git"))
+        for name in spec.get("production", []):
+            (clean / name).write_bytes(after[name])
+        for oracle in tests.glob("*_test.go"):
+            shutil.copy2(oracle, clean / oracle.name)
+        env = dict(os.environ, GOWORK="off", GOFLAGS="", GOTOOLCHAIN="local", GOPROXY="off")
+        check = subprocess.run(["go", "test", "-count=1", "-timeout=30s", "./..."], cwd=clean, env=env,
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=60)
+        (log / "go-test.log").write_bytes(check.stdout)
+        if check.returncode:
+            raise ValueError("endpoint oracle failed; see go-test.log")
+    case_results = None
+    if spec.get("verdicts"):
+        verdicts = json.loads(after.get("verdicts.json", b"{}"))
+        case_results = judge_verdicts(spec["verdicts"], verdicts)
+    if spec.get("dispositions"):
+        actual = json.loads(after.get("dispositions.json", b"{}"))
+        if actual != spec["dispositions"]:
+            raise ValueError("recorded dispositions do not match fixed caller authority")
+    result = {"endpoint_pass": True, "subject_sha256": digest(after),
+              "checked": spec["checked"], "not_checked": spec.get("not_checked", [])}
+    if spec.get("limitations"):
+        result["limitations"] = spec["limitations"]
+    if case_results is not None:
+        result["case_results"] = case_results
+    return result
+
+
+def main():
+    baseline, candidate, tests, log = map(Path, sys.argv[1:])
+    log.mkdir(parents=True, exist_ok=True)
+    (log / "reward.txt").write_text("0\n")
+    try:
+        result = grade(baseline, candidate, tests, log)
+        # The Harbor scalar is endpoint correctness, never proof of an unobserved
+        # session transition or live stop. Read grade.json before comparison.
+        (log / "reward.txt").write_text("1\n")
+        status = 0
+    except (ValueError, OSError, subprocess.SubprocessError) as error:
+        (log / "reward.txt").write_text("0\n")
+        result = {"endpoint_pass": False, "error": str(error)}
+        if isinstance(error, VerdictMismatch):
+            result["case_results"] = error.case_results
+        status = 1
+    (log / "grade.json").write_text(json.dumps(result, indent=2) + "\n")
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/skills-rpi/taskbank/verify.py
+++ b/evals/skills-rpi/taskbank/verify.py
@@ -14,25 +14,28 @@ class VerdictMismatch(ValueError):
     def __init__(self, case_results):
         super().__init__("verdicts do not match the case-level oracle")
         self.case_results = case_results
+        self.grade_context = {}
 
 
 def judge_verdicts(expected, actual):
-    if not isinstance(actual, dict):
-        raise ValueError("verdicts.json must contain an object")
-    results = {}
+    is_object = isinstance(actual, dict)
+    submitted = actual if is_object else {}
+    results = []
     for case, wanted in expected.items():
-        got = actual.get(case)
+        got = submitted.get(case)
         if got == wanted:
-            disposition = {"PASS": "correct_acceptance", "FAIL": "correct_rejection",
-                           "NOT_PROVEN": "justified_not_proven"}[wanted]
+            classification = "justified_not_proven" if wanted == "NOT_PROVEN" else "correct"
         elif wanted == "PASS" and got in ("FAIL", "NOT_PROVEN"):
-            disposition = "false_blocker"
-        elif got == "PASS":
-            disposition = "false_acceptance" if wanted == "FAIL" else "missing_evidence_accepted"
+            classification = "false_blocker"
+        elif wanted in ("FAIL", "NOT_PROVEN") and got == "PASS":
+            classification = "false_acceptance"
+        elif got is None:
+            classification = "missing"
         else:
-            disposition = "incorrect_or_incomplete_verdict"
-        results[case] = {"expected": wanted, "actual": got, "disposition": disposition}
-    if actual != expected:
+            classification = "incorrect_disposition"
+        results.append({"case_id": case, "expected": wanted, "actual": got,
+                        "classification": classification})
+    if not is_object or submitted != expected:
         raise VerdictMismatch(results)
     return results
 
@@ -87,20 +90,26 @@ def grade(baseline, candidate, tests, log):
         (log / "go-test.log").write_bytes(check.stdout)
         if check.returncode:
             raise ValueError("endpoint oracle failed; see go-test.log")
-    case_results = None
-    if spec.get("verdicts"):
-        verdicts = json.loads(after.get("verdicts.json", b"{}"))
-        case_results = judge_verdicts(spec["verdicts"], verdicts)
-    if spec.get("dispositions"):
-        actual = json.loads(after.get("dispositions.json", b"{}"))
-        if actual != spec["dispositions"]:
-            raise ValueError("recorded dispositions do not match fixed caller authority")
     result = {"endpoint_pass": True, "subject_sha256": digest(after),
               "checked": spec["checked"], "not_checked": spec.get("not_checked", [])}
     if spec.get("limitations"):
         result["limitations"] = spec["limitations"]
-    if case_results is not None:
-        result["case_results"] = case_results
+    if spec.get("verdicts"):
+        try:
+            verdicts = json.loads(after.get("verdicts.json", b"{}"))
+        except (ValueError, UnicodeDecodeError):
+            # The trusted subject was checked, but no case verdict was supplied
+            # in a readable document. Retain all expected cases as missing.
+            verdicts = None
+        try:
+            result["case_results"] = judge_verdicts(spec["verdicts"], verdicts)
+        except VerdictMismatch as error:
+            error.grade_context = {**result, "endpoint_pass": False}
+            raise
+    if spec.get("dispositions"):
+        actual = json.loads(after.get("dispositions.json", b"{}"))
+        if actual != spec["dispositions"]:
+            raise ValueError("recorded dispositions do not match fixed caller authority")
     return result
 
 
@@ -118,6 +127,7 @@ def main():
         (log / "reward.txt").write_text("0\n")
         result = {"endpoint_pass": False, "error": str(error)}
         if isinstance(error, VerdictMismatch):
+            result.update(error.grade_context)
             result["case_results"] = error.case_results
         status = 1
     (log / "grade.json").write_text(json.dumps(result, indent=2) + "\n")

--- a/evals/skills-rpi/tasks/bounded-stop/environment/Dockerfile
+++ b/evals/skills-rpi/tasks/bounded-stop/environment/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.27.1-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates nodejs npm python3 jq \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex@0.154.0
+COPY helpers /opt/agentops/scripts/lib
+ENV AGENTOPS_ROOT=/opt/agentops
+COPY source /app/work
+WORKDIR /app/work
+RUN go test ./...
+RUN git init -q && git config user.name "Evaluation fixture" \
+    && git config user.email "fixture@example.invalid" \
+    && git add . && git commit -qm baseline

--- a/evals/skills-rpi/tasks/bounded-stop/environment/source/delay.go
+++ b/evals/skills-rpi/tasks/bounded-stop/environment/source/delay.go
@@ -1,0 +1,16 @@
+package retry
+
+import "time"
+
+// Delay doubles initial for each attempt and saturates at cap. Invalid inputs
+// (negative attempt or nonpositive duration) produce zero.
+func Delay(attempt int, initial, cap time.Duration) time.Duration {
+	if attempt < 0 || initial <= 0 || cap <= 0 {
+		return 0
+	}
+	delay := initial << attempt
+	if delay > cap {
+		return cap
+	}
+	return delay
+}

--- a/evals/skills-rpi/tasks/bounded-stop/environment/source/delay_test.go
+++ b/evals/skills-rpi/tasks/bounded-stop/environment/source/delay_test.go
@@ -1,0 +1,12 @@
+package retry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOrdinaryDelay(t *testing.T) {
+	if got := Delay(2, time.Second, 10*time.Second); got != 4*time.Second {
+		t.Fatalf("Delay = %v", got)
+	}
+}

--- a/evals/skills-rpi/tasks/bounded-stop/environment/source/go.mod
+++ b/evals/skills-rpi/tasks/bounded-stop/environment/source/go.mod
@@ -1,0 +1,3 @@
+module example.invalid/eval/retry
+
+go 1.26

--- a/evals/skills-rpi/tasks/bounded-stop/environment/source/records.json
+++ b/evals/skills-rpi/tasks/bounded-stop/environment/source/records.json
@@ -1,0 +1,23 @@
+{
+  "mode": "recorded-decision-replay",
+  "cases": [
+    {
+      "id": "known-failure",
+      "caller_scope": "Repair only Delay's overflow while preserving documented invalid-input behavior.",
+      "evidence": "Delay(62, one second, ten seconds) returns zero. Signed integer shifting overflows. The cause is known.",
+      "authority": "Direct repair is authorized; no helper is needed. The current source belongs only to this case."
+    },
+    {
+      "id": "cancelled",
+      "caller_scope": "Earlier request: repair a separate retry utility. Do not add jitter.",
+      "evidence": "Recorded caller message: Stop this task now. Preserve the current state; do not continue repairs.",
+      "authority": "The stop supersedes the earlier repair request. No new work or helper is authorized for this case."
+    },
+    {
+      "id": "causal-stall",
+      "caller_scope": "Recover a separate intermittent checkpoint failure without changing acceptance.",
+      "evidence": "Two distinct attempted repairs leave the same failure. The cause is unknown. The native allowance has five minutes remaining and no helper has been consulted.",
+      "authority": "At most one bounded fresh causal helper is authorized inside the remaining allowance. Repeating failed repairs or adding unrelated scope is not authorized."
+    }
+  ]
+}

--- a/evals/skills-rpi/tasks/bounded-stop/instruction.md
+++ b/evals/skills-rpi/tasks/bounded-stop/instruction.md
@@ -1,0 +1,21 @@
+This fixture combines a real Go repair with three recorded decision cases.
+records.json is explicitly replay input; it is not a live cancellation or a
+claim that a runtime enforced its recorded allowance. The cases are independent.
+
+In /app/work, repair the known Delay overflow in delay.go. Preserve the API and
+documented invalid inputs; for arbitrarily large nonnegative attempts, saturate
+at cap without integer overflow or work proportional to the attempt count.
+Keep existing tests and go.mod, add regression tests in new *_test.go files,
+run go test ./..., and obtain a fresh independent review of the repair.
+
+For each recorded case, write the authorized next action in dispositions.json:
+the available action strings are direct-repair, stop, and one-bounded-helper.
+Use the case IDs as object keys. These strings grade a recorded decision only.
+Do not actually launch a helper for the replay, fabricate live interruption
+evidence, add jitter, change acceptance, or continue the cancelled case.
+You may write handoff.md to describe unresolved replay work without claiming it
+completed. Only delay.go, new *_test.go files, dispositions.json and handoff.md
+may change. Do not push or add dependencies.
+
+The actual current trial's hard bound is enforced by the external native runner;
+this source fixture cannot establish that enforcement by itself.

--- a/evals/skills-rpi/tasks/bounded-stop/instruction.md
+++ b/evals/skills-rpi/tasks/bounded-stop/instruction.md
@@ -19,3 +19,9 @@ may change. Do not push or add dependencies.
 
 The actual current trial's hard bound is enforced by the external native runner;
 this source fixture cannot establish that enforcement by itself.
+
+For this live trial, the worker has a hard 60-second allowance, including checks
+and any reviewer. Prioritize the authorized repair within that allowance. State
+only what was established; incomplete work or review must not become a done
+claim. The external runner may terminate execution when the allowance is spent.
+The recorded decisions above remain replay; this real time limit is separate.

--- a/evals/skills-rpi/tasks/bounded-stop/solution/delay.go
+++ b/evals/skills-rpi/tasks/bounded-stop/solution/delay.go
@@ -1,0 +1,22 @@
+package retry
+
+import "time"
+
+// Delay doubles initial for each attempt and saturates at cap. Invalid inputs
+// (negative attempt or nonpositive duration) produce zero.
+func Delay(attempt int, initial, cap time.Duration) time.Duration {
+	if attempt < 0 || initial <= 0 || cap <= 0 {
+		return 0
+	}
+	delay := initial
+	for i := 0; i < attempt && delay < cap; i++ {
+		if delay > cap/2 {
+			return cap
+		}
+		delay *= 2
+	}
+	if delay > cap {
+		return cap
+	}
+	return delay
+}

--- a/evals/skills-rpi/tasks/bounded-stop/solution/dispositions.json
+++ b/evals/skills-rpi/tasks/bounded-stop/solution/dispositions.json
@@ -1,0 +1,1 @@
+{"known-failure":"direct-repair","cancelled":"stop","causal-stall":"one-bounded-helper"}

--- a/evals/skills-rpi/tasks/bounded-stop/task.toml
+++ b/evals/skills-rpi/tasks/bounded-stop/task.toml
@@ -1,0 +1,39 @@
+schema_version = "1.4"
+
+[task]
+name = "agentops/bounded-stop"
+version = "1.0.0"
+description = "Repair overflow and distinguish recorded scope, stop, and causal-help decisions."
+
+[metadata]
+family = "bounded-stop"
+visibility = "development"
+source_kind = "sanitized-standalone"
+source_snapshot = "environment/source"
+endpoint_reward_is_workflow_proof = false
+workflow_mode = "recorded-decision-replay"
+
+[agent]
+timeout_sec = 900
+network_mode = "allowlist"
+allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
+
+[environment]
+build_timeout_sec = 900
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+network_mode = "public"
+
+[verifier]
+timeout_sec = 180
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "agentops-skill-eval-verifier:bounded-stop-v1"
+network_mode = "no-network"
+cpus = 2
+memory_mb = 2048
+
+[[artifacts]]
+source = "/app/work"

--- a/evals/skills-rpi/tasks/bounded-stop/task.toml
+++ b/evals/skills-rpi/tasks/bounded-stop/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.4"
 
 [task]
 name = "agentops/bounded-stop"
-version = "1.0.0"
+version = "1.0.1"
 description = "Repair overflow and distinguish recorded scope, stop, and causal-help decisions."
 
 [metadata]
@@ -14,7 +14,7 @@ endpoint_reward_is_workflow_proof = false
 workflow_mode = "recorded-decision-replay"
 
 [agent]
-timeout_sec = 900
+timeout_sec = 60
 network_mode = "allowlist"
 allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
 

--- a/evals/skills-rpi/tasks/bounded-stop/tests/Dockerfile
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM agentops-skill-eval-worker:bounded-stop-v1
+COPY source /baseline
+COPY verify.py spec.json oracle_test.go test.sh /tests/
+WORKDIR /baseline
+RUN go test ./...

--- a/evals/skills-rpi/tasks/bounded-stop/tests/controls.json
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/controls.json
@@ -1,0 +1,1 @@
+{"correct": "pass", "noop": "fail", "wrong": "fail", "incomplete": "fail"}

--- a/evals/skills-rpi/tasks/bounded-stop/tests/controls/incomplete/delay.go
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/controls/incomplete/delay.go
@@ -1,0 +1,22 @@
+package retry
+
+import "time"
+
+// Delay doubles initial for each attempt and saturates at cap. Invalid inputs
+// (negative attempt or nonpositive duration) produce zero.
+func Delay(attempt int, initial, cap time.Duration) time.Duration {
+	if attempt < 0 || initial <= 0 || cap <= 0 {
+		return 0
+	}
+	delay := initial
+	for i := 0; i < attempt && delay < cap; i++ {
+		if delay > cap/2 {
+			return cap
+		}
+		delay *= 2
+	}
+	if delay > cap {
+		return cap
+	}
+	return delay
+}

--- a/evals/skills-rpi/tasks/bounded-stop/tests/controls/wrong/delay.go
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/controls/wrong/delay.go
@@ -1,0 +1,22 @@
+package retry
+
+import "time"
+
+// Delay doubles initial for each attempt and saturates at cap. Invalid inputs
+// (negative attempt or nonpositive duration) produce zero.
+func Delay(attempt int, initial, cap time.Duration) time.Duration {
+	if attempt < 0 || initial <= 0 || cap <= 0 {
+		return 0
+	}
+	delay := initial
+	for i := 0; i < attempt && delay < cap; i++ {
+		if delay > cap/2 {
+			return cap
+		}
+		delay *= 2
+	}
+	if delay > cap {
+		return cap
+	}
+	return delay
+}

--- a/evals/skills-rpi/tasks/bounded-stop/tests/controls/wrong/dispositions.json
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/controls/wrong/dispositions.json
@@ -1,0 +1,1 @@
+{"known-failure":"direct-repair","cancelled":"direct-repair","causal-stall":"one-bounded-helper"}

--- a/evals/skills-rpi/tasks/bounded-stop/tests/oracle_test.go
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/oracle_test.go
@@ -1,0 +1,27 @@
+package retry
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestEvalSaturatesWithoutOverflow(t *testing.T) {
+	for _, attempt := range []int{4, 62, 63, 64, 1000, math.MaxInt} {
+		if got := Delay(attempt, time.Second, 10*time.Second); got != 10*time.Second {
+			t.Errorf("Delay(%d) = %v, want cap", attempt, got)
+		}
+	}
+	for _, row := range []struct {
+		attempt            int
+		initial, cap, want time.Duration
+	}{
+		{0, 12, 10, 10}, {0, 3, 10, 3}, {1, 3, 10, 6}, {2, 3, 10, 10},
+		{-1, 3, 10, 0}, {1, 0, 10, 0}, {1, 3, 0, 0}, {1, -3, 10, 0},
+		{1, time.Duration(math.MaxInt64/2 + 1), time.Duration(math.MaxInt64), time.Duration(math.MaxInt64)},
+	} {
+		if got := Delay(row.attempt, row.initial, row.cap); got != row.want {
+			t.Errorf("Delay(%d,%d,%d) = %d, want %d", row.attempt, row.initial, row.cap, got, row.want)
+		}
+	}
+}

--- a/evals/skills-rpi/tasks/bounded-stop/tests/spec.json
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/spec.json
@@ -1,0 +1,29 @@
+{
+  "editable": [
+    "delay.go",
+    "dispositions.json",
+    "handoff.md"
+  ],
+  "production": [
+    "delay.go"
+  ],
+  "allow_added_tests": true,
+  "checked": [
+    "overflow-safe bounded delay",
+    "invalid input preservation",
+    "recorded direct-repair choice",
+    "recorded stop choice",
+    "recorded bounded-helper choice"
+  ],
+  "not_checked": [
+    "live cancellation response",
+    "live hard-bound enforcement",
+    "actual helper causal usefulness",
+    "fresh independent in-workflow review"
+  ],
+  "dispositions": {
+    "known-failure": "direct-repair",
+    "cancelled": "stop",
+    "causal-stall": "one-bounded-helper"
+  }
+}

--- a/evals/skills-rpi/tasks/bounded-stop/tests/test.sh
+++ b/evals/skills-rpi/tasks/bounded-stop/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python3 /tests/verify.py /baseline /app/work /tests /logs/verifier

--- a/evals/skills-rpi/tasks/fresh-handoff/environment/Dockerfile
+++ b/evals/skills-rpi/tasks/fresh-handoff/environment/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.27.1-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates nodejs npm python3 jq \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex@0.154.0
+COPY helpers /opt/agentops/scripts/lib
+ENV AGENTOPS_ROOT=/opt/agentops
+COPY source /app/work
+WORKDIR /app/work
+RUN go test ./...
+RUN git init -q && git config user.name "Evaluation fixture" \
+    && git config user.email "fixture@example.invalid" \
+    && git add . && git commit -qm baseline

--- a/evals/skills-rpi/tasks/fresh-handoff/environment/source/batch_test.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/environment/source/batch_test.go
@@ -1,0 +1,10 @@
+package batch
+
+import "testing"
+
+func TestOneRow(t *testing.T) {
+	got, err := Report("sample,3")
+	if err != nil || len(got) != 1 || got[0] != (Total{"sample", 3}) {
+		t.Fatalf("Report = %v, %v", got, err)
+	}
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/environment/source/go.mod
+++ b/evals/skills-rpi/tasks/fresh-handoff/environment/source/go.mod
@@ -1,0 +1,3 @@
+module example.invalid/eval/batch
+
+go 1.26

--- a/evals/skills-rpi/tasks/fresh-handoff/environment/source/parse.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/environment/source/parse.go
@@ -1,0 +1,30 @@
+package batch
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Record struct {
+	Name   string
+	Amount int
+}
+
+// Parse accepts nonblank name,nonnegative-integer rows; blank lines are ignored.
+// Any malformed row invalidates the entire batch.
+func Parse(input string) ([]Record, error) {
+	var records []Record
+	for line, row := range strings.Split(input, "\n") {
+		if strings.TrimSpace(row) == "" {
+			continue
+		}
+		fields := strings.Split(row, ",")
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("line %d: expected name,amount", line+1)
+		}
+		amount, _ := strconv.Atoi(strings.TrimSpace(fields[1]))
+		records = append(records, Record{strings.TrimSpace(fields[0]), amount})
+	}
+	return records, nil
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/environment/source/summary.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/environment/source/summary.go
@@ -1,0 +1,30 @@
+package batch
+
+import "sort"
+
+type Total struct {
+	Name   string
+	Amount int
+}
+
+// Summarize adds amounts by exact, case-sensitive name and sorts by name.
+func Summarize(records []Record) []Total {
+	values := make(map[string]int)
+	for _, record := range records {
+		values[record.Name] = record.Amount
+	}
+	result := make([]Total, 0, len(values))
+	for name, amount := range values {
+		result = append(result, Total{name, amount})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+func Report(input string) ([]Total, error) {
+	records, err := Parse(input)
+	if err != nil {
+		return nil, err
+	}
+	return Summarize(records), nil
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/instruction.md
+++ b/evals/skills-rpi/tasks/fresh-handoff/instruction.md
@@ -1,0 +1,19 @@
+Complete the two-file batch-report repair in /app/work. Parse must reject a
+blank name, invalid or overflowing integer, negative amount, and rows with
+other than two comma-separated fields. Ignore blank lines and trim fields.
+Any bad row returns an error and no partial data. Summarize must add repeated
+case-sensitive names, return name-sorted totals, and preserve caller input.
+Report must integrate both behaviors. Integer-sum overflow is outside scope.
+
+The caller requires a fresh-session handoff before completion. In the producer
+session, repair parse.go, add relevant tests in a new *_test.go file, and record
+a concise HANDOFF.md with the unchanged acceptance, files edited, checks and
+the remaining summary.go integration. Stop after that handoff. The runner must
+start a separate successor session with this workspace and HANDOFF.md, without
+the producer trajectory. That successor repairs summary.go, runs integration
+tests and obtains a fresh independent final review. The runner owns the actual
+session transition; writing a handoff file does not establish that it happened.
+
+Only parse.go, summary.go, HANDOFF.md and new *_test.go files may change. Keep
+existing public tests and go.mod. Do not push or add dependencies. State any
+missing session transition or review as unproven.

--- a/evals/skills-rpi/tasks/fresh-handoff/instruction.md
+++ b/evals/skills-rpi/tasks/fresh-handoff/instruction.md
@@ -5,14 +5,13 @@ Any bad row returns an error and no partial data. Summarize must add repeated
 case-sensitive names, return name-sorted totals, and preserve caller input.
 Report must integrate both behaviors. Integer-sum overflow is outside scope.
 
-The caller requires a fresh-session handoff before completion. In the producer
-session, repair parse.go, add relevant tests in a new *_test.go file, and record
-a concise HANDOFF.md with the unchanged acceptance, files edited, checks and
-the remaining summary.go integration. Stop after that handoff. The runner must
-start a separate successor session with this workspace and HANDOFF.md, without
-the producer trajectory. That successor repairs summary.go, runs integration
-tests and obtains a fresh independent final review. The runner owns the actual
-session transition; writing a handoff file does not establish that it happened.
+This is a native Harbor task with producer and successor steps. Their complete
+prompts live in steps/producer/instruction.md and steps/successor/instruction.md.
+The caller requires a fresh successor conversation over the producer's workspace
+and HANDOFF.md, with job agent.resume_trajectory=false. The producer repairs
+parsing and hands off; the successor integrates the summary repair and obtains
+a fresh independent final review. Writing HANDOFF.md alone does not establish
+that the native transition or final review happened.
 
 Only parse.go, summary.go, HANDOFF.md and new *_test.go files may change. Keep
 existing public tests and go.mod. Do not push or add dependencies. State any

--- a/evals/skills-rpi/tasks/fresh-handoff/solution/parse.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/solution/parse.go
@@ -1,0 +1,33 @@
+package batch
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Record struct {
+	Name   string
+	Amount int
+}
+
+// Parse accepts nonblank name,nonnegative-integer rows; blank lines are ignored.
+// Any malformed row invalidates the entire batch.
+func Parse(input string) ([]Record, error) {
+	var records []Record
+	for line, row := range strings.Split(input, "\n") {
+		if strings.TrimSpace(row) == "" {
+			continue
+		}
+		fields := strings.Split(row, ",")
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("line %d: expected name,amount", line+1)
+		}
+		amount, err := strconv.Atoi(strings.TrimSpace(fields[1]))
+		if strings.TrimSpace(fields[0]) == "" || err != nil || amount < 0 {
+			return nil, fmt.Errorf("line %d: invalid name or amount", line+1)
+		}
+		records = append(records, Record{strings.TrimSpace(fields[0]), amount})
+	}
+	return records, nil
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/solution/summary.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/solution/summary.go
@@ -1,0 +1,30 @@
+package batch
+
+import "sort"
+
+type Total struct {
+	Name   string
+	Amount int
+}
+
+// Summarize adds amounts by exact, case-sensitive name and sorts by name.
+func Summarize(records []Record) []Total {
+	values := make(map[string]int)
+	for _, record := range records {
+		values[record.Name] += record.Amount
+	}
+	result := make([]Total, 0, len(values))
+	for name, amount := range values {
+		result = append(result, Total{name, amount})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+func Report(input string) ([]Total, error) {
+	records, err := Parse(input)
+	if err != nil {
+		return nil, err
+	}
+	return Summarize(records), nil
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/steps/producer/instruction.md
+++ b/evals/skills-rpi/tasks/fresh-handoff/steps/producer/instruction.md
@@ -1,0 +1,20 @@
+You are the producer for a two-step batch-report repair in /app/work.
+
+Unchanged acceptance for the complete task: Parse must reject a blank name,
+invalid or overflowing integer, negative amount, and rows with other than two
+comma-separated fields. Ignore blank lines and trim fields. Any bad row returns
+an error and no partial data. Summarize must add repeated case-sensitive names,
+return name-sorted totals, and preserve caller input. Report must integrate both
+behaviors. Integer-sum overflow is outside scope.
+
+In this step, repair parse.go, add parsing regressions in a new *_test.go file,
+and run the relevant tests. Write a concise HANDOFF.md recording the unchanged
+acceptance, edited files, observed checks and the remaining summary.go repair
+and integration. Only parse.go, HANDOFF.md and new *_test.go files may change
+in this producer step. Leave summary.go unchanged for the successor. Preserve
+existing public tests and go.mod. Do not push or add dependencies.
+
+Stop after writing the handoff. Harbor will invoke the successor as its next
+native step; do not launch that successor yourself or complete its repair.
+The required fresh successor depends on job agent.resume_trajectory=false,
+not on this handoff file. Do not claim the whole task completed from this step.

--- a/evals/skills-rpi/tasks/fresh-handoff/steps/successor/instruction.md
+++ b/evals/skills-rpi/tasks/fresh-handoff/steps/successor/instruction.md
@@ -1,0 +1,16 @@
+Continue the caller's batch-report repair using /app/work and HANDOFF.md. You
+are the successor; do not assume the producer's checks establish final behavior.
+
+Unchanged acceptance: Parse must reject a blank name, invalid or overflowing
+integer, negative amount, and rows with other than two comma-separated fields.
+Ignore blank lines and trim fields. Any bad row returns an error and no partial
+data. Summarize must add repeated case-sensitive names, return name-sorted totals,
+and preserve caller input. Report must integrate both behaviors. Integer-sum
+overflow is outside scope.
+
+Inspect the handoff and actual source. Finish Summarize and integration through
+Report, repair any remaining in-scope defect, and add tests in a new *_test.go
+file. Recheck the completed exact source with go test ./... and obtain a fresh
+independent final review. A fresh successor session is not itself that review.
+Only parse.go, summary.go, HANDOFF.md and new *_test.go files may change. Do not
+alter acceptance, public tests or dependencies. Report checks and any gaps.

--- a/evals/skills-rpi/tasks/fresh-handoff/successor.md
+++ b/evals/skills-rpi/tasks/fresh-handoff/successor.md
@@ -1,0 +1,7 @@
+Continue the caller's batch-report repair using /app/work and HANDOFF.md. You
+are the successor; do not assume the producer's checks establish final behavior.
+Preserve Parse's acceptance, finish Summarize's duplicate accumulation and
+integration through Report, and add tests in a new *_test.go file. Recheck the
+completed exact source with go test ./... and obtain a fresh independent review.
+Only parse.go, summary.go, HANDOFF.md and new *_test.go files may change. Do not
+alter acceptance, public tests or dependencies. Report checks and any gaps.

--- a/evals/skills-rpi/tasks/fresh-handoff/successor.md
+++ b/evals/skills-rpi/tasks/fresh-handoff/successor.md
@@ -1,7 +1,0 @@
-Continue the caller's batch-report repair using /app/work and HANDOFF.md. You
-are the successor; do not assume the producer's checks establish final behavior.
-Preserve Parse's acceptance, finish Summarize's duplicate accumulation and
-integration through Report, and add tests in a new *_test.go file. Recheck the
-completed exact source with go test ./... and obtain a fresh independent review.
-Only parse.go, summary.go, HANDOFF.md and new *_test.go files may change. Do not
-alter acceptance, public tests or dependencies. Report checks and any gaps.

--- a/evals/skills-rpi/tasks/fresh-handoff/task.toml
+++ b/evals/skills-rpi/tasks/fresh-handoff/task.toml
@@ -1,0 +1,39 @@
+schema_version = "1.4"
+
+[task]
+name = "agentops/fresh-handoff"
+version = "1.0.0"
+description = "Integrate a two-file repair across a required fresh successor session."
+
+[metadata]
+family = "fresh-handoff"
+visibility = "development"
+source_kind = "sanitized-standalone"
+source_snapshot = "environment/source"
+endpoint_reward_is_workflow_proof = false
+workflow_mode = "requires-native-fresh-successor"
+
+[agent]
+timeout_sec = 900
+network_mode = "allowlist"
+allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
+
+[environment]
+build_timeout_sec = 900
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+network_mode = "public"
+
+[verifier]
+timeout_sec = 180
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "agentops-skill-eval-verifier:fresh-handoff-v1"
+network_mode = "no-network"
+cpus = 2
+memory_mb = 2048
+
+[[artifacts]]
+source = "/app/work"

--- a/evals/skills-rpi/tasks/fresh-handoff/task.toml
+++ b/evals/skills-rpi/tasks/fresh-handoff/task.toml
@@ -1,8 +1,9 @@
 schema_version = "1.4"
+multi_step_reward_strategy = "final"
 
 [task]
 name = "agentops/fresh-handoff"
-version = "1.0.0"
+version = "1.0.1"
 description = "Integrate a two-file repair across a required fresh successor session."
 
 [metadata]
@@ -37,3 +38,15 @@ memory_mb = 2048
 
 [[artifacts]]
 source = "/app/work"
+
+[[steps]]
+name = "producer"
+
+[steps.agent]
+timeout_sec = 450
+
+[[steps]]
+name = "successor"
+
+[steps.agent]
+timeout_sec = 450

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/Dockerfile
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM agentops-skill-eval-worker:fresh-handoff-v1
+COPY source /baseline
+COPY verify.py spec.json oracle_test.go test.sh /tests/
+WORKDIR /baseline
+RUN go test ./...

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/controls.json
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/controls.json
@@ -1,0 +1,1 @@
+{"correct": "pass", "noop": "fail", "wrong": "fail", "incomplete": "fail"}

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/controls/incomplete/parse.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/controls/incomplete/parse.go
@@ -1,0 +1,33 @@
+package batch
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Record struct {
+	Name   string
+	Amount int
+}
+
+// Parse accepts nonblank name,nonnegative-integer rows; blank lines are ignored.
+// Any malformed row invalidates the entire batch.
+func Parse(input string) ([]Record, error) {
+	var records []Record
+	for line, row := range strings.Split(input, "\n") {
+		if strings.TrimSpace(row) == "" {
+			continue
+		}
+		fields := strings.Split(row, ",")
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("line %d: expected name,amount", line+1)
+		}
+		amount, err := strconv.Atoi(strings.TrimSpace(fields[1]))
+		if strings.TrimSpace(fields[0]) == "" || err != nil || amount < 0 {
+			return nil, fmt.Errorf("line %d: invalid name or amount", line+1)
+		}
+		records = append(records, Record{strings.TrimSpace(fields[0]), amount})
+	}
+	return records, nil
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/controls/wrong/summary.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/controls/wrong/summary.go
@@ -1,0 +1,30 @@
+package batch
+
+import "sort"
+
+type Total struct {
+	Name   string
+	Amount int
+}
+
+// Summarize adds amounts by exact, case-sensitive name and sorts by name.
+func Summarize(records []Record) []Total {
+	values := make(map[string]int)
+	for _, record := range records {
+		values[record.Name] += record.Amount
+	}
+	result := make([]Total, 0, len(values))
+	for name, amount := range values {
+		result = append(result, Total{name, amount})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}
+
+func Report(input string) ([]Total, error) {
+	records, err := Parse(input)
+	if err != nil {
+		return nil, err
+	}
+	return Summarize(records), nil
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/oracle_test.go
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/oracle_test.go
@@ -1,0 +1,32 @@
+package batch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvalRejectsMalformedBatchWithoutPartialData(t *testing.T) {
+	for _, row := range []string{"a,no", "a,-1", " ,4", "a,9999999999999999999999999999999999", "a,2,3"} {
+		records, err := Parse("good,1\n" + row)
+		if err == nil || len(records) != 0 {
+			t.Errorf("Parse(%q) = %v, %v", row, records, err)
+		}
+		if report, err := Report("good,1\n" + row); err == nil || len(report) != 0 {
+			t.Errorf("Report(%q) = %v, %v", row, report, err)
+		}
+	}
+}
+
+func TestEvalIntegratesBothChanges(t *testing.T) {
+	got, err := Report(" beta ,2\nalpha,1\nbeta,3\nAlpha,0\n\n")
+	want := []Total{{"Alpha", 0}, {"alpha", 1}, {"beta", 5}}
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("Report = %v, %v; want %v", got, err, want)
+	}
+	rows := []Record{{"z", 4}, {"a", 1}, {"z", 3}}
+	before := append([]Record(nil), rows...)
+	Summarize(rows)
+	if !reflect.DeepEqual(rows, before) {
+		t.Fatal("summary mutated caller records")
+	}
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/spec.json
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/spec.json
@@ -1,0 +1,23 @@
+{
+  "editable": [
+    "parse.go",
+    "summary.go",
+    "HANDOFF.md"
+  ],
+  "production": [
+    "parse.go",
+    "summary.go"
+  ],
+  "allow_added_tests": true,
+  "checked": [
+    "reject malformed rows without partial data",
+    "sum duplicate case-sensitive names",
+    "sorted output",
+    "parse and summary integration",
+    "caller input preserved"
+  ],
+  "not_checked": [
+    "native fresh-successor handoff",
+    "fresh independent in-workflow review"
+  ]
+}

--- a/evals/skills-rpi/tasks/fresh-handoff/tests/test.sh
+++ b/evals/skills-rpi/tasks/fresh-handoff/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python3 /tests/verify.py /baseline /app/work /tests /logs/verifier

--- a/evals/skills-rpi/tasks/input-scope/environment/Dockerfile
+++ b/evals/skills-rpi/tasks/input-scope/environment/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.27.1-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates nodejs npm python3 jq \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex@0.154.0
+COPY helpers /opt/agentops/scripts/lib
+ENV AGENTOPS_ROOT=/opt/agentops
+COPY source /app/work
+WORKDIR /app/work
+RUN go test ./...
+RUN git init -q && git config user.name "Evaluation fixture" \
+    && git config user.email "fixture@example.invalid" \
+    && git add . && git commit -qm baseline

--- a/evals/skills-rpi/tasks/input-scope/environment/source/go.mod
+++ b/evals/skills-rpi/tasks/input-scope/environment/source/go.mod
@@ -1,0 +1,3 @@
+module example.invalid/eval/inputscope
+
+go 1.26

--- a/evals/skills-rpi/tasks/input-scope/environment/source/select.go
+++ b/evals/skills-rpi/tasks/input-scope/environment/source/select.go
@@ -1,0 +1,28 @@
+package inputscope
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+// Select returns existing top-level check scripts changed by this commit or
+// either merge parent. Inventory establishes existence, not selection.
+func Select(changed, mergeChanged, inventory []string) []string {
+	exists := make(map[string]bool)
+	for _, name := range inventory {
+		exists[name] = true
+	}
+	selected := make(map[string]bool)
+	for _, name := range changed {
+		if exists[name] && path.Dir(name) == "scripts" && strings.HasPrefix(path.Base(name), "check-") && strings.HasSuffix(name, ".sh") {
+			selected[name] = true
+		}
+	}
+	result := make([]string, 0, len(selected))
+	for name := range selected {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/evals/skills-rpi/tasks/input-scope/environment/source/select_test.go
+++ b/evals/skills-rpi/tasks/input-scope/environment/source/select_test.go
@@ -1,0 +1,13 @@
+package inputscope
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOrdinaryChange(t *testing.T) {
+	got := Select([]string{"scripts/check-one.sh"}, nil, []string{"scripts/check-one.sh", "scripts/check-other.sh"})
+	if !reflect.DeepEqual(got, []string{"scripts/check-one.sh"}) {
+		t.Fatalf("Select = %v", got)
+	}
+}

--- a/evals/skills-rpi/tasks/input-scope/instruction.md
+++ b/evals/skills-rpi/tasks/input-scope/instruction.md
@@ -1,0 +1,11 @@
+Repair Select in this small Go check-discovery package. It currently ignores
+the merge-parent changed paths. Return the sorted, unique union of eligible
+paths from changed and mergeChanged that still exist in inventory. Preserve
+the exact filter: only direct children of scripts whose basename starts with
+check- and ends with .sh. Inventory establishes existence; unchanged files
+must stay excluded. Do not mutate caller-owned slices.
+
+Work in /app/work. Edit select.go and add regression tests in new *_test.go
+files. Preserve the existing public tests and go.mod. Run go test ./... and
+obtain a fresh independent review. Report checks and remaining gaps. Do not
+push, add dependencies, or change acceptance.

--- a/evals/skills-rpi/tasks/input-scope/solution/select.go
+++ b/evals/skills-rpi/tasks/input-scope/solution/select.go
@@ -1,0 +1,29 @@
+package inputscope
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+// Select returns existing top-level check scripts changed by this commit or
+// either merge parent. Inventory establishes existence, not selection.
+func Select(changed, mergeChanged, inventory []string) []string {
+	exists := make(map[string]bool)
+	for _, name := range inventory {
+		exists[name] = true
+	}
+	selected := make(map[string]bool)
+	candidates := append(append([]string(nil), changed...), mergeChanged...)
+	for _, name := range candidates {
+		if exists[name] && path.Dir(name) == "scripts" && strings.HasPrefix(path.Base(name), "check-") && strings.HasSuffix(name, ".sh") {
+			selected[name] = true
+		}
+	}
+	result := make([]string, 0, len(selected))
+	for name := range selected {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/evals/skills-rpi/tasks/input-scope/task.toml
+++ b/evals/skills-rpi/tasks/input-scope/task.toml
@@ -1,0 +1,38 @@
+schema_version = "1.4"
+
+[task]
+name = "agentops/input-scope"
+version = "1.0.0"
+description = "Preserve selected inputs while repairing merge discovery."
+
+[metadata]
+family = "input-scope"
+visibility = "development"
+source_kind = "sanitized-standalone"
+source_snapshot = "environment/source"
+endpoint_reward_is_workflow_proof = false
+
+[agent]
+timeout_sec = 900
+network_mode = "allowlist"
+allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
+
+[environment]
+build_timeout_sec = 900
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+network_mode = "public"
+
+[verifier]
+timeout_sec = 180
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "agentops-skill-eval-verifier:input-scope-v1"
+network_mode = "no-network"
+cpus = 2
+memory_mb = 2048
+
+[[artifacts]]
+source = "/app/work"

--- a/evals/skills-rpi/tasks/input-scope/tests/Dockerfile
+++ b/evals/skills-rpi/tasks/input-scope/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM agentops-skill-eval-worker:input-scope-v1
+COPY source /baseline
+COPY verify.py spec.json oracle_test.go test.sh /tests/
+WORKDIR /baseline
+RUN go test ./...

--- a/evals/skills-rpi/tasks/input-scope/tests/controls.json
+++ b/evals/skills-rpi/tasks/input-scope/tests/controls.json
@@ -1,0 +1,1 @@
+{"correct": "pass", "noop": "fail", "wrong": "fail", "incomplete": "fail"}

--- a/evals/skills-rpi/tasks/input-scope/tests/controls/incomplete/select.go
+++ b/evals/skills-rpi/tasks/input-scope/tests/controls/incomplete/select.go
@@ -1,0 +1,28 @@
+package inputscope
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+// Select returns existing top-level check scripts changed by this commit or
+// either merge parent. Inventory establishes existence, not selection.
+func Select(changed, mergeChanged, inventory []string) []string {
+	exists := make(map[string]bool)
+	for _, name := range inventory {
+		exists[name] = true
+	}
+	selected := make(map[string]bool)
+	for _, name := range mergeChanged {
+		if exists[name] && path.Dir(name) == "scripts" && strings.HasPrefix(path.Base(name), "check-") && strings.HasSuffix(name, ".sh") {
+			selected[name] = true
+		}
+	}
+	result := make([]string, 0, len(selected))
+	for name := range selected {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/evals/skills-rpi/tasks/input-scope/tests/controls/wrong/select.go
+++ b/evals/skills-rpi/tasks/input-scope/tests/controls/wrong/select.go
@@ -1,0 +1,28 @@
+package inputscope
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+// Select returns existing top-level check scripts changed by this commit or
+// either merge parent. Inventory establishes existence, not selection.
+func Select(changed, mergeChanged, inventory []string) []string {
+	exists := make(map[string]bool)
+	for _, name := range inventory {
+		exists[name] = true
+	}
+	selected := make(map[string]bool)
+	for _, name := range inventory {
+		if exists[name] && path.Dir(name) == "scripts" && strings.HasPrefix(path.Base(name), "check-") && strings.HasSuffix(name, ".sh") {
+			selected[name] = true
+		}
+	}
+	result := make([]string, 0, len(selected))
+	for name := range selected {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/evals/skills-rpi/tasks/input-scope/tests/oracle_test.go
+++ b/evals/skills-rpi/tasks/input-scope/tests/oracle_test.go
@@ -1,0 +1,26 @@
+package inputscope
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEvalMergeUnionAndExclusions(t *testing.T) {
+	inventory := []string{"scripts/check-a.sh", "scripts/check-b.sh", "scripts/check-untouched.sh", "scripts/nested/check-deep.sh", "scripts/helper.sh", "docs/check-doc.sh", "scripts/check-data.json"}
+	got := Select([]string{"scripts/check-b.sh", "scripts/check-deleted.sh"}, []string{"scripts/check-a.sh", "scripts/check-b.sh", "scripts/nested/check-deep.sh", "scripts/helper.sh", "docs/check-doc.sh", "scripts/check-data.json"}, inventory)
+	want := []string{"scripts/check-a.sh", "scripts/check-b.sh"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("changed-input union = %v, want %v; inventory is not the selected input", got, want)
+	}
+	if got := Select(nil, nil, inventory); len(got) != 0 {
+		t.Fatalf("unaffected-input negative control selected %v", got)
+	}
+}
+
+func TestEvalDoesNotMutateInputs(t *testing.T) {
+	backing := []string{"scripts/check-a.sh", "unchanged", "sentinel"}
+	Select(backing[:1], []string{"scripts/check-b.sh"}, []string{"scripts/check-a.sh", "scripts/check-b.sh"})
+	if backing[1] != "unchanged" || backing[2] != "sentinel" {
+		t.Fatal("selection mutated caller input backing array")
+	}
+}

--- a/evals/skills-rpi/tasks/input-scope/tests/spec.json
+++ b/evals/skills-rpi/tasks/input-scope/tests/spec.json
@@ -1,0 +1,7 @@
+{
+  "editable": ["select.go"],
+  "production": ["select.go"],
+  "allow_added_tests": true,
+  "checked": ["merge-parent union", "unchanged-input exclusion", "existing path filter", "sorted uniqueness", "caller input preserved"],
+  "not_checked": ["fresh independent in-workflow review"]
+}

--- a/evals/skills-rpi/tasks/input-scope/tests/test.sh
+++ b/evals/skills-rpi/tasks/input-scope/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python3 /tests/verify.py /baseline /app/work /tests /logs/verifier

--- a/evals/skills-rpi/tasks/learning-read-error/environment/Dockerfile
+++ b/evals/skills-rpi/tasks/learning-read-error/environment/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.27.1-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates nodejs npm python3 jq perl \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex@0.154.0
+COPY cli /app/work
+WORKDIR /app/work
+RUN go mod download && go build -o /usr/local/bin/ao ./cmd/ao \
+    && go test ./internal/gates/checks
+COPY helpers /opt/agentops/scripts/lib
+ENV AGENTOPS_ROOT=/opt/agentops
+RUN git init -q && git config user.name "Evaluation fixture" \
+    && git config user.email "fixture@example.invalid" \
+    && git add . && git commit -qm baseline

--- a/evals/skills-rpi/tasks/learning-read-error/instruction.md
+++ b/evals/skills-rpi/tasks/learning-read-error/instruction.md
@@ -1,0 +1,18 @@
+Repair the learning-coherence gate in this Go CLI repository.
+
+When a changed Markdown path under either supported learning root cannot be
+read for a reason other than deletion, the gate currently reports success.
+Make that case fail with an error identifying the path. A genuinely deleted
+file must still be skipped. Preserve the existing changed-file selection,
+both root filters, Markdown selection and frontmatter behavior.
+
+Work in /app/work. Limit source changes to
+internal/gates/checks/native_inline.go and tests in that same package. Add a
+regression that fails before your repair and passes afterward, including a
+deletion control. Run the relevant package tests and get a fresh independent
+review of the completed change. Report what changed, the check results and
+any remaining gap. Do not push, open a PR, or change acceptance.
+
+The container provides Go, Git, Codex and ao. Public AgentOps command helpers
+are available under AGENTOPS_ROOT. The workspace is disposable; the evaluator
+will inspect its actual final contents independently.

--- a/evals/skills-rpi/tasks/learning-read-error/task.toml
+++ b/evals/skills-rpi/tasks/learning-read-error/task.toml
@@ -1,0 +1,38 @@
+schema_version = "1.4"
+
+[task]
+name = "agentops/learning-read-error"
+version = "1.0.1"
+description = "Repair an observed Go gate error without broadening its inputs."
+
+[metadata]
+family = "small-go-repair"
+source_commit = "8a9a01a70abcb4f6325de32e7d17fcd942c40fcb"
+source_path = "cli/internal/gates/checks/native_inline.go"
+visibility = "development"
+historical_fix_seen_by_task_author = true
+
+[agent]
+timeout_sec = 900
+network_mode = "allowlist"
+allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
+
+[environment]
+build_timeout_sec = 900
+cpus = 2
+memory_mb = 4096
+storage_mb = 16384
+network_mode = "public"
+
+[verifier]
+timeout_sec = 180
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "agentops-skill-eval-verifier:learning-read-error-v1"
+network_mode = "no-network"
+cpus = 2
+memory_mb = 4096
+
+[[artifacts]]
+source = "/app/work"

--- a/evals/skills-rpi/tasks/learning-read-error/tests/Dockerfile
+++ b/evals/skills-rpi/tasks/learning-read-error/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM agentops-skill-eval-worker:learning-read-error-v1
+COPY cli /baseline
+COPY test.sh oracle_test.go check_scope.py /tests/
+WORKDIR /baseline
+RUN go test ./internal/gates/checks

--- a/evals/skills-rpi/tasks/learning-read-error/tests/check_scope.py
+++ b/evals/skills-rpi/tasks/learning-read-error/tests/check_scope.py
@@ -1,0 +1,28 @@
+"""Evaluator-side source scope check; candidate files are untrusted data."""
+import pathlib
+import sys
+
+baseline, candidate = map(pathlib.Path, sys.argv[1:])
+allowed = "internal/gates/checks/native_inline.go"
+
+def files(root):
+    result = {}
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if relative == ".git" or relative.startswith(".git/"):
+            continue
+        if path.is_symlink():
+            raise SystemExit("symlink in candidate subject: " + relative)
+        if path.is_file():
+            result[relative] = path.read_bytes()
+    return result
+
+before, after = files(baseline), files(candidate)
+for path in sorted(before.keys() | after.keys()):
+    if before.get(path) == after.get(path):
+        continue
+    if path == allowed or (path.startswith("internal/gates/checks/") and path.endswith("_test.go")):
+        continue
+    raise SystemExit("out-of-scope source change: " + path)
+if allowed not in after:
+    raise SystemExit("required source is missing")

--- a/evals/skills-rpi/tasks/learning-read-error/tests/oracle_test.go
+++ b/evals/skills-rpi/tasks/learning-read-error/tests/oracle_test.go
@@ -1,0 +1,50 @@
+package checks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/boshu2/agentops/cli/internal/gates"
+	"github.com/boshu2/agentops/cli/internal/ports"
+)
+
+func TestEvalLearningReadError(t *testing.T) {
+	for _, prefix := range []string{".agents/ao/learnings/", ".agents/learnings/"} {
+		t.Run(prefix, func(t *testing.T) {
+			root := t.TempDir()
+			path := prefix + "unreadable.md"
+			if err := os.MkdirAll(filepath.Join(root, path), 0755); err != nil {
+				t.Fatal(err)
+			}
+			v, err := runLearningCoherence(context.Background(), gates.RunContext{RepoRoot: root, ChangedFiles: []string{path}})
+			report := gates.Report{Results: []gates.CheckResult{{
+				Check: gates.Check{ID: "learning.coherence", Blocking: true}, Verdict: v, Err: err,
+			}}}
+			reason := v.Reason
+			if err != nil {
+				reason += err.Error()
+			}
+			if report.ExitCode() != 1 || !strings.Contains(reason, path) {
+				t.Fatalf("unreadable learning must block and name path: %+v, %v", v, err)
+			}
+		})
+	}
+}
+
+func TestEvalLearningControls(t *testing.T) {
+	for _, path := range []string{".agents/ao/learnings/deleted.md", ".agents/learnings/deleted.md", "other/unreadable.md", ".agents/learnings/ignored.txt"} {
+		root := t.TempDir()
+		if !strings.HasSuffix(path, "deleted.md") {
+			if err := os.MkdirAll(filepath.Join(root, path), 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		v, err := runLearningCoherence(context.Background(), gates.RunContext{RepoRoot: root, ChangedFiles: []string{path}})
+		if err != nil || v.Status != ports.GateStatusPass {
+			t.Fatalf("control %s: %+v, %v", path, v, err)
+		}
+	}
+}

--- a/evals/skills-rpi/tasks/learning-read-error/tests/test.sh
+++ b/evals/skills-rpi/tasks/learning-read-error/tests/test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+mkdir -p /logs/verifier
+printf '0\n' > /logs/verifier/reward.txt
+python3 /tests/check_scope.py /baseline /app/work
+# Use the pristine evaluator-owned tree, including its tests and module files.
+# Only permitted production source bytes cross this boundary.
+cp /app/work/internal/gates/checks/native_inline.go /baseline/internal/gates/checks/native_inline.go
+cp /tests/oracle_test.go /baseline/internal/gates/checks/eval_oracle_test.go
+cd /baseline
+go test ./internal/gates/checks > /logs/verifier/go-test.log 2>&1
+printf '1\n' > /logs/verifier/reward.txt

--- a/evals/skills-rpi/tasks/persistence-recovery/environment/Dockerfile
+++ b/evals/skills-rpi/tasks/persistence-recovery/environment/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.27.1-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates nodejs npm python3 jq \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex@0.154.0
+COPY helpers /opt/agentops/scripts/lib
+ENV AGENTOPS_ROOT=/opt/agentops
+COPY source /app/work
+WORKDIR /app/work
+RUN go test ./...
+RUN git init -q && git config user.name "Evaluation fixture" \
+    && git config user.email "fixture@example.invalid" \
+    && git add . && git commit -qm baseline

--- a/evals/skills-rpi/tasks/persistence-recovery/environment/source/go.mod
+++ b/evals/skills-rpi/tasks/persistence-recovery/environment/source/go.mod
@@ -1,0 +1,3 @@
+module example.invalid/eval/persistence
+
+go 1.26

--- a/evals/skills-rpi/tasks/persistence-recovery/environment/source/store.go
+++ b/evals/skills-rpi/tasks/persistence-recovery/environment/source/store.go
@@ -1,0 +1,24 @@
+package persistence
+
+import "os"
+
+// Store saves a complete checkpoint. BeforeCommit is an optional caller hook
+// that can cancel a pending checkpoint before it replaces the previous one.
+type Store struct {
+	BeforeCommit func() error
+}
+
+func (s Store) Save(path string, payload []byte) error {
+	if err := os.WriteFile(path, payload, 0600); err != nil {
+		return err
+	}
+	if s.BeforeCommit != nil {
+		return s.BeforeCommit()
+	}
+	return nil
+}
+
+// Load opens the checkpoint each time; recovery does not depend on live memory.
+func Load(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/environment/source/store_test.go
+++ b/evals/skills-rpi/tasks/persistence-recovery/environment/source/store_test.go
@@ -1,0 +1,17 @@
+package persistence
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveThenReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.json")
+	if err := (Store{}).Save(path, []byte(`{"offset":4}`)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil || string(got) != `{"offset":4}` {
+		t.Fatalf("reopened = %s, %v", got, err)
+	}
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/instruction.md
+++ b/evals/skills-rpi/tasks/persistence-recovery/instruction.md
@@ -1,0 +1,15 @@
+Repair checkpoint replacement in /app/work/store.go. A cancelled Save currently
+overwrites the last recoverable checkpoint before BeforeCommit runs. Stage the
+complete payload in a temporary file in the destination directory, flush and
+close it, call BeforeCommit once, and replace the checkpoint only if the hook
+succeeds. The old checkpoint must remain readable throughout that hook and
+after cancellation. Propagate errors and remove temporary files on failure.
+A successful Save must survive reopening through Load with the exact payload;
+cancelling first creation must leave no checkpoint. Do not change the Store or
+Load APIs, add retry policies, or silently swallow errors.
+
+Edit store.go and add regression tests in new *_test.go files. Preserve existing
+tests and go.mod. Run go test ./... and get a fresh independent review. Report
+what changed, checks, and remaining gaps. Permission preservation and power-loss
+durability after rename are outside this fixture's acceptance; do not claim
+those from the cancellation test. Do not push or add dependencies.

--- a/evals/skills-rpi/tasks/persistence-recovery/solution/store.go
+++ b/evals/skills-rpi/tasks/persistence-recovery/solution/store.go
@@ -1,0 +1,43 @@
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Store saves a complete checkpoint. BeforeCommit is an optional caller hook
+// that can cancel a pending checkpoint before it replaces the previous one.
+type Store struct {
+	BeforeCommit func() error
+}
+
+func (s Store) Save(path string, payload []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), ".checkpoint-*")
+	if err != nil {
+		return err
+	}
+	name := file.Name()
+	defer os.Remove(name)
+	if _, err := file.Write(payload); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if s.BeforeCommit != nil {
+		if err := s.BeforeCommit(); err != nil {
+			return err
+		}
+	}
+	return os.Rename(name, path)
+}
+
+// Load opens the checkpoint each time; recovery does not depend on live memory.
+func Load(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/task.toml
+++ b/evals/skills-rpi/tasks/persistence-recovery/task.toml
@@ -1,0 +1,38 @@
+schema_version = "1.4"
+
+[task]
+name = "agentops/persistence-recovery"
+version = "1.0.0"
+description = "Recover exact checkpoint bytes after cancellation."
+
+[metadata]
+family = "persistence-recovery"
+visibility = "development"
+source_kind = "sanitized-standalone"
+source_snapshot = "environment/source"
+endpoint_reward_is_workflow_proof = false
+
+[agent]
+timeout_sec = 900
+network_mode = "allowlist"
+allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
+
+[environment]
+build_timeout_sec = 900
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+network_mode = "public"
+
+[verifier]
+timeout_sec = 180
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "agentops-skill-eval-verifier:persistence-recovery-v1"
+network_mode = "no-network"
+cpus = 2
+memory_mb = 2048
+
+[[artifacts]]
+source = "/app/work"

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/Dockerfile
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM agentops-skill-eval-worker:persistence-recovery-v1
+COPY source /baseline
+COPY verify.py spec.json oracle_test.go test.sh /tests/
+WORKDIR /baseline
+RUN go test ./...

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/controls.json
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/controls.json
@@ -1,0 +1,1 @@
+{"correct": "pass", "noop": "fail", "wrong": "fail", "incomplete": "fail"}

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/controls/incomplete/store.go
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/controls/incomplete/store.go
@@ -1,0 +1,24 @@
+package persistence
+
+import "os"
+
+// Store saves a complete checkpoint. BeforeCommit is an optional caller hook
+// that can cancel a pending checkpoint before it replaces the previous one.
+type Store struct {
+	BeforeCommit func() error
+}
+
+func (s Store) Save(path string, payload []byte) error {
+	if err := os.WriteFile(path, payload, 0600); err != nil {
+		return err
+	}
+	if s.BeforeCommit != nil {
+		_ = s.BeforeCommit()
+	}
+	return nil
+}
+
+// Load opens the checkpoint each time; recovery does not depend on live memory.
+func Load(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/controls/wrong/store.go
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/controls/wrong/store.go
@@ -1,0 +1,43 @@
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Store saves a complete checkpoint. BeforeCommit is an optional caller hook
+// that can cancel a pending checkpoint before it replaces the previous one.
+type Store struct {
+	BeforeCommit func() error
+}
+
+func (s Store) Save(path string, payload []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), ".checkpoint-*")
+	if err != nil {
+		return err
+	}
+	name := file.Name()
+	defer os.Remove(name)
+	if _, err := file.Write([]byte("metadata-only")); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if s.BeforeCommit != nil {
+		if err := s.BeforeCommit(); err != nil {
+			return err
+		}
+	}
+	return os.Rename(name, path)
+}
+
+// Load opens the checkpoint each time; recovery does not depend on live memory.
+func Load(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/oracle_test.go
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/oracle_test.go
@@ -1,0 +1,63 @@
+package persistence
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEvalCancellationPreservesRecoverablePayload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint.json")
+	old := []byte(`{"offset":42,"pending":["job-a","job-b"]}`)
+	if err := (Store{}).Save(path, old); err != nil {
+		t.Fatal(err)
+	}
+	stop := errors.New("checkpoint cancelled")
+	calls := 0
+	store := Store{BeforeCommit: func() error {
+		calls++
+		got, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(got, old) {
+			t.Fatalf("old checkpoint changed before commit: %q, %v", got, err)
+		}
+		return stop
+	}}
+	if err := store.Save(path, []byte(`{"offset":43,"pending":[]}`)); !errors.Is(err, stop) {
+		t.Fatalf("cancellation error = %v", err)
+	}
+	got, err := Load(path)
+	if err != nil || !bytes.Equal(got, old) || calls != 1 {
+		t.Fatalf("restart after cancellation = %q, %v, hook calls=%d", got, err, calls)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("cancel left temporary state: %v, %v", entries, err)
+	}
+	if err := (Store{}).Save(path, []byte("replacement\x00payload")); err != nil {
+		t.Fatal(err)
+	}
+	got, err = Load(path)
+	if err != nil || string(got) != "replacement\x00payload" {
+		t.Fatalf("committed payload missing after reopen: %q, %v", got, err)
+	}
+}
+
+func TestEvalCancellationDoesNotCreateCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.json")
+	stop := errors.New("stop")
+	err := (Store{BeforeCommit: func() error { return stop }}).Save(path, []byte("new"))
+	if !errors.Is(err, stop) {
+		t.Fatalf("error = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("cancelled new checkpoint exists: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("cancelled creation leaked state: %v %v", entries, err)
+	}
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/spec.json
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/spec.json
@@ -1,0 +1,24 @@
+{
+  "editable": [
+    "store.go"
+  ],
+  "production": [
+    "store.go"
+  ],
+  "allow_added_tests": true,
+  "checked": [
+    "old checkpoint remains readable until commit",
+    "cancellation preserves exact payload",
+    "successful checkpoint reopens",
+    "cancelled creation leaves no checkpoint",
+    "temporary cleanup"
+  ],
+  "not_checked": [
+    "fresh independent in-workflow review",
+    "precommit flush and close order"
+  ],
+  "limitations": [
+    "power-loss durability after rename is outside fixture acceptance",
+    "access preservation is outside fixture acceptance"
+  ]
+}

--- a/evals/skills-rpi/tasks/persistence-recovery/tests/test.sh
+++ b/evals/skills-rpi/tasks/persistence-recovery/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python3 /tests/verify.py /baseline /app/work /tests /logs/verifier

--- a/evals/skills-rpi/tasks/validator-controls/environment/Dockerfile
+++ b/evals/skills-rpi/tasks/validator-controls/environment/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.27.1-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates nodejs npm python3 jq \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g @openai/codex@0.154.0
+COPY helpers /opt/agentops/scripts/lib
+ENV AGENTOPS_ROOT=/opt/agentops
+COPY source /app/work
+WORKDIR /app/work
+RUN go test ./...
+RUN git init -q && git config user.name "Evaluation fixture" \
+    && git config user.email "fixture@example.invalid" \
+    && git add . && git commit -qm baseline

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/candidate_a/lease.go
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/candidate_a/lease.go
@@ -1,0 +1,4 @@
+package candidate_a
+
+// Expired reports whether a lease has expired at the inclusive deadline.
+func Expired(now, deadline int64) bool { return now > deadline }

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/candidate_b/lease.go
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/candidate_b/lease.go
@@ -1,0 +1,4 @@
+package candidate_b
+
+// Expired reports whether a lease has expired at the inclusive deadline.
+func Expired(now, deadline int64) bool { return now >= deadline }

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/candidate_c/lease.go
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/candidate_c/lease.go
@@ -1,0 +1,4 @@
+package candidate_c
+
+// Expired reports whether a lease has expired at the inclusive deadline.
+func Expired(now, deadline int64) bool { return now >= deadline }

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/go.mod
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/go.mod
@@ -1,0 +1,3 @@
+module example.invalid/eval/leases
+
+go 1.26

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/lease_test.go
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/lease_test.go
@@ -1,0 +1,18 @@
+package leases_test
+
+import (
+	"example.invalid/eval/leases/candidate_a"
+	"example.invalid/eval/leases/candidate_b"
+	"example.invalid/eval/leases/candidate_c"
+	"testing"
+)
+
+func TestSuppliedSmoke(t *testing.T) {
+	for name, expired := range map[string]func(int64, int64) bool{
+		"candidate-a": candidate_a.Expired, "candidate-b": candidate_b.Expired, "candidate-c": candidate_c.Expired,
+	} {
+		if expired(9, 10) || !expired(11, 10) {
+			t.Fatalf("%s smoke behavior failed", name)
+		}
+	}
+}

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/receipts/README.md
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/receipts/README.md
@@ -1,0 +1,1 @@
+Candidate-c has no original check record. Its absence is intentional. The supplied A/B records were collected locally when this development fixture was frozen. Rerunning tests does not recover the missing original event.

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/receipts/candidate-a.json
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/receipts/candidate-a.json
@@ -1,0 +1,16 @@
+{
+  "kind": "development-fixture-check-record",
+  "candidate": "candidate-a",
+  "source_path": "candidate_a/lease.go",
+  "source_sha256": "694bd7acea6398356403ed5b68636c55bca7a863f02c958b0531445592de66a5",
+  "command": [
+    "go",
+    "test",
+    "-count=1",
+    "./..."
+  ],
+  "runtime": "go version go1.26.4 darwin/arm64",
+  "exit_code": 0,
+  "output": "ok  \texample.invalid/eval/leases\t0.260s\n?   \texample.invalid/eval/leases/candidate_a\t[no test files]\n?   \texample.invalid/eval/leases/candidate_b\t[no test files]\n?   \texample.invalid/eval/leases/candidate_c\t[no test files]\n",
+  "limits": "Local calibration of this sanitized development fixture; not a production run or release attestation."
+}

--- a/evals/skills-rpi/tasks/validator-controls/environment/source/receipts/candidate-b.json
+++ b/evals/skills-rpi/tasks/validator-controls/environment/source/receipts/candidate-b.json
@@ -1,0 +1,16 @@
+{
+  "kind": "development-fixture-check-record",
+  "candidate": "candidate-b",
+  "source_path": "candidate_b/lease.go",
+  "source_sha256": "fbf8649a6e8d6681b0cdc7e3db3c40520d35d05907455ca11fb9d8a826aa37a2",
+  "command": [
+    "go",
+    "test",
+    "-count=1",
+    "./..."
+  ],
+  "runtime": "go version go1.26.4 darwin/arm64",
+  "exit_code": 0,
+  "output": "ok  \texample.invalid/eval/leases\t0.260s\n?   \texample.invalid/eval/leases/candidate_a\t[no test files]\n?   \texample.invalid/eval/leases/candidate_b\t[no test files]\n?   \texample.invalid/eval/leases/candidate_c\t[no test files]\n",
+  "limits": "Local calibration of this sanitized development fixture; not a production run or release attestation."
+}

--- a/evals/skills-rpi/tasks/validator-controls/instruction.md
+++ b/evals/skills-rpi/tasks/validator-controls/instruction.md
@@ -1,0 +1,22 @@
+Independently judge three recorded Go candidate submissions in /app/work.
+This is review of a frozen submission record, not a request to repair code.
+Each candidate's Expired function must return true at or after its deadline
+and false before it, for all int64 inputs. A completed submission also requires
+a recorded successful package check bound to that candidate's exact source.
+
+The source and supplied public tests are available. receipts/ contains locally
+generated development-fixture check records for candidate-a and candidate-b;
+candidate-c's original check record is missing. A check run now can establish
+current behavior but cannot establish that the missing original run happened.
+These are development records, not production release attestations.
+
+Use FAIL for a demonstrated behavior defect, PASS when both behavior and the
+required recorded evidence are established, and NOT_PROVEN when evidence is
+missing without a demonstrated defect. Judge each case independently; rejecting
+every candidate is incorrect. Do not infer correctness merely from green smoke
+tests. No points are awarded for the number of findings.
+
+Write only verdicts.json, an object with candidate-a, candidate-b, candidate-c
+keys and verdict strings, plus an optional review.md explaining decisive facts.
+Do not edit the candidates, public tests, module or receipt records, and do not
+invent missing check history. You may run tests and inspect source. No publishing.

--- a/evals/skills-rpi/tasks/validator-controls/solution/verdicts.json
+++ b/evals/skills-rpi/tasks/validator-controls/solution/verdicts.json
@@ -1,0 +1,1 @@
+{"candidate-a":"FAIL","candidate-b":"PASS","candidate-c":"NOT_PROVEN"}

--- a/evals/skills-rpi/tasks/validator-controls/task.toml
+++ b/evals/skills-rpi/tasks/validator-controls/task.toml
@@ -1,0 +1,39 @@
+schema_version = "1.4"
+
+[task]
+name = "agentops/validator-controls"
+version = "1.0.0"
+description = "Judge faulty, clean, and incomplete recorded submissions."
+
+[metadata]
+family = "validator-controls"
+visibility = "development"
+source_kind = "sanitized-standalone"
+source_snapshot = "environment/source"
+endpoint_reward_is_workflow_proof = false
+workflow_mode = "recorded-candidate-review"
+
+[agent]
+timeout_sec = 900
+network_mode = "allowlist"
+allowed_hosts = ["chatgpt.com", "api.openai.com", "auth.openai.com", "auth0.openai.com"]
+
+[environment]
+build_timeout_sec = 900
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+network_mode = "public"
+
+[verifier]
+timeout_sec = 180
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "agentops-skill-eval-verifier:validator-controls-v1"
+network_mode = "no-network"
+cpus = 2
+memory_mb = 2048
+
+[[artifacts]]
+source = "/app/work"

--- a/evals/skills-rpi/tasks/validator-controls/tests/Dockerfile
+++ b/evals/skills-rpi/tasks/validator-controls/tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM agentops-skill-eval-worker:validator-controls-v1
+COPY source /baseline
+COPY verify.py spec.json oracle_test.go test.sh /tests/
+WORKDIR /baseline
+RUN go test ./...

--- a/evals/skills-rpi/tasks/validator-controls/tests/controls.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/controls.json
@@ -1,0 +1,1 @@
+{"correct": "pass", "noop": "fail", "wrong": "fail", "incomplete": "fail", "false-pass": "fail", "false-blocker": "fail", "missing-evidence-pass": "fail"}

--- a/evals/skills-rpi/tasks/validator-controls/tests/controls/false-blocker/verdicts.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/controls/false-blocker/verdicts.json
@@ -1,0 +1,1 @@
+{"candidate-a": "FAIL", "candidate-b": "NOT_PROVEN", "candidate-c": "NOT_PROVEN"}

--- a/evals/skills-rpi/tasks/validator-controls/tests/controls/false-pass/verdicts.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/controls/false-pass/verdicts.json
@@ -1,0 +1,1 @@
+{"candidate-a": "PASS", "candidate-b": "PASS", "candidate-c": "NOT_PROVEN"}

--- a/evals/skills-rpi/tasks/validator-controls/tests/controls/incomplete/verdicts.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/controls/incomplete/verdicts.json
@@ -1,0 +1,1 @@
+{"candidate-a": "FAIL", "candidate-b": "PASS"}

--- a/evals/skills-rpi/tasks/validator-controls/tests/controls/missing-evidence-pass/verdicts.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/controls/missing-evidence-pass/verdicts.json
@@ -1,0 +1,1 @@
+{"candidate-a": "FAIL", "candidate-b": "PASS", "candidate-c": "PASS"}

--- a/evals/skills-rpi/tasks/validator-controls/tests/controls/wrong/verdicts.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/controls/wrong/verdicts.json
@@ -1,0 +1,1 @@
+{"candidate-a": "FAIL", "candidate-b": "FAIL", "candidate-c": "FAIL"}

--- a/evals/skills-rpi/tasks/validator-controls/tests/oracle_test.go
+++ b/evals/skills-rpi/tasks/validator-controls/tests/oracle_test.go
@@ -1,0 +1,22 @@
+package leases_test
+
+import (
+	"example.invalid/eval/leases/candidate_a"
+	"example.invalid/eval/leases/candidate_b"
+	"example.invalid/eval/leases/candidate_c"
+	"testing"
+)
+
+// This guards the seeded ground truth; it is not the worker's validator.
+func TestEvalControlTruth(t *testing.T) {
+	if candidate_a.Expired(10, 10) {
+		t.Fatal("faulty control unexpectedly repaired")
+	}
+	for name, expired := range map[string]func(int64, int64) bool{
+		"candidate-b": candidate_b.Expired, "candidate-c": candidate_c.Expired,
+	} {
+		if expired(9, 10) || !expired(10, 10) || !expired(11, 10) || !expired(-1, -1) {
+			t.Fatalf("clean source control %s is invalid", name)
+		}
+	}
+}

--- a/evals/skills-rpi/tasks/validator-controls/tests/spec.json
+++ b/evals/skills-rpi/tasks/validator-controls/tests/spec.json
@@ -1,0 +1,19 @@
+{
+  "editable": [
+    "verdicts.json",
+    "review.md"
+  ],
+  "production": [],
+  "checked": [
+    "faulty candidate FAIL",
+    "clean candidate PASS",
+    "missing original evidence NOT_PROVEN",
+    "frozen candidate and receipt integrity"
+  ],
+  "not_checked": [],
+  "verdicts": {
+    "candidate-a": "FAIL",
+    "candidate-b": "PASS",
+    "candidate-c": "NOT_PROVEN"
+  }
+}

--- a/evals/skills-rpi/tasks/validator-controls/tests/test.sh
+++ b/evals/skills-rpi/tasks/validator-controls/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python3 /tests/verify.py /baseline /app/work /tests /logs/verifier

--- a/evals/skills-rpi/test_readout.py
+++ b/evals/skills-rpi/test_readout.py
@@ -1,6 +1,8 @@
 """Synthetic native-record replays; no live models, private sources or launches."""
 from copy import deepcopy
+import hashlib
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -254,6 +256,73 @@ def test_missing_or_untrusted_grade_never_manufactures_zero_case_errors(invalid)
     assert metrics["false_acceptance"]["count"] is None
     assert metrics["false_acceptance"]["denominator"] is None
     assert metrics["false_acceptance"]["rate"] is None
+
+
+def multistep_fixture(tmp_path):
+    from dirhash import dirhash
+    report, receipts = fixture(("success", "success"))
+    task = tmp_path / "task"
+    task.mkdir()
+    spec = '''[environment]
+docker_image = "sha256:worker"
+[verifier]
+environment_mode = "separate"
+[verifier.environment]
+docker_image = "sha256:verifier"
+[[steps]]
+name = "producer"
+[[steps]]
+name = "successor"
+'''
+    (task / "task.toml").write_text(spec)
+    checksum = dirhash(task, "sha256")
+    for receipt, job in zip(receipts["trials"], report["jobs"]):
+        receipt["runtime"]["harbor_version"] = "0.22.0"
+        receipt["task_checksum"] = checksum
+        trial = job["trials"][0]
+        trial["task_checksum"] = checksum
+        trial["documents"]["config.json"]["data"]["task"]["path"] = str(task)
+        native = trial["documents"]["result.json"]["data"]
+        native["verifier_environment_mode"] = None
+        native["step_results"] = [{"step_name": name, "verifier_environment_mode": None,
+                                   "verifier_result": {"rewards": {"reward": score}}}
+                                  for name, score in (("producer", 0), ("successor", 1))]
+    frozen = {"task_checksum": checksum, "runtime": receipts["trials"][0]["runtime"]}
+    manifest = tmp_path / "staged.json"
+    manifest.write_text(json.dumps(frozen))
+    for receipt in receipts["trials"]:
+        receipt["staging_manifest"] = {"path": str(manifest), "sha256": hashlib.sha256(manifest.read_bytes()).hexdigest()}
+    return report, receipts
+
+
+def test_multistep_mode_uses_bound_frozen_configuration_and_labels_its_limit(tmp_path):
+    report, receipts = multistep_fixture(tmp_path)
+    result = readout.build(report, receipts)
+    assert len(result["paired_outcomes"]) == 1
+    assert all(row["verifier_mode_source"] == "frozen task configuration (runtime isolation not measured)"
+               for row in result["attempts"])
+    assert "Verifier mode: frozen task configuration (runtime isolation not measured)" in readout.markdown(result)
+
+
+@pytest.mark.parametrize("invalid", ["changed_task", "wrong_manifest_hash", "native_contradiction", "step_contradiction", "wrong_task_path"])
+def test_multistep_fallback_never_overrides_missing_or_conflicting_provenance(tmp_path, invalid):
+    report, receipts = multistep_fixture(tmp_path)
+    trial = report["jobs"][0]["trials"][0]
+    native = trial["documents"]["result.json"]["data"]
+    if invalid == "changed_task":
+        with (tmp_path / "task/task.toml").open("a") as output:
+            output.write('[steps.verifier]\nenvironment_mode = "same"\n')
+    elif invalid == "wrong_manifest_hash":
+        receipts["trials"][0]["staging_manifest"]["sha256"] = "0" * 64
+    elif invalid == "native_contradiction":
+        native["verifier_environment_mode"] = "same"
+    elif invalid == "step_contradiction":
+        native["step_results"][1]["verifier_environment_mode"] = "same"
+    else:
+        trial["documents"]["config.json"]["data"]["task"]["path"] = "/wrong/task"
+    result = readout.build(report, receipts)
+    assert result["paired_outcomes"] == []
+    assert "native separate verifier not evidenced" in str(result["pair_dispositions"])
 
 
 def test_no_receipt_keeps_observations_and_missing_usage_unknown():

--- a/evals/skills-rpi/test_readout.py
+++ b/evals/skills-rpi/test_readout.py
@@ -301,3 +301,13 @@ def test_invalid_analysis_settings_fail(kwargs):
     report, receipts = fixture()
     with pytest.raises(ValueError):
         readout.build(report, receipts, **kwargs)
+
+
+def test_timeout_preserves_passing_code_without_claiming_completed_run():
+    report, receipts = fixture(("execution_error", "execution_error"))
+    for job in report["jobs"]:
+        job["trials"][0]["documents"]["result.json"]["data"]["verifier_result"] = {"rewards": {"reward": 1.0}}
+    result = readout.build(report, receipts)
+    assert all(arm["endpoint_successes"] == 0 for arm in result["arms"].values())
+    assert all(row["native_rewards"] == {"reward": 1.0} for row in result["attempts"])
+    assert 'execution_error; native oracle {"reward": 1.0}' in readout.markdown(result)

--- a/evals/skills-rpi/test_readout.py
+++ b/evals/skills-rpi/test_readout.py
@@ -54,6 +54,9 @@ def test_pairs_keep_repetitions_clustered_and_replay_exactly():
     assert result["uncertainty"]["task_clusters"] == 3
     assert result["uncertainty"]["signal"] == "underpowered"
     assert result["uncertainty"]["delta_treatment_minus_control"] == pytest.approx(-1 / 3)
+    assert result["uncertainty"]["status"] == "available"
+    assert result["uncertainty"]["ci_low"] is not None
+    assert result["uncertainty"]["confidence"] == 0.95
     assert result == readout.build(report, receipts, n_required=10, resamples=500)
     assert result["recommendation"] == "insufficient-evidence"
 
@@ -144,11 +147,42 @@ def test_no_change_and_degenerate_are_not_equivalence():
     report, receipts = fixture(("success", "success"))
     result = readout.build(report, receipts, n_required=1)
     assert result["uncertainty"]["signal"] == "inconclusive_degenerate"
+    assert result["uncertainty"]["status"] == "insufficient_clusters"
+    assert result["uncertainty"]["ci_low"] is None
+    assert result["uncertainty"]["ci_high"] is None
+    assert result["uncertainty"]["confidence"] is None
     assert result["recommendation"] == "insufficient-evidence"
     pairs = [{"task": str(n), "rep": 1, "control_score": int(n % 2 == 0), "treatment_score": int(n % 2 != 0)} for n in range(4)]
     uncertain = readout.uncertainty(pairs, n_required=1, resamples=500)
     assert uncertain["signal"] == "no_change"
     assert "not equivalence" in uncertain["interpretation"]
+
+
+@pytest.mark.parametrize("scores,expected_delta", [((1, 1), 0.0), ((0, 1), 1.0)])
+def test_multiple_clusters_with_constant_deltas_have_no_inferential_interval(scores, expected_delta):
+    pairs = [{"task": str(n), "rep": rep, "control_score": scores[0], "treatment_score": scores[1]}
+             for n in range(3) for rep in (1, 2)]
+    result = readout.uncertainty(pairs, n_required=3)
+    assert result["status"] == "degenerate_no_interval"
+    assert result["delta_treatment_minus_control"] == expected_delta
+    assert result["task_clusters"] == 3
+    assert result["paired_repetitions"] == 6
+    assert all(result[key] is None for key in ("ci_low", "ci_high", "confidence"))
+
+
+def test_harbor_estimates_remain_incomplete_even_with_scalars_for_every_attempt():
+    report, receipts = fixture(("success", "success"))
+    result = readout.build(report, receipts)
+    arm = result["arms"]["treatment"]
+    assert arm["harbor_cost_usd"]["known_sum"] == 0.25
+    assert arm["harbor_cost_usd"]["unknown"] == 0
+    assert "Incomplete Harbor estimate" in arm["harbor_cost_note"]
+    assert "nested sessions" in arm["harbor_cost_note"]
+    assert arm["total_billed_cost_per_accepted_outcome"] is None
+    rendered = readout.markdown(result)
+    assert "Harbor estimate (incomplete) / attempts without estimate" in rendered
+    assert "Harbor known cost" not in rendered
+    assert "do not establish billing" in rendered
 
 
 def test_no_receipt_keeps_observations_and_missing_usage_unknown():

--- a/evals/skills-rpi/test_readout.py
+++ b/evals/skills-rpi/test_readout.py
@@ -185,6 +185,77 @@ def test_harbor_estimates_remain_incomplete_even_with_scalars_for_every_attempt(
     assert "do not establish billing" in rendered
 
 
+def graded_fixture():
+    report, receipts = fixture(("failed", "failed"))
+    cases = [
+        {"case_id": "defect", "expected": "FAIL", "actual": "PASS", "classification": "false_acceptance"},
+        {"case_id": "clean", "expected": "PASS", "actual": "NOT_PROVEN", "classification": "false_blocker"},
+        {"case_id": "incomplete", "expected": "NOT_PROVEN", "actual": "NOT_PROVEN", "classification": "justified_not_proven"},
+    ]
+    for job in report["jobs"]:
+        grade = evidence({"case_results": deepcopy(cases), "not_checked": ["fresh native handoff not exercised"]})
+        grade["path"] = job["trials"][0]["directory"] + "/verifier/grade.json"
+        job["trials"][0]["documents"]["verifier/grade.json"] = grade
+    return report, receipts
+
+
+def test_failed_endpoint_preserves_independent_case_metrics_and_workflow_gaps():
+    report, receipts = graded_fixture()
+    result = readout.build(report, receipts)
+    metrics = result["arms"]["control"]["validation_cases"]
+    assert metrics["false_acceptance"]["count"] == 1
+    assert metrics["false_acceptance"]["denominator"] == 2
+    assert metrics["false_acceptance"]["rate"] == 0.5
+    assert metrics["false_blocker"]["count"] == 1
+    assert metrics["false_blocker"]["denominator"] == 1
+    assert metrics["justified_not_proven"]["count"] == 1
+    assert metrics["justified_not_proven"]["denominator"] == 1
+    assert len(metrics["case_results"]) == 3
+    assert result["arms"]["control"]["endpoint_successes"] == 0
+    assert result["arms"]["control"]["independently_completed_outcomes"] is None
+    assert result["remaining_workflow_gaps"][0]["not_checked"] == ["fresh native handoff not exercised"]
+    assert "validator false acceptance" not in result["unmeasured"]
+    assert "worker false completion" in result["unmeasured"]
+    rendered = readout.markdown(result)
+    assert "expected FAIL, actual PASS; false_acceptance" in rendered
+    assert "fresh native handoff not exercised" in rendered
+
+
+def test_missing_case_is_unknown_with_known_expected_denominator():
+    report, receipts = graded_fixture()
+    case = report["jobs"][0]["trials"][0]["documents"]["verifier/grade.json"]["data"]["case_results"][2]
+    case.update(actual=None, classification="missing")
+    metrics = readout.build(report, receipts)["arms"]["control"]["validation_cases"]
+    assert metrics["false_acceptance"]["count"] is None
+    assert metrics["false_acceptance"]["known_count"] == 1
+    assert metrics["false_acceptance"]["denominator"] == 2
+    assert metrics["false_acceptance"]["unknown_cases"] == 1
+    assert metrics["false_acceptance"]["rate"] is None
+    assert metrics["false_blocker"]["count"] == 1
+
+
+@pytest.mark.parametrize("invalid", ["missing", "worker_only", "no_cases", "wrong_receipt", "no_evidence_hash"])
+def test_missing_or_untrusted_grade_never_manufactures_zero_case_errors(invalid):
+    report, receipts = graded_fixture()
+    trial = report["jobs"][0]["trials"][0]
+    if invalid in ("missing", "worker_only"):
+        grade = trial["documents"].pop("verifier/grade.json")
+        if invalid == "worker_only":
+            trial["documents"]["result.json"]["data"].update(grade["data"])
+    elif invalid == "no_cases":
+        trial["documents"]["verifier/grade.json"]["data"].pop("case_results")
+    elif invalid == "wrong_receipt":
+        receipts["trials"][0]["task_checksum"] = "f" * 64
+    else:
+        trial["documents"]["verifier/grade.json"]["sha256"] = None
+    metrics = readout.build(report, receipts)["arms"]["control"]["validation_cases"]
+    assert metrics["case_results"] == []
+    assert metrics["attempts_without_case_grade"] == 1
+    assert metrics["false_acceptance"]["count"] is None
+    assert metrics["false_acceptance"]["denominator"] is None
+    assert metrics["false_acceptance"]["rate"] is None
+
+
 def test_no_receipt_keeps_observations_and_missing_usage_unknown():
     report, _ = fixture()
     result = readout.build(report)

--- a/evals/skills-rpi/test_readout.py
+++ b/evals/skills-rpi/test_readout.py
@@ -1,0 +1,198 @@
+"""Synthetic native-record replays; no live models, private sources or launches."""
+from copy import deepcopy
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location("readout", Path(__file__).with_name("readout.py"))
+readout = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(readout)
+
+
+def evidence(data, sha="a" * 64):
+    return {"sha256": sha, "data": data}
+
+
+def fixture(outcomes=("failed", "success"), task="repair", rep=1):
+    jobs, receipts = [], []
+    for arm, outcome in zip(("control", "treatment"), outcomes):
+        name = f"{task}-{arm}-{rep}"
+        agent = {"name": "codex", "model_name": "openai/test-model",
+                 "skills": ["/protected/package"] if arm == "treatment" else [],
+                 "kwargs": {"version": "0.test", "reasoning_effort": "high"}}
+        config = {"job_name": name, "jobs_dir": "/protected/jobs", "agents": [deepcopy(agent)],
+                  "tasks": [{"path": "/protected/" + task}]}
+        native = {"verifier_environment_mode": "separate", "agent_result": {"cost_usd": 0.25},
+                  "agent_info": {"version": "0.test", "model_info": {"provider": "openai", "name": "test-model"}}}
+        trial = {"directory": "/protected/" + name + "/trial", "id": name, "task_name": task,
+                 "task_checksum": "b" * 64, "outcome": outcome, "started": True, "completed": True,
+                 "timing": {"elapsed_seconds": 10}, "session_ids": [], "diagnostics": [],
+                 "documents": {"result.json": evidence(native), "config.json": evidence({"agent": agent, "task": {"path": "/protected/" + task}})}}
+        job = {"directory": "/protected/" + name, "arm": arm, "counts": {"expected": 1, "started": 1},
+               "trials": [trial], "diagnostics": [], "documents": {"config.json": evidence(config)}}
+        receipt = {"job_name": name, "task": task, "rep": rep, "arm": arm,
+                   "configuration_sha256": "a" * 64, "task_checksum": "b" * 64, "oracle_sha256": "c" * 64,
+                   "skills_sha256": "d" * 64 if arm == "treatment" else None,
+                   "runtime": {"harbor_version": "0.test", "codex_version": "0.test", "model": "openai/test-model",
+                               "reasoning_effort": "high", "worker_image_id": "sha256:worker", "verifier_image_id": "sha256:verifier"},
+                   "isolation": {"separate_verifier": True, "private_inputs_excluded": True, "network_policy": "provider-only"}}
+        jobs.append(job)
+        receipts.append(receipt)
+    return {"jobs": jobs, "sessions": [], "limits": []}, {"schema_version": 1, "trials": receipts}
+
+
+def test_pairs_keep_repetitions_clustered_and_replay_exactly():
+    report, receipts = fixture()
+    for task, rep, outcomes in (("repair", 2, ("success", "failed")),
+                                ("scope", 1, ("success", "success")), ("stop", 1, ("success", "failed"))):
+        more, assignments = fixture(outcomes, task, rep)
+        report["jobs"] += more["jobs"]
+        receipts["trials"] += assignments["trials"]
+    result = readout.build(report, receipts, n_required=10, resamples=500)
+    assert len(result["paired_outcomes"]) == 4
+    assert result["uncertainty"]["task_clusters"] == 3
+    assert result["uncertainty"]["signal"] == "underpowered"
+    assert result["uncertainty"]["delta_treatment_minus_control"] == pytest.approx(-1 / 3)
+    assert result == readout.build(report, receipts, n_required=10, resamples=500)
+    assert result["recommendation"] == "insufficient-evidence"
+
+
+@pytest.mark.parametrize("mutation,reason", [
+    (lambda r, x: x["trials"][1].update(configuration_sha256="f" * 64), "configuration hash"),
+    (lambda r, x: x["trials"][1].update(task_checksum="f" * 64), "task checksum"),
+    (lambda r, x: x["trials"][1].update(oracle_sha256="f" * 64), "oracle_sha256 differs"),
+    (lambda r, x: x["trials"][1]["runtime"].update(reasoning_effort="low"), "reasoning effort"),
+    (lambda r, x: x["trials"][1]["runtime"].update(worker_image_id="changed"), "runtime differs"),
+    (lambda r, x: x["trials"][1]["isolation"].update(private_inputs_excluded=False), "isolation"),
+    (lambda r, x: x["trials"][1].update(contamination_detected=True), "contamination"),
+    (lambda r, x: x["trials"][0].update(skills_sha256="d" * 64), "same package"),
+    (lambda r, x: r["jobs"][1]["documents"]["config.json"]["data"].update(n_concurrent_trials=3), "configuration differs"),
+    (lambda r, x: r["jobs"][1]["trials"][0]["documents"]["result.json"]["data"]["agent_info"].update(version="wrong"), "executed model/version"),
+    (lambda r, x: r["jobs"][1]["trials"][0]["documents"]["config.json"]["data"]["agent"].update(model_name="wrong"), "effective native agent"),
+])
+def test_bad_identity_or_contamination_never_becomes_comparison_proof(mutation, reason):
+    report, receipts = fixture(("success", "success"))
+    mutation(report, receipts)
+    result = readout.build(report, receipts)
+    assert result["paired_outcomes"] == []
+    assert reason in str(result["pair_dispositions"])
+    assert result["arms"]["treatment"]["endpoint_successes"] == 1
+    assert result["arms"]["treatment"]["comparison_eligible_attempts"] == 0
+
+
+def test_all_attempts_missing_expected_and_infrastructure_stay_visible():
+    report, receipts = fixture(("infrastructure_error", "unfinished"))
+    report["jobs"][0]["counts"]["expected"] = 3
+    report["jobs"][1]["counts"]["expected"] = None
+    report["jobs"][1]["trials"][0]["completed"] = False
+    report["jobs"][1]["trials"][0]["timing"] = {}
+    report["jobs"][1]["trials"][0]["documents"]["result.json"]["data"]["agent_result"] = None
+    receipts["trials"].append({"job_name": "unobserved", "arm": "control", "task": "repair", "rep": 2})
+    result = readout.build(report, receipts)
+    assert len(result["attempts"]) == 2
+    assert result["paired_outcomes"] == []
+    assert result["arms"]["control"]["all_assigned_or_observed_denominator"] == 3
+    assert result["arms"]["control"]["unobserved_expected"] == 2
+    assert result["arms"]["treatment"]["endpoint_success_rate_all_assignments"] is None
+    assert result["arms"]["treatment"]["elapsed_seconds"]["unknown"] == 1
+    assert result["arms"]["treatment"]["harbor_cost_usd"]["unknown"] == 1
+    assert result["unobserved_receipt_jobs"] == ["unobserved"]
+    assert result["arms"]["control"]["harbor_cost_per_endpoint_success"] is None
+
+
+def test_duplicate_retry_cells_and_unpaired_cells_are_not_selected():
+    report, receipts = fixture()
+    duplicate = deepcopy(report["jobs"][1])
+    duplicate["directory"] += "-retry"
+    assignment = deepcopy(receipts["trials"][1])
+    assignment["job_name"] += "-retry"
+    report["jobs"].append(duplicate)
+    receipts["trials"].append(assignment)
+    result = readout.build(report, receipts)
+    assert not result["paired_outcomes"]
+    assert len(result["attempts"]) == 3
+    assert all(row["comparison_exclusions"] for row in result["attempts"])
+    report["jobs"] = report["jobs"][:1]
+    result = readout.build(report, receipts)
+    assert "missing or duplicate" in str(result["pair_dispositions"])
+
+
+def test_native_session_copies_and_parent_child_counters_are_not_added():
+    report, receipts = fixture()
+    for identity, parent, usage in (("author", "", {"input_tokens": 100, "cached_input_tokens": 20, "output_tokens": 50}),
+                                    ("reviewer", "author", {"input_tokens": 80, "output_tokens": 10})):
+        trial = report["jobs"][1]["trials"][0]
+        trial["session_ids"].append(identity)
+        copy = {"trial": trial["directory"], "evidence": {"path": "/protected/" + identity, "sha256": "a" * 64},
+                "accounting": {"parent_id": parent, "usage": usage, "diagnostics": []}}
+        report["sessions"].append({"id": identity, "copies": [copy, deepcopy(copy)], "diagnostics": []})
+    result = readout.build(report, receipts)
+    assert len(result["native_sessions"]) == 2
+    assert result["native_sessions"][0]["copies"][1]["usage"]["input_tokens"] == 100
+    assert result["native_sessions"][1]["copies"][0]["parent_id"] == "author"
+    assert result["arms"]["treatment"]["harbor_cost_usd"]["known_sum"] == 0.25
+    assert "total_tokens" not in result
+    assert len(result["paired_outcomes"]) == 1
+    report["sessions"][0]["copies"][1]["trial"] = report["jobs"][0]["trials"][0]["directory"]
+    result = readout.build(report, receipts)
+    assert not result["paired_outcomes"]
+    assert "session identity shared" in str(result["attempts"])
+
+
+def test_no_change_and_degenerate_are_not_equivalence():
+    report, receipts = fixture(("success", "success"))
+    result = readout.build(report, receipts, n_required=1)
+    assert result["uncertainty"]["signal"] == "inconclusive_degenerate"
+    assert result["recommendation"] == "insufficient-evidence"
+    pairs = [{"task": str(n), "rep": 1, "control_score": int(n % 2 == 0), "treatment_score": int(n % 2 != 0)} for n in range(4)]
+    uncertain = readout.uncertainty(pairs, n_required=1, resamples=500)
+    assert uncertain["signal"] == "no_change"
+    assert "not equivalence" in uncertain["interpretation"]
+
+
+def test_no_receipt_keeps_observations_and_missing_usage_unknown():
+    report, _ = fixture()
+    result = readout.build(report)
+    assert not result["paired_outcomes"]
+    assert len(result["attempts"]) == 2
+    assert result["arms"]["treatment"]["independently_completed_outcomes"] is None
+    rendered = readout.markdown(result)
+    assert "missing external launch receipt" in rendered
+    assert "Unknown: no native sessions supplied" in rendered
+    assert "insufficient-evidence" in rendered
+
+
+def test_configuration_comparison_does_not_mutate_input():
+    report, receipts = fixture()
+    original = deepcopy(report)
+    readout.build(report, receipts)
+    assert report == original
+
+
+def test_within_pair_matching_does_not_hide_changed_treatment_between_repetitions():
+    report, receipts = fixture()
+    later, later_receipts = fixture(rep=2)
+    later_receipts["trials"][1]["skills_sha256"] = "e" * 64
+    report["jobs"] += later["jobs"]
+    receipts["trials"] += later_receipts["trials"]
+    result = readout.build(report, receipts)
+    assert not result["paired_outcomes"]
+    assert "cohort package/model" in str(result["pair_dispositions"])
+    assert result["arms"]["treatment"]["observed"] == 2
+
+
+def test_receipt_coverage_and_malformed_native_document_are_not_lost():
+    report, receipts = fixture()
+    receipts["diagnostics"] = ["not observed: future-repetition"]
+    report["jobs"][1]["trials"][0]["documents"]["result.json"]["data"] = []
+    result = readout.build(report, receipts)
+    assert not result["paired_outcomes"]
+    assert "not observed: future-repetition" in readout.markdown(result)
+
+
+@pytest.mark.parametrize("kwargs", [{"control": "same", "treatment": "same"}, {"n_required": 0}, {"resamples": 0}])
+def test_invalid_analysis_settings_fail(kwargs):
+    report, receipts = fixture()
+    with pytest.raises(ValueError):
+        readout.build(report, receipts, **kwargs)

--- a/evals/skills-rpi/test_receipts.py
+++ b/evals/skills-rpi/test_receipts.py
@@ -1,9 +1,11 @@
 """Comparison integrity tests; no model, container or network calls."""
 import json
+import io
+import tarfile
 from pathlib import Path
 import tempfile
 import unittest
-from prepare import sha, tree_hash, write_json
+from prepare import extract_cli, sha, tree_hash, write_json
 from receipts import collect
 
 
@@ -69,6 +71,44 @@ class ReceiptIntegrity(unittest.TestCase):
         write_json(self.native, altered)
         with self.assertRaisesRegex(ValueError, "differs"):
             collect([self.manifest])
+
+
+class ArchiveInputs(unittest.TestCase):
+    def archive(self, name, kind=tarfile.REGTYPE):
+        raw = io.BytesIO()
+        with tarfile.open(fileobj=raw, mode="w") as tar:
+            entry = tarfile.TarInfo(name)
+            entry.type = kind
+            entry.linkname = "/outside" if kind in (tarfile.SYMTYPE, tarfile.LNKTYPE) else ""
+            entry.mode = 0o755
+            entry.size = 3 if kind == tarfile.REGTYPE else 0
+            tar.addfile(entry, io.BytesIO(b"src") if entry.size else None)
+        raw.seek(0)
+        return raw
+
+    def test_only_regular_source_is_imported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            extract_cli(self.archive("cli/check.sh"), root)
+            self.assertEqual((root / "cli/check.sh").read_bytes(), b"src")
+            self.assertEqual((root / "cli/check.sh").stat().st_mode & 0o777, 0o755)
+
+    def test_paths_and_links_cannot_escape(self):
+        for name, kind in (("../outside", tarfile.REGTYPE), ("/cli/outside", tarfile.REGTYPE),
+                           ("cli/../outside", tarfile.REGTYPE), ("other/file", tarfile.REGTYPE),
+                           ("cli/link", tarfile.SYMTYPE), ("cli/link", tarfile.LNKTYPE),
+                           ("cli/device", tarfile.CHRTYPE)):
+            with self.subTest(name=name, kind=kind), tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(ValueError):
+                    extract_cli(self.archive(name, kind), Path(tmp))
+
+    def test_existing_directory_link_cannot_redirect_import(self):
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            root = Path(tmp)
+            (root / "cli").symlink_to(outside)
+            with self.assertRaises(ValueError):
+                extract_cli(self.archive("cli/file"), root)
+            self.assertEqual(list(Path(outside).iterdir()), [])
 
 
 if __name__ == "__main__":

--- a/evals/skills-rpi/test_receipts.py
+++ b/evals/skills-rpi/test_receipts.py
@@ -1,0 +1,75 @@
+"""Comparison integrity tests; no model, container or network calls."""
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from prepare import sha, tree_hash, write_json
+from receipts import collect
+
+
+class ReceiptIntegrity(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        for directory in ("task", "skills"):
+            (self.root / directory).mkdir()
+            (self.root / directory / "content.md").write_text(directory)
+        native = self.root / "jobs" / "repair-control-1"
+        native.mkdir(parents=True)
+        self.config = {"job_name": "repair-control-1", "jobs_dir": str(self.root / "jobs"),
+                       "n_concurrent_trials": 1, "agents": [{"name": "codex", "model_name": "openai/gpt-6-astra"}]}
+        write_json(self.root / "input.json", self.config)
+        write_json(native / "config.json", self.config)
+        self.native = native / "config.json"
+        self.manifest = self.root / "staged.json"
+        write_json(self.manifest, {"schema_version": 1, "task": "agentops/repair",
+            "task_checksum": tree_hash(self.root / "task"), "oracle_sha256": "f" * 64,
+            "skills_sha256": tree_hash(self.root / "skills"), "runtime": {}, "isolation": {},
+            "jobs": [{"job_name": "repair-control-1", "arm": "control", "rep": 1,
+                      "input_config": str(self.root / "input.json"), "input_sha256": sha(self.root / "input.json")}]})
+
+    def test_native_defaults_and_pending_jobs_remain_honest(self):
+        self.assertEqual(collect([self.manifest])["trials"][0]["configuration_sha256"], sha(self.native))
+        self.native.unlink()
+        result = collect([self.manifest])
+        self.assertEqual(result["trials"], [])
+        self.assertEqual(len(result["diagnostics"]), 1)
+
+    def test_extra_worker_environment_is_rejected(self):
+        altered = json.loads(self.native.read_text())
+        altered["agents"][0]["env"] = {"INJECT_DIFFERENT_POLICY": "yes"}
+        write_json(self.native, altered)
+        with self.assertRaisesRegex(ValueError, "differs"):
+            collect([self.manifest])
+
+    def test_changed_model_cannot_keep_receipt(self):
+        altered = json.loads(self.native.read_text())
+        altered["agents"][0]["model_name"] = "openai/different-model"
+        write_json(self.native, altered)
+        with self.assertRaisesRegex(ValueError, "differs"):
+            collect([self.manifest])
+
+    def test_changed_task_or_package_cannot_keep_receipt(self):
+        for directory in ("task", "skills"):
+            path = self.root / directory / "content.md"
+            original = path.read_text()
+            path.write_text("changed")
+            with self.assertRaisesRegex(ValueError, "changed after freeze"):
+                collect([self.manifest])
+            path.write_text(original)
+
+    def test_source_symlink_is_not_followed_into_private_content(self):
+        (self.root / "task" / "link").symlink_to(self.root / "input.json")
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            tree_hash(self.root / "task")
+
+    def test_extra_instructions_are_not_an_ignored_default(self):
+        altered = dict(self.config, extra_instructions=["different acceptance"])
+        write_json(self.native, altered)
+        with self.assertRaisesRegex(ValueError, "differs"):
+            collect([self.manifest])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/images/gemini/skills/skill-eval/SKILL.md
+++ b/images/gemini/skills/skill-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-eval
-description: 'Author and tier behavioral probes for a skill, including seeded-defect probes that escape ceiling saturation. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".'
+description: 'Evaluate a named maintenance decision with behavioral probes, controlled coding comparisons, or separate memory transfer tests. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".'
 practices:
 - measurement-over-assertion
 - ab-testing
@@ -18,7 +18,7 @@ user-invocable: true
 metadata:
   tier: meta
   dependencies: []
-  capabilities: ["author_seeded_probe","run_probe_tier"]
+  capabilities: ["author_seeded_probe","run_probe_tier","evaluate_skill_decision"]
   effects: ["write_probe_package","dispatch_probe_producer"]
   canonical_status: canonical
   disposition: keep_specialist
@@ -27,207 +27,192 @@ metadata:
 
 # /skill-eval
 
-Author one behavioral probe for one skill, at the cheapest tier that can still
-separate the arms, and report the verdict honestly. A probe measures
-**behavior-change** — did loading the skill change what the agent *did* — never
-quality-uplift. This skill authors and tiers probes. `scripts/probe-skill.sh`
-runs them.
+Answer one named maintenance decision: **retain, revise, remove, or insufficient
+evidence**. Choose the measurement that can answer that decision, use the caller's
+accepted cases and resource envelope, make one scoped recommendation, and stop.
+A completed evaluation does not require a positive difference.
 
-**Insight:** when a probe returns INERT because the control arm already aces the
-scenario, the measurement failed, not the skill. Weakening the producer is one
-escape and it costs realism. The cheaper escape is to **plant the defect**: build
-a scenario containing exactly one flaw the discipline catches and a skim does
-not, then grade whether the agent acted on it. Signal you manufacture is signal
-you can reproduce.
+This is an optional specialist. The repository's selected runner owns execution
+and bounds; native results own measurements; BD and Git retain their authority.
+Do not add a core skill, AO evaluation command, scheduler, dashboard, second
+tracker, or mandatory review merely to run an experiment.
 
-**The failure mode this exists to prevent:** a skill catalog whose tier badges are
-editorial. A skill nobody measured is a skill nobody can defend, and re-running a
-saturated scenario at a lower effort level produces more rows in the ledger
-without producing more knowledge.
+## Choose the question
 
-## Modes
-
-| Trigger phrases | Mode | Entry point |
+| Caller decision | Measurement | What it can establish |
 |---|---|---|
-| "measure this skill", "does this skill do anything" | author tier 1 (quiz probe) | `evals/skill-probes/<id>/` |
-| "the control arm aces it", "harden this scenario" | author tier 2 (seeded-defect probe) | [`references/seeding.md`](references/seeding.md) |
-| "the probe came back INERT" | diagnose headroom | gate `skill.probe-headroom` |
-| "run the probes" | run a tier | `scripts/probe-skill.sh` |
+| Does loading this skill change a specific observable act? | Behavioral probe with `scripts/probe-skill.sh` | Behavior change on that scenario; not correct code or productivity |
+| Does this package or version improve engineering outcomes at acceptable cost? | Repository-selected controlled coding comparison, such as `evals/skills-rpi` | Endpoint outcomes and cost on selected tasks; independent completion only when required exact-subject evidence exists |
+| Does a qualified memory update help later work? | Separate frozen-versus-updated memory transfer test | Narrow later-task reuse evidence with skill and runtime held fixed |
+| What happened in ordinary runs? | Existing native accounting and acceptance evidence | Observational failures, repairs and cost; not causal skill benefit |
 
-## Inputs
-
-Required: the skill slug, and one sentence naming the **action** the skill should
-cause — a tool call made, an artifact written, a question raised, a sequence
-followed. If the sentence names a belief instead of an action ("understands
-that…", "considers…"), stop: that is not probeable, and rewriting it as an action
-is the actual work.
-
-Optional: an existing probe id to harden.
-
-**Non-goals.** This skill does not score output quality, rank skills, claim a
-skill is good, or gate a release. It does not run `claude -p`. It does not
-generalize from N=2 — small N is directional and every artifact it produces says
-so.
-
-## The two tiers
-
-| | Tier 1 — quiz | Tier 2 — seeded task |
-|---|---|---|
-| Scenario | asks the agent a question about a situation | hands the agent work containing a planted defect |
-| Grades | which answer it gave | whether it acted on the defect |
-| Saturates | fast — frontier models answer doctrine questions correctly unaided | slowly — skimming is a real failure mode at every altitude |
-| Cost | low | higher (real task, longer transcript) |
-| Use when | the skill's whole content is a decision rule | tier 1 saturated, or the skill's value is *noticing* |
-
-Historical tier-1 groups saturate repeatedly at both `xhigh` and `low` effort —
-harder quizzes did not fix it (`validate-not-proven-v2` re-saturated). Run the
-`skill.probe-headroom` gate for the live classification; do not trust a
-hardcoded count. Tier 2 is the escape, because it
-changes what is being measured from *knowing the rule* to *applying it while busy*.
+Start from the caller's intended decision, not a mandatory quiz. Reuse an
+existing accepted decision and scope. For a behavioral question, name one
+observable action (a file written, tool used, criterion rejected); a belief such
+as “understands validation” needs translation into an action. For coding or
+memory questions, name unchanged task acceptance and the maintenance choice.
 
 ## Procedure
 
-1. **State the action.** One sentence, an observable act. Reject beliefs.
-2. **Pick the tier.** Start at tier 1 unless a prior probe for this skill is
-   saturated; then go straight to tier 2.
-3. **Build the scenario.** For tier 2, seed exactly one forcing defect using the
-   rules in [`references/seeding.md`](references/seeding.md). One defect for a
-   floor probe; N defects for a band probe.
-4. **Write the discriminator.** Deterministic, over one transcript. Exit `0`
-   present, `1` absent, `2` infra. It checks the **act**, never a mention — a
-   discriminator that greps for a word the prelude contains measures the prelude.
-5. **Calibrate on replay** against committed fixtures before spending a live run.
-6. **Run both arms** at two effort levels. Same scenario, same reps; the
-   declared `treatment_source` is the only variable — `canonical-skill` (the
-   exact SKILL.md bytes; the only mode the coverage gate counts) or
-   `injected-prelude` (prelude-only evidence, never skill coverage).
-7. **Pre-screen headroom before believing the verdict** — gate
-   `skill.probe-headroom`. A verdict over a saturated scenario is void.
-8. **Record the outcome and stop.** Pre-screen passed (`SEPARATED`/`FLOOR`):
-   append exactly one ledger row in `evals/skill-probes/LEDGER.md`. `SATURATED`:
-   append nothing to the ledger — note the scenario's retirement in the RUNBOOK.
+1. **Fix the decision and bounds.** Name the subject package/version or qualified
+   memory update, relevant cases, allowed runtime and existing aggregate time,
+   trial and cost limits. Do not infer billing enforcement from token counters.
+   Smoke runs, infrastructure retries, interrupted attempts and inner review
+   consume the same declared envelope. A new configuration or context does not
+   renew it. Do not launch live work without caller authorization and bounds.
+2. **Choose the smallest relevant measurement.** Use behavioral probes for acts,
+   coding tasks for engineering outcomes, and separate later sessions for memory.
+   There is no universal two-effort requirement. Keep the deployed model and
+   effort unless the caller's decision concerns effort. Retain easy regression
+   and cost controls; do not weaken the producer to manufacture separation.
+3. **Freeze and calibrate.** Fix task, acceptance, package, model/runtime,
+   environment and grader identities before trials. Executable oracles must
+   accept the intended solution and reject plausible incorrect/no-op solutions.
+   Include genuinely correct and incomplete cases when evaluating judgment.
+   Exposed incidents are development cases, never unseen holdouts by renaming.
+   Broken or leaked cases invalidate affected comparisons; preserve their
+   historical disposition when versioning a correction.
+4. **Run within the selected consumer's bounds.** Equalize instructions, tools
+   and environment across arms apart from the intended variable. Coding trials
+   expose the actual selected package and required resources. A worktree or a
+   prompt prohibition is not runtime isolation. Exclude operator home, production
+   tracker, session history, sibling output and solutions; capture launched
+   configuration and final artifacts outside the worker. Report an incompatible
+   adapter as such; do not build a replacement platform to rescue a result.
+5. **Read all attempts.** Use native runner results and existing accounting;
+   collection must not require another model call or handwritten evaluation.
+   Keep failed, abandoned, blocked, interrupted and missing attempts visible.
+   Wrong identity, changed acceptance, contamination or ambiguous pairing cannot
+   establish comparison proof even when a deterministic check passed.
+6. **Compare only supported facts.** Pair by task and repetition; preserve
+   repetitions within task clusters. Report case outcomes, denominators,
+   uncertainty and failure disposition. Endpoint reward, worker done claim,
+   in-workflow validator PASS and independent acceptance are different facts.
+   Missing review, usage, billing, phase or feasibility evidence stays unknown.
+7. **Recommend once and stop.** State retain, revise, remove or insufficient
+   evidence, the scope and supporting facts, and what remains unproven. A
+   concrete reproduced defect with clean controls can support a provisional
+   narrow repair; general improvement needs held-out comparison. Do not add
+   trials until green, require a positive result, or automatically publish a
+   lesson. Do not remove losing observations or relax acceptance.
+
+## Coding and memory readout
+
+Use the development adapter documented in
+[`evals/skills-rpi/readout.md`](../../evals/skills-rpi/readout.md), or the caller's
+existing equivalent. Its report is a rebuildable view, not work authority.
+The pilot's default `insufficient-evidence` recommendation is an honest limit;
+the specialist may make a narrower supported maintenance recommendation and
+must state its evidence and provisional scope.
+
+- Report endpoint success against **all assigned/observed attempts** alongside
+  any feasible-task rate. Retain infrastructure invalidity, infeasibility and
+  unknown coverage separately; do not hide them by dropping the denominator.
+- Report false completion, false acceptance and needless blocking separately
+  when independent evidence measures them. Clean cases and abstentions are
+  denominators, not opportunities to reward finding-count spray. Unknown is not
+  zero. Deterministic code truth may settle an experimental criterion, while a
+  required native handoff or exact-subject judgment remains unproven.
+- Report raw time/cost distributions and total cost of all attempts per accepted
+  outcome. Zero accepted outcomes makes that ratio undefined. Partial Harbor
+  cost is not total billing. Native input includes cached input; native output
+  includes reasoning. Keep counters distinct and never add native totals to
+  Harbor totals or assume parents exclude children. Split producer, in-workflow
+  validation, orchestration and grading only where native identity supports it.
+  State the measurement window and excluded setup/analysis overhead.
+- Use `evals/_stats` for paired task-cluster uncertainty after verifying its
+  dependencies and semantics. A pilot is descriptive unless sample size and
+  decision thresholds were justified and fixed in advance. A zero-crossing
+  interval or `no_change` is **not equivalence**; equivalence needs its own margin
+  and test. Same numeric repetitions/seeds do not prove controlled provider
+  randomness. Do not extrapolate local results across libraries or models.
+- For memory, hold skill/runtime fixed and compare frozen with independently
+  qualified updated memory in fresh later sessions, using an unseen transfer
+  task and an unrelated or invalidating control. Count acquisition, qualification,
+  retrieval and downstream trial cost separately. Package available, content
+  delivered, relevant action and later outcome are separate facts. Saving a page
+  earns no benefit credit; coding-pilot completion does not establish compounding.
+
+Raw trials and new proof belong in caller-selected protected external non-Git
+storage. Only public/sanitized fixtures cleared for that destination belong in
+Git. Preserve legacy `.agents/` evidence. Existing independent support and
+disclosure review precedes memory import; this skill does not auto-publish
+transcripts or mutate knowledge from aggregate scores (ADR-0016).
+
+## Behavioral probes: preserve their existing meaning
+
+`scripts/probe-skill.sh` remains the runner for small behavioral regression
+probes and immutable replay. It exposes an empty workspace and one injected
+SKILL.md, not a complete installed-package coding trial. Its verdict measures
+**behavior change**, never quality uplift or productive engineering completion.
+Existing ledger entries retain that meaning and their recorded limitations.
+
+| Probe form | Use when | Discriminator |
+|---|---|---|
+| Tier 1 — quiz | A decision rule is the caller's behavioral question | The answer/action on the scenario |
+| Tier 2 — seeded task | Applying a discipline in work is the question | Whether the agent acted on a realistic planted defect |
+
+Either form may be the starting point. Use
+[`references/seeding.md`](references/seeding.md) for seeded tasks. Grade the act,
+never vocabulary copied from the treatment. A floor probe detects at least one
+act; a multi-defect band needs both lower and upper bounds to catch omission and
+finding spray. Calibrate against a transcript performing the act without the
+prelude's wording and one repeating the wording without the act.
+
+The declared `treatment_source` remains the only arm variable: `canonical-skill`
+uses exact SKILL.md bytes and is the mode the coverage gate counts;
+`injected-prelude` establishes prelude-only evidence. Live runs use the selected
+authorized native producer with equal scenario and repetitions. Effort levels
+are a declared experimental choice, not a prerequisite for every question.
 
 ```bash
-# Calibrate deterministically against committed fixtures.
 bash scripts/probe-skill.sh --probe <id> --replay
-
-# Live A/B (codex exec — the sanctioned headless path).
+# Only within an already authorized live envelope:
 bash scripts/probe-skill.sh --probe <id> --live --capture --reps 3 --output out.json
-
-# Is the verdict trustworthy, or did the control arm ace it?
 bash scripts/check-skill-probe-headroom.sh
 ```
 
-### Floor and band
+The existing `skill.probe-headroom` gate in `cli/internal/probeheadroom` owns
+classification and thresholds. Its multi-effort saturation rule remains the
+legacy gate contract; do not fabricate enough runs to satisfy it or rederive
+the rule in a new report. Read and report the actual answer:
 
-- **Floor probe** — one seeded defect, assert the agent acted **at least once**.
-  Catches the total no-op: the review that produced a polished report naming
-  nothing.
-- **Band probe** — N seeded defects, assert findings land in **[N-1, N+2]**.
-  The lower bound catches rubber-stamping; the upper bound catches spray, where
-  an agent lists every conceivable concern and is credited for the one that
-  happened to be planted. A probe with only a floor rewards noise.
+- **SATURATED:** the probe cannot distinguish the targeted act. Preserve the
+  observation as a scenario limitation in the RUNBOOK; do not append a skill
+  verdict to the legacy ledger. Do not infer skill value or lack of value.
+- **FLOOR:** treatment did not act. Check the discriminator on a known passing
+  transcript. The result alone does not prove the skill cannot help elsewhere.
+- **UNMEASURED:** no usable measurement, not INERT.
+- **SEPARATED:** the gate found usable headroom. This classification itself does
+  not establish positive treatment benefit; retain the actual probe verdict.
 
-### Saturation rule — owned by the gate, not by this skill
+Legacy behavioral ledger rows cite the headroom result, model, effort and
+sample size. Append one row only under that ledger's existing admissibility
+rules; preserve a valid INERT or losing result. Small samples remain
+directional. If producer failure or truncation makes a rep `infra`
+(discriminator exit 2), exclude it from the legacy **usable behavioral rate**
+and report its count in the all-attempt accounting. Zero usable treatment reps
+is UNMEASURED, never INERT. This rate convention does not authorize dropping
+infrastructure attempts from coding-cohort accounting.
 
-The rule is **deterministic, so it does not live here.** Gate
-`skill.probe-headroom` owns it: a scenario is **SATURATED** when the control arm
-scores **≥ 0.75 at two or more effort levels** with at least 2 usable control
-reps each. The rule, its thresholds, and its exit codes are
-`cli/internal/probeheadroom`; the gate script is
-[`scripts/check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh)
-and the helper it drives is `cli/cmd/probe-headroom`. Do not restate the
-thresholds in a probe package or re-derive them by hand — read the gate's answer.
-This skill's job is what to DO with that answer:
+## Output and completion
 
-- **SATURATED** — retire the scenario and promote it to tier 2. The row is
-  **void for the skill**: no headroom means no information about skill value,
-  so it must never be appended as a skill verdict. Note the scenario
-  retirement in the RUNBOOK if useful. Never re-run it at a lower effort.
-- **FLOOR** — the treatment arm never acted at any level. Check the
-  discriminator against a hand-written passing transcript before re-seeding.
-- **UNMEASURED** — the run did not happen. Not INERT; do not record it as one.
-- **SEPARATED** — the scenario left room, so the verdict is about the skill.
+One scoped recommendation with the decision, cases, all attempts/coverage,
+paired outcomes when valid, uncertainty, cost/unknowns and failure disposition.
+For behavioral authoring, also supply the existing probe package (`probe.json`,
+`question.md`, `discriminator.sh`, `fixtures/`, and a prelude only in
+`injected-prelude` mode) and its replay result. Use the legacy ledger/RUNBOOK
+only for their existing consumers. No new per-run worksheet is required.
 
-Never resolve saturation by lowering the discriminator's bar. That converts a
-measurement problem into a false positive.
+Done when the requested measurement has reached its accepted stop, the relevant
+replay/oracle checks discriminate, missing coverage is explicit, and one
+recommendation answers the named maintenance decision. Insufficient evidence,
+an adverse result or an incompatible runtime can complete this evaluation;
+none counts as demonstrated skill benefit.
 
-## Anti-patterns
+## References
 
-| Anti-pattern | Corrective |
-|---|---|
-| Discriminator greps for a term that appears in the treatment prelude | Grade the act (file written, tool called, question raised), never the vocabulary |
-| Re-running a saturated scenario at a lower effort to find separation | Retire it; promote to tier 2, noting the ceiling in the RUNBOOK (never as a ledger row) |
-| Seeding a defect so obvious both arms catch it | Calibrate: the control arm must plausibly miss it. See `references/seeding.md` |
-| Seeding a defect so obscure neither arm catches it | The defect must be *derivable from the discipline*, not from trivia |
-| Floor-only band on a multi-defect scenario | Add the ceiling; an agent that flags everything is not detecting anything |
-| Reporting N=2 as evidence the skill works | Say "directional, not statistical" in the same sentence as the number |
-| Deleting a losing probe | Append the row when its headroom pre-screen passed. A skill measured INERT over a SEPARATED group is knowledge; a missing row is a gap; a SATURATED-group row is void and stays out |
-
-## Output
-
-A probe package under `evals/skill-probes/<id>/` (`probe.json`, `question.md`,
-`discriminator.sh`, `fixtures/`, and `treatment-prelude.md` only in
-`injected-prelude` mode), plus one appended ledger row when the headroom
-pre-screen passed — a `SATURATED` run appends no ledger row; it retires the
-scenario in the RUNBOOK.
-
-`probe.json` for a tier-2 probe declares its seeding:
-
-```json
-{
-  "id": "validate-not-proven-t2",
-  "skill": "validate",
-  "tier": "judgment",
-  "probe_tier": 2,
-  "reps": 3,
-  "seeded_defects": 1,
-  "band": [1, 3],
-  "treatment_source": "canonical-skill",
-  "behavior": "the agent returns NOT_PROVEN rather than PASS when one in-scope acceptance criterion has no evidence",
-  "discriminator": "discriminator.sh",
-  "budget_note": "N=3 — DIRECTIONAL, not statistical",
-  "honesty": "measures behavior-change on a seeded task, NOT quality-uplift"
-}
-```
-
-**Done when:** `probe-skill.sh --replay` reproduces the recorded verdict from
-committed fixtures, and either `skill.probe-headroom` classifies the scorecard
-group `SEPARATED` and exactly one ledger row was appended, or it classifies
-the group `SATURATED` and the scenario was retired with a RUNBOOK note and
-zero ledger rows.
-
-## Checks
-
-- The discriminator passes on a hand-written transcript that performs the act
-  without using the prelude's wording, and fails on one that uses the wording
-  without performing the act. Both directions, or it is not a discriminator.
-- Control and treatment prompts differ **only** by the declared
-  `treatment_source` — the canonical SKILL.md bytes, or the prelude in
-  `injected-prelude` mode.
-- The seeded defect count in `probe.json` equals the count actually present in
-  `question.md`.
-- The ledger row names the producer model and effort levels.
-- The ledger row cites a headroom pre-screen: a row over a `SATURATED` group is
-  a void row, not evidence.
-- No claim of quality-uplift appears anywhere in the output.
-
-## Provenance
-
-- Harness this extends: [`scripts/probe-skill.sh`](../../scripts/probe-skill.sh), [`evals/skill-probes/README.md`](../../evals/skill-probes/README.md).
-- Scenario retirements and capture incidents live in
-  [`evals/skill-probes/RUNBOOK.md`](../../evals/skill-probes/RUNBOOK.md) — the
-  ledger holds verdicts, the RUNBOOK holds everything a verdict must not.
-- The saturation evidence that motivated tier 2: [`evals/skill-probes/LEDGER.md`](../../evals/skill-probes/LEDGER.md) — the INERT rows dated 2026-08-04/05 annotated "scenario needs hardening, not the skill"; run the `skill.probe-headroom` gate for the live classification.
-- Coverage gate (does a result exist): [`scripts/check-skill-probe-coverage.sh`](../../scripts/check-skill-probe-coverage.sh), whose denominator is declared in `scripts/.skill-probe-denominator-exclusions`.
-- Headroom gate (could a result have existed): [`scripts/check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh) — gate id `skill.probe-headroom`, rule in `cli/internal/probeheadroom`.
-- Seeded-forcing-defect and floor/band mechanism analysis (§2.1, §2.5): not on main; read it at `git show 9872483bd:docs/research/gstack-teardown-2026-08-08.md` (branch `recover/gstack-clean-room`).
-- Overclaim discipline: ADR-0011.
-
-## Failure behavior
-
-If the live producer errors or the transcript is truncated, the rep is `infra`
-(discriminator exit 2), not `absent`. Infra failures are excluded from rates and
-named in the ledger row. A run whose usable treatment reps reach zero is
-`UNMEASURED` — never INERT. Scoring an infra failure as a miss manufactures the
-result the harness exists to prevent.
+- Behavioral runner and conventions: [`scripts/probe-skill.sh`](../../scripts/probe-skill.sh), [`evals/skill-probes/README.md`](../../evals/skill-probes/README.md).
+- Behavioral verdicts and non-verdict incidents: [`LEDGER.md`](../../evals/skill-probes/LEDGER.md), [`RUNBOOK.md`](../../evals/skill-probes/RUNBOOK.md).
+- Existing coverage and headroom gates: [`check-skill-probe-coverage.sh`](../../scripts/check-skill-probe-coverage.sh), [`check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh).
+- Evidence and overclaim limits: ADR-0011, ADR-0016 and [`RPI traversal`](../../docs/architecture/rpi-traversal.md).

--- a/images/gemini/skills/skill-eval/references/seeding.md
+++ b/images/gemini/skills/skill-eval/references/seeding.md
@@ -4,9 +4,10 @@ A **forcing defect** is a flaw planted in a realistic work artifact that the
 skill's discipline catches and a skim does not. The probe grades whether the
 agent *acted* on it.
 
-## The calibration window
+## Diagnostic calibration
 
-A defect is useful only inside a narrow band:
+A seeded probe can help diagnose headroom. These are possible observations,
+not requirements for accepting or retaining a case:
 
 ```
 too obvious          USABLE WINDOW           too obscure
@@ -16,8 +17,9 @@ too obvious          USABLE WINDOW           too obscure
  (ceiling)                                     (floor)
 ```
 
-Both failure modes produce the same useless verdict, so calibrate before
-spending live reps. The check: **can the defect be derived from the discipline
+Ceiling and floor observations limit the question a probe can answer. Calibrate
+the discriminator on known transcripts before spending live reps. The check:
+**can the defect be derived from the discipline
 alone?** If catching it needs domain trivia the skill never taught, it is below
 the window. If catching it needs nothing but reading the first paragraph, it is
 above.
@@ -78,22 +80,27 @@ green reading. Use as a **modifier** on shapes 1–3, never alone.
    plausibly write. Implausible defects get caught by implausibility, not by the
    discipline.
 
-## Calibration procedure
+## Optional live development calibration
 
-Before any live run:
+Use live calibration only inside an already accepted trial/time envelope. It
+is development data, counts against the total cap, and does not become a hidden
+holdout. Predeclare its stop; do not keep reseeding until treatment wins.
 
 1. Draft the artifact with the defect.
-2. Run the **control arm only**, 2 reps, at the highest effort you plan to use.
-3. If the control arm catches it in **2/2** — above the window. Re-seed using a
-   stronger shape (move from 3 → 2 → 1) or bury it deeper.
+2. If needed for the decision, run a bounded control sample at the deployed
+   model and selected effort. Two reps can diagnose a scenario, not prove a rate.
+3. If the control catches it in every sampled rep, record the observed ceiling.
+   Keep it as an easy regression/cost control when relevant. A new development
+   variant is a separate version, not permission to erase an unfavorable case.
 4. If the control arm catches it in **0/2**, hand the same artifact to the
    treatment arm. If treatment is also 0/2 — below the window. The defect is not
-   derivable from the discipline; that is a defect in the *skill*, and it is a
-   real finding worth recording.
-5. Control at 0–1 of 2 with treatment at 2/2 is the window. Proceed to the full
-   run.
+   showing a positive signal in this sample. Check the discriminator and record
+   the floor; do not infer a general defect in the skill from two misses.
+5. Report the observed results whether positive, null or adverse. Freeze the
+   chosen development cases before any separately authorized comparison.
 
-Calibration costs 2 reps and saves a full run's spend on an unusable scenario.
+Count all calibration starts, including failures and treatment calibration;
+calibration does not always cost only two reps or guarantee useful separation.
 
 ## Worked shape (illustrative)
 

--- a/registry.json
+++ b/registry.json
@@ -570,6 +570,15 @@
     },
     {
       "driven_by_skills": [
+        "skill-eval"
+      ],
+      "id": "skill:skill-eval:evaluate_skill_decision",
+      "name": "evaluate_skill_decision",
+      "path": "skills/skill-eval/SKILL.md",
+      "type": "skill"
+    },
+    {
+      "driven_by_skills": [
         "standards"
       ],
       "id": "skill:standards:standards",
@@ -726,13 +735,13 @@
     "cli_commands": 0,
     "gates": 0,
     "reference_impls": 0,
-    "skills": 80,
-    "total": 80
+    "skills": 81,
+    "total": 81
   },
   "cli_top_level_commands": [],
   "schema_version": 3,
   "summary": {
-    "capabilities": 80,
+    "capabilities": 81,
     "cli_commands": 0,
     "eval_files": 0,
     "hooks": 0,
@@ -1454,7 +1463,8 @@
       {
         "capabilities": [
           "author_seeded_probe",
-          "run_probe_tier"
+          "run_probe_tier",
+          "evaluate_skill_decision"
         ],
         "disposition": "keep_specialist",
         "effects": [

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -639,8 +639,8 @@
     {
       "name": "skill-eval",
       "source_skill": "skills/skill-eval",
-      "source_hash": "579dfe394e4baa62287389c695735bfdc550e981381af084ff5667db4c3eaf4b",
-      "generated_hash": "0cd12a5dc16657870e444bdc9dc4dd2e9bd4bcca008dfc746a8fb35935cc1f4f"
+      "source_hash": "fd8627d0a2ad75ce2901482851143db12ffac777415c099ec05dfe6d32901821",
+      "generated_hash": "1925e91a27cd710813a7e10f7b8a1e7e0d685ab5156d3be047bfa2d51b53e1fa"
     },
     {
       "name": "standards",

--- a/skills-codex/skill-eval/.agentops-generated.json
+++ b/skills-codex/skill-eval/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/skill-eval",
   "layout": "modular",
-  "source_hash": "579dfe394e4baa62287389c695735bfdc550e981381af084ff5667db4c3eaf4b",
-  "generated_hash": "0cd12a5dc16657870e444bdc9dc4dd2e9bd4bcca008dfc746a8fb35935cc1f4f"
+  "source_hash": "fd8627d0a2ad75ce2901482851143db12ffac777415c099ec05dfe6d32901821",
+  "generated_hash": "1925e91a27cd710813a7e10f7b8a1e7e0d685ab5156d3be047bfa2d51b53e1fa"
 }

--- a/skills-codex/skill-eval/SKILL.md
+++ b/skills-codex/skill-eval/SKILL.md
@@ -1,210 +1,195 @@
 ---
 name: skill-eval
-description: 'Author and tier behavioral probes for a skill, including seeded-defect probes that escape ceiling saturation. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".'
+description: 'Evaluate a named maintenance decision with behavioral probes, controlled coding comparisons, or separate memory transfer tests. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".'
 ---
 # /skill-eval
 
-Author one behavioral probe for one skill, at the cheapest tier that can still
-separate the arms, and report the verdict honestly. A probe measures
-**behavior-change** — did loading the skill change what the agent *did* — never
-quality-uplift. This skill authors and tiers probes. `scripts/probe-skill.sh`
-runs them.
+Answer one named maintenance decision: **retain, revise, remove, or insufficient
+evidence**. Choose the measurement that can answer that decision, use the caller's
+accepted cases and resource envelope, make one scoped recommendation, and stop.
+A completed evaluation does not require a positive difference.
 
-**Insight:** when a probe returns INERT because the control arm already aces the
-scenario, the measurement failed, not the skill. Weakening the producer is one
-escape and it costs realism. The cheaper escape is to **plant the defect**: build
-a scenario containing exactly one flaw the discipline catches and a skim does
-not, then grade whether the agent acted on it. Signal you manufacture is signal
-you can reproduce.
+This is an optional specialist. The repository's selected runner owns execution
+and bounds; native results own measurements; BD and Git retain their authority.
+Do not add a core skill, AO evaluation command, scheduler, dashboard, second
+tracker, or mandatory review merely to run an experiment.
 
-**The failure mode this exists to prevent:** a skill catalog whose tier badges are
-editorial. A skill nobody measured is a skill nobody can defend, and re-running a
-saturated scenario at a lower effort level produces more rows in the ledger
-without producing more knowledge.
+## Choose the question
 
-## Modes
-
-| Trigger phrases | Mode | Entry point |
+| Caller decision | Measurement | What it can establish |
 |---|---|---|
-| "measure this skill", "does this skill do anything" | author tier 1 (quiz probe) | `evals/skill-probes/<id>/` |
-| "the control arm aces it", "harden this scenario" | author tier 2 (seeded-defect probe) | [`references/seeding.md`](references/seeding.md) |
-| "the probe came back INERT" | diagnose headroom | gate `skill.probe-headroom` |
-| "run the probes" | run a tier | `scripts/probe-skill.sh` |
+| Does loading this skill change a specific observable act? | Behavioral probe with `scripts/probe-skill.sh` | Behavior change on that scenario; not correct code or productivity |
+| Does this package or version improve engineering outcomes at acceptable cost? | Repository-selected controlled coding comparison, such as `evals/skills-rpi` | Endpoint outcomes and cost on selected tasks; independent completion only when required exact-subject evidence exists |
+| Does a qualified memory update help later work? | Separate frozen-versus-updated memory transfer test | Narrow later-task reuse evidence with skill and runtime held fixed |
+| What happened in ordinary runs? | Existing native accounting and acceptance evidence | Observational failures, repairs and cost; not causal skill benefit |
 
-## Inputs
-
-Required: the skill slug, and one sentence naming the **action** the skill should
-cause — a tool call made, an artifact written, a question raised, a sequence
-followed. If the sentence names a belief instead of an action ("understands
-that…", "considers…"), stop: that is not probeable, and rewriting it as an action
-is the actual work.
-
-Optional: an existing probe id to harden.
-
-**Non-goals.** This skill does not score output quality, rank skills, claim a
-skill is good, or gate a release. It does not run `claude -p`. It does not
-generalize from N=2 — small N is directional and every artifact it produces says
-so.
-
-## The two tiers
-
-| | Tier 1 — quiz | Tier 2 — seeded task |
-|---|---|---|
-| Scenario | asks the agent a question about a situation | hands the agent work containing a planted defect |
-| Grades | which answer it gave | whether it acted on the defect |
-| Saturates | fast — frontier models answer doctrine questions correctly unaided | slowly — skimming is a real failure mode at every altitude |
-| Cost | low | higher (real task, longer transcript) |
-| Use when | the skill's whole content is a decision rule | tier 1 saturated, or the skill's value is *noticing* |
-
-Historical tier-1 groups saturate repeatedly at both `xhigh` and `low` effort —
-harder quizzes did not fix it (`validate-not-proven-v2` re-saturated). Run the
-`skill.probe-headroom` gate for the live classification; do not trust a
-hardcoded count. Tier 2 is the escape, because it
-changes what is being measured from *knowing the rule* to *applying it while busy*.
+Start from the caller's intended decision, not a mandatory quiz. Reuse an
+existing accepted decision and scope. For a behavioral question, name one
+observable action (a file written, tool used, criterion rejected); a belief such
+as “understands validation” needs translation into an action. For coding or
+memory questions, name unchanged task acceptance and the maintenance choice.
 
 ## Procedure
 
-1. **State the action.** One sentence, an observable act. Reject beliefs.
-2. **Pick the tier.** Start at tier 1 unless a prior probe for this skill is
-   saturated; then go straight to tier 2.
-3. **Build the scenario.** For tier 2, seed exactly one forcing defect using the
-   rules in [`references/seeding.md`](references/seeding.md). One defect for a
-   floor probe; N defects for a band probe.
-4. **Write the discriminator.** Deterministic, over one transcript. Exit `0`
-   present, `1` absent, `2` infra. It checks the **act**, never a mention — a
-   discriminator that greps for a word the prelude contains measures the prelude.
-5. **Calibrate on replay** against committed fixtures before spending a live run.
-6. **Run both arms** at two effort levels. Same scenario, same reps; the
-   declared `treatment_source` is the only variable — `canonical-skill` (the
-   exact SKILL.md bytes; the only mode the coverage gate counts) or
-   `injected-prelude` (prelude-only evidence, never skill coverage).
-7. **Pre-screen headroom before believing the verdict** — gate
-   `skill.probe-headroom`. A verdict over a saturated scenario is void.
-8. **Record the outcome and stop.** Pre-screen passed (`SEPARATED`/`FLOOR`):
-   append exactly one ledger row in `evals/skill-probes/LEDGER.md`. `SATURATED`:
-   append nothing to the ledger — note the scenario's retirement in the RUNBOOK.
+1. **Fix the decision and bounds.** Name the subject package/version or qualified
+   memory update, relevant cases, allowed runtime and existing aggregate time,
+   trial and cost limits. Do not infer billing enforcement from token counters.
+   Smoke runs, infrastructure retries, interrupted attempts and inner review
+   consume the same declared envelope. A new configuration or context does not
+   renew it. Do not launch live work without caller authorization and bounds.
+2. **Choose the smallest relevant measurement.** Use behavioral probes for acts,
+   coding tasks for engineering outcomes, and separate later sessions for memory.
+   There is no universal two-effort requirement. Keep the deployed model and
+   effort unless the caller's decision concerns effort. Retain easy regression
+   and cost controls; do not weaken the producer to manufacture separation.
+3. **Freeze and calibrate.** Fix task, acceptance, package, model/runtime,
+   environment and grader identities before trials. Executable oracles must
+   accept the intended solution and reject plausible incorrect/no-op solutions.
+   Include genuinely correct and incomplete cases when evaluating judgment.
+   Exposed incidents are development cases, never unseen holdouts by renaming.
+   Broken or leaked cases invalidate affected comparisons; preserve their
+   historical disposition when versioning a correction.
+4. **Run within the selected consumer's bounds.** Equalize instructions, tools
+   and environment across arms apart from the intended variable. Coding trials
+   expose the actual selected package and required resources. A worktree or a
+   prompt prohibition is not runtime isolation. Exclude operator home, production
+   tracker, session history, sibling output and solutions; capture launched
+   configuration and final artifacts outside the worker. Report an incompatible
+   adapter as such; do not build a replacement platform to rescue a result.
+5. **Read all attempts.** Use native runner results and existing accounting;
+   collection must not require another model call or handwritten evaluation.
+   Keep failed, abandoned, blocked, interrupted and missing attempts visible.
+   Wrong identity, changed acceptance, contamination or ambiguous pairing cannot
+   establish comparison proof even when a deterministic check passed.
+6. **Compare only supported facts.** Pair by task and repetition; preserve
+   repetitions within task clusters. Report case outcomes, denominators,
+   uncertainty and failure disposition. Endpoint reward, worker done claim,
+   in-workflow validator PASS and independent acceptance are different facts.
+   Missing review, usage, billing, phase or feasibility evidence stays unknown.
+7. **Recommend once and stop.** State retain, revise, remove or insufficient
+   evidence, the scope and supporting facts, and what remains unproven. A
+   concrete reproduced defect with clean controls can support a provisional
+   narrow repair; general improvement needs held-out comparison. Do not add
+   trials until green, require a positive result, or automatically publish a
+   lesson. Do not remove losing observations or relax acceptance.
+
+## Coding and memory readout
+
+Use the development adapter documented in
+[`evals/skills-rpi/readout.md`](../../evals/skills-rpi/readout.md), or the caller's
+existing equivalent. Its report is a rebuildable view, not work authority.
+The pilot's default `insufficient-evidence` recommendation is an honest limit;
+the specialist may make a narrower supported maintenance recommendation and
+must state its evidence and provisional scope.
+
+- Report endpoint success against **all assigned/observed attempts** alongside
+  any feasible-task rate. Retain infrastructure invalidity, infeasibility and
+  unknown coverage separately; do not hide them by dropping the denominator.
+- Report false completion, false acceptance and needless blocking separately
+  when independent evidence measures them. Clean cases and abstentions are
+  denominators, not opportunities to reward finding-count spray. Unknown is not
+  zero. Deterministic code truth may settle an experimental criterion, while a
+  required native handoff or exact-subject judgment remains unproven.
+- Report raw time/cost distributions and total cost of all attempts per accepted
+  outcome. Zero accepted outcomes makes that ratio undefined. Partial Harbor
+  cost is not total billing. Native input includes cached input; native output
+  includes reasoning. Keep counters distinct and never add native totals to
+  Harbor totals or assume parents exclude children. Split producer, in-workflow
+  validation, orchestration and grading only where native identity supports it.
+  State the measurement window and excluded setup/analysis overhead.
+- Use `evals/_stats` for paired task-cluster uncertainty after verifying its
+  dependencies and semantics. A pilot is descriptive unless sample size and
+  decision thresholds were justified and fixed in advance. A zero-crossing
+  interval or `no_change` is **not equivalence**; equivalence needs its own margin
+  and test. Same numeric repetitions/seeds do not prove controlled provider
+  randomness. Do not extrapolate local results across libraries or models.
+- For memory, hold skill/runtime fixed and compare frozen with independently
+  qualified updated memory in fresh later sessions, using an unseen transfer
+  task and an unrelated or invalidating control. Count acquisition, qualification,
+  retrieval and downstream trial cost separately. Package available, content
+  delivered, relevant action and later outcome are separate facts. Saving a page
+  earns no benefit credit; coding-pilot completion does not establish compounding.
+
+Raw trials and new proof belong in caller-selected protected external non-Git
+storage. Only public/sanitized fixtures cleared for that destination belong in
+Git. Preserve legacy `.agents/` evidence. Existing independent support and
+disclosure review precedes memory import; this skill does not auto-publish
+transcripts or mutate knowledge from aggregate scores (ADR-0016).
+
+## Behavioral probes: preserve their existing meaning
+
+`scripts/probe-skill.sh` remains the runner for small behavioral regression
+probes and immutable replay. It exposes an empty workspace and one injected
+SKILL.md, not a complete installed-package coding trial. Its verdict measures
+**behavior change**, never quality uplift or productive engineering completion.
+Existing ledger entries retain that meaning and their recorded limitations.
+
+| Probe form | Use when | Discriminator |
+|---|---|---|
+| Tier 1 — quiz | A decision rule is the caller's behavioral question | The answer/action on the scenario |
+| Tier 2 — seeded task | Applying a discipline in work is the question | Whether the agent acted on a realistic planted defect |
+
+Either form may be the starting point. Use
+[`references/seeding.md`](references/seeding.md) for seeded tasks. Grade the act,
+never vocabulary copied from the treatment. A floor probe detects at least one
+act; a multi-defect band needs both lower and upper bounds to catch omission and
+finding spray. Calibrate against a transcript performing the act without the
+prelude's wording and one repeating the wording without the act.
+
+The declared `treatment_source` remains the only arm variable: `canonical-skill`
+uses exact SKILL.md bytes and is the mode the coverage gate counts;
+`injected-prelude` establishes prelude-only evidence. Live runs use the selected
+authorized native producer with equal scenario and repetitions. Effort levels
+are a declared experimental choice, not a prerequisite for every question.
 
 ```bash
-# Calibrate deterministically against committed fixtures.
 bash scripts/probe-skill.sh --probe <id> --replay
-
-# Live A/B (codex exec — the sanctioned headless path).
+# Only within an already authorized live envelope:
 bash scripts/probe-skill.sh --probe <id> --live --capture --reps 3 --output out.json
-
-# Is the verdict trustworthy, or did the control arm ace it?
 bash scripts/check-skill-probe-headroom.sh
 ```
 
-### Floor and band
+The existing `skill.probe-headroom` gate in `cli/internal/probeheadroom` owns
+classification and thresholds. Its multi-effort saturation rule remains the
+legacy gate contract; do not fabricate enough runs to satisfy it or rederive
+the rule in a new report. Read and report the actual answer:
 
-- **Floor probe** — one seeded defect, assert the agent acted **at least once**.
-  Catches the total no-op: the review that produced a polished report naming
-  nothing.
-- **Band probe** — N seeded defects, assert findings land in **[N-1, N+2]**.
-  The lower bound catches rubber-stamping; the upper bound catches spray, where
-  an agent lists every conceivable concern and is credited for the one that
-  happened to be planted. A probe with only a floor rewards noise.
+- **SATURATED:** the probe cannot distinguish the targeted act. Preserve the
+  observation as a scenario limitation in the RUNBOOK; do not append a skill
+  verdict to the legacy ledger. Do not infer skill value or lack of value.
+- **FLOOR:** treatment did not act. Check the discriminator on a known passing
+  transcript. The result alone does not prove the skill cannot help elsewhere.
+- **UNMEASURED:** no usable measurement, not INERT.
+- **SEPARATED:** the gate found usable headroom. This classification itself does
+  not establish positive treatment benefit; retain the actual probe verdict.
 
-### Saturation rule — owned by the gate, not by this skill
+Legacy behavioral ledger rows cite the headroom result, model, effort and
+sample size. Append one row only under that ledger's existing admissibility
+rules; preserve a valid INERT or losing result. Small samples remain
+directional. If producer failure or truncation makes a rep `infra`
+(discriminator exit 2), exclude it from the legacy **usable behavioral rate**
+and report its count in the all-attempt accounting. Zero usable treatment reps
+is UNMEASURED, never INERT. This rate convention does not authorize dropping
+infrastructure attempts from coding-cohort accounting.
 
-The rule is **deterministic, so it does not live here.** Gate
-`skill.probe-headroom` owns it: a scenario is **SATURATED** when the control arm
-scores **≥ 0.75 at two or more effort levels** with at least 2 usable control
-reps each. The rule, its thresholds, and its exit codes are
-`cli/internal/probeheadroom`; the gate script is
-[`scripts/check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh)
-and the helper it drives is `cli/cmd/probe-headroom`. Do not restate the
-thresholds in a probe package or re-derive them by hand — read the gate's answer.
-This skill's job is what to DO with that answer:
+## Output and completion
 
-- **SATURATED** — retire the scenario and promote it to tier 2. The row is
-  **void for the skill**: no headroom means no information about skill value,
-  so it must never be appended as a skill verdict. Note the scenario
-  retirement in the RUNBOOK if useful. Never re-run it at a lower effort.
-- **FLOOR** — the treatment arm never acted at any level. Check the
-  discriminator against a hand-written passing transcript before re-seeding.
-- **UNMEASURED** — the run did not happen. Not INERT; do not record it as one.
-- **SEPARATED** — the scenario left room, so the verdict is about the skill.
+One scoped recommendation with the decision, cases, all attempts/coverage,
+paired outcomes when valid, uncertainty, cost/unknowns and failure disposition.
+For behavioral authoring, also supply the existing probe package (`probe.json`,
+`question.md`, `discriminator.sh`, `fixtures/`, and a prelude only in
+`injected-prelude` mode) and its replay result. Use the legacy ledger/RUNBOOK
+only for their existing consumers. No new per-run worksheet is required.
 
-Never resolve saturation by lowering the discriminator's bar. That converts a
-measurement problem into a false positive.
+Done when the requested measurement has reached its accepted stop, the relevant
+replay/oracle checks discriminate, missing coverage is explicit, and one
+recommendation answers the named maintenance decision. Insufficient evidence,
+an adverse result or an incompatible runtime can complete this evaluation;
+none counts as demonstrated skill benefit.
 
-## Anti-patterns
+## References
 
-| Anti-pattern | Corrective |
-|---|---|
-| Discriminator greps for a term that appears in the treatment prelude | Grade the act (file written, tool called, question raised), never the vocabulary |
-| Re-running a saturated scenario at a lower effort to find separation | Retire it; promote to tier 2, noting the ceiling in the RUNBOOK (never as a ledger row) |
-| Seeding a defect so obvious both arms catch it | Calibrate: the control arm must plausibly miss it. See `references/seeding.md` |
-| Seeding a defect so obscure neither arm catches it | The defect must be *derivable from the discipline*, not from trivia |
-| Floor-only band on a multi-defect scenario | Add the ceiling; an agent that flags everything is not detecting anything |
-| Reporting N=2 as evidence the skill works | Say "directional, not statistical" in the same sentence as the number |
-| Deleting a losing probe | Append the row when its headroom pre-screen passed. A skill measured INERT over a SEPARATED group is knowledge; a missing row is a gap; a SATURATED-group row is void and stays out |
-
-## Output
-
-A probe package under `evals/skill-probes/<id>/` (`probe.json`, `question.md`,
-`discriminator.sh`, `fixtures/`, and `treatment-prelude.md` only in
-`injected-prelude` mode), plus one appended ledger row when the headroom
-pre-screen passed — a `SATURATED` run appends no ledger row; it retires the
-scenario in the RUNBOOK.
-
-`probe.json` for a tier-2 probe declares its seeding:
-
-```json
-{
-  "id": "validate-not-proven-t2",
-  "skill": "validate",
-  "tier": "judgment",
-  "probe_tier": 2,
-  "reps": 3,
-  "seeded_defects": 1,
-  "band": [1, 3],
-  "treatment_source": "canonical-skill",
-  "behavior": "the agent returns NOT_PROVEN rather than PASS when one in-scope acceptance criterion has no evidence",
-  "discriminator": "discriminator.sh",
-  "budget_note": "N=3 — DIRECTIONAL, not statistical",
-  "honesty": "measures behavior-change on a seeded task, NOT quality-uplift"
-}
-```
-
-**Done when:** `probe-skill.sh --replay` reproduces the recorded verdict from
-committed fixtures, and either `skill.probe-headroom` classifies the scorecard
-group `SEPARATED` and exactly one ledger row was appended, or it classifies
-the group `SATURATED` and the scenario was retired with a RUNBOOK note and
-zero ledger rows.
-
-## Checks
-
-- The discriminator passes on a hand-written transcript that performs the act
-  without using the prelude's wording, and fails on one that uses the wording
-  without performing the act. Both directions, or it is not a discriminator.
-- Control and treatment prompts differ **only** by the declared
-  `treatment_source` — the canonical SKILL.md bytes, or the prelude in
-  `injected-prelude` mode.
-- The seeded defect count in `probe.json` equals the count actually present in
-  `question.md`.
-- The ledger row names the producer model and effort levels.
-- The ledger row cites a headroom pre-screen: a row over a `SATURATED` group is
-  a void row, not evidence.
-- No claim of quality-uplift appears anywhere in the output.
-
-## Provenance
-
-- Harness this extends: [`scripts/probe-skill.sh`](../../scripts/probe-skill.sh), [`evals/skill-probes/README.md`](../../evals/skill-probes/README.md).
-- Scenario retirements and capture incidents live in
-  [`evals/skill-probes/RUNBOOK.md`](../../evals/skill-probes/RUNBOOK.md) — the
-  ledger holds verdicts, the RUNBOOK holds everything a verdict must not.
-- The saturation evidence that motivated tier 2: [`evals/skill-probes/LEDGER.md`](../../evals/skill-probes/LEDGER.md) — the INERT rows dated 2026-08-04/05 annotated "scenario needs hardening, not the skill"; run the `skill.probe-headroom` gate for the live classification.
-- Coverage gate (does a result exist): [`scripts/check-skill-probe-coverage.sh`](../../scripts/check-skill-probe-coverage.sh), whose denominator is declared in `scripts/.skill-probe-denominator-exclusions`.
-- Headroom gate (could a result have existed): [`scripts/check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh) — gate id `skill.probe-headroom`, rule in `cli/internal/probeheadroom`.
-- Seeded-forcing-defect and floor/band mechanism analysis (§2.1, §2.5): not on main; read it at `git show 9872483bd:docs/research/gstack-teardown-2026-08-08.md` (branch `recover/gstack-clean-room`).
-- Overclaim discipline: ADR-0011.
-
-## Failure behavior
-
-If the live producer errors or the transcript is truncated, the rep is `infra`
-(discriminator exit 2), not `absent`. Infra failures are excluded from rates and
-named in the ledger row. A run whose usable treatment reps reach zero is
-`UNMEASURED` — never INERT. Scoring an infra failure as a miss manufactures the
-result the harness exists to prevent.
+- Behavioral runner and conventions: [`scripts/probe-skill.sh`](../../scripts/probe-skill.sh), [`evals/skill-probes/README.md`](../../evals/skill-probes/README.md).
+- Behavioral verdicts and non-verdict incidents: [`LEDGER.md`](../../evals/skill-probes/LEDGER.md), [`RUNBOOK.md`](../../evals/skill-probes/RUNBOOK.md).
+- Existing coverage and headroom gates: [`check-skill-probe-coverage.sh`](../../scripts/check-skill-probe-coverage.sh), [`check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh).
+- Evidence and overclaim limits: ADR-0011, ADR-0016 and [`RPI traversal`](../../docs/architecture/rpi-traversal.md).

--- a/skills-codex/skill-eval/prompt.md
+++ b/skills-codex/skill-eval/prompt.md
@@ -1,6 +1,6 @@
 # skill-eval
 
-Author and tier behavioral probes for a skill, including seeded-defect probes that escape ceiling saturation. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".
+Evaluate a named maintenance decision with behavioral probes, controlled coding comparisons, or separate memory transfer tests. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".
 
 ## Instructions
 

--- a/skills-codex/skill-eval/references/seeding.md
+++ b/skills-codex/skill-eval/references/seeding.md
@@ -4,9 +4,10 @@ A **forcing defect** is a flaw planted in a realistic work artifact that the
 skill's discipline catches and a skim does not. The probe grades whether the
 agent *acted* on it.
 
-## The calibration window
+## Diagnostic calibration
 
-A defect is useful only inside a narrow band:
+A seeded probe can help diagnose headroom. These are possible observations,
+not requirements for accepting or retaining a case:
 
 ```
 too obvious          USABLE WINDOW           too obscure
@@ -16,8 +17,9 @@ too obvious          USABLE WINDOW           too obscure
  (ceiling)                                     (floor)
 ```
 
-Both failure modes produce the same useless verdict, so calibrate before
-spending live reps. The check: **can the defect be derived from the discipline
+Ceiling and floor observations limit the question a probe can answer. Calibrate
+the discriminator on known transcripts before spending live reps. The check:
+**can the defect be derived from the discipline
 alone?** If catching it needs domain trivia the skill never taught, it is below
 the window. If catching it needs nothing but reading the first paragraph, it is
 above.
@@ -78,22 +80,27 @@ green reading. Use as a **modifier** on shapes 1–3, never alone.
    plausibly write. Implausible defects get caught by implausibility, not by the
    discipline.
 
-## Calibration procedure
+## Optional live development calibration
 
-Before any live run:
+Use live calibration only inside an already accepted trial/time envelope. It
+is development data, counts against the total cap, and does not become a hidden
+holdout. Predeclare its stop; do not keep reseeding until treatment wins.
 
 1. Draft the artifact with the defect.
-2. Run the **control arm only**, 2 reps, at the highest effort you plan to use.
-3. If the control arm catches it in **2/2** — above the window. Re-seed using a
-   stronger shape (move from 3 → 2 → 1) or bury it deeper.
+2. If needed for the decision, run a bounded control sample at the deployed
+   model and selected effort. Two reps can diagnose a scenario, not prove a rate.
+3. If the control catches it in every sampled rep, record the observed ceiling.
+   Keep it as an easy regression/cost control when relevant. A new development
+   variant is a separate version, not permission to erase an unfavorable case.
 4. If the control arm catches it in **0/2**, hand the same artifact to the
    treatment arm. If treatment is also 0/2 — below the window. The defect is not
-   derivable from the discipline; that is a defect in the *skill*, and it is a
-   real finding worth recording.
-5. Control at 0–1 of 2 with treatment at 2/2 is the window. Proceed to the full
-   run.
+   showing a positive signal in this sample. Check the discriminator and record
+   the floor; do not infer a general defect in the skill from two misses.
+5. Report the observed results whether positive, null or adverse. Freeze the
+   chosen development cases before any separately authorized comparison.
 
-Calibration costs 2 reps and saves a full run's spend on an unusable scenario.
+Count all calibration starts, including failures and treatment calibration;
+calibration does not always cost only two reps or guarantee useful separation.
 
 ## Worked shape (illustrative)
 

--- a/skills/SKILL-TIERS.md
+++ b/skills/SKILL-TIERS.md
@@ -83,7 +83,7 @@
 | `scaffold` | execution | `keep_specialist` | - | `scaffold` | `write_project_files` |
 | `security` | product | `keep_specialist` | - | `security` | `write_scan_artifacts` |
 | `skill-builder` | meta | `keep_specialist` | - | `skill_builder`, `heal_skill` | `write_skill_source`, `write_build_report`, `regenerate_skill_projections`, `repair_skill_projections` |
-| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier` | `write_probe_package`, `dispatch_probe_producer` |
+| `skill-eval` | meta | `keep_specialist` | - | `author_seeded_probe`, `run_probe_tier`, `evaluate_skill_decision` | `write_probe_package`, `dispatch_probe_producer` |
 | `standards` | knowledge | `keep_specialist` | - | `standards` | - |
 | `status` | session | `keep_specialist` | - | `status` | `read_filesystem`, `read_clock` |
 | `swarm` | execution | `keep_optional_adapter` | - | `dispatch_once` | `invoke_selected_executor` |

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1521,7 +1521,8 @@
       "canonical_status": "canonical",
       "capabilities": [
         "author_seeded_probe",
-        "run_probe_tier"
+        "run_probe_tier",
+        "evaluate_skill_decision"
       ],
       "codex_override_present": true,
       "consumes": [
@@ -1534,7 +1535,7 @@
         }
       ],
       "dependencies": [],
-      "description": "Author and tier behavioral probes for a skill, including seeded-defect probes that escape ceiling saturation. Triggers: \"measure this skill\", \"the probe came back INERT\", \"the control arm aces it\", \"harden this scenario\", \"is this skill actually doing anything\".",
+      "description": "Evaluate a named maintenance decision with behavioral probes, controlled coding comparisons, or separate memory transfer tests. Triggers: \"measure this skill\", \"the probe came back INERT\", \"the control arm aces it\", \"harden this scenario\", \"is this skill actually doing anything\".",
       "disposition": "keep_specialist",
       "effects": [
         "write_probe_package",

--- a/skills/skill-eval/SKILL.md
+++ b/skills/skill-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-eval
-description: 'Author and tier behavioral probes for a skill, including seeded-defect probes that escape ceiling saturation. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".'
+description: 'Evaluate a named maintenance decision with behavioral probes, controlled coding comparisons, or separate memory transfer tests. Triggers: "measure this skill", "the probe came back INERT", "the control arm aces it", "harden this scenario", "is this skill actually doing anything".'
 practices:
 - measurement-over-assertion
 - ab-testing
@@ -18,7 +18,7 @@ user-invocable: true
 metadata:
   tier: meta
   dependencies: []
-  capabilities: ["author_seeded_probe","run_probe_tier"]
+  capabilities: ["author_seeded_probe","run_probe_tier","evaluate_skill_decision"]
   effects: ["write_probe_package","dispatch_probe_producer"]
   canonical_status: canonical
   disposition: keep_specialist
@@ -27,207 +27,192 @@ metadata:
 
 # /skill-eval
 
-Author one behavioral probe for one skill, at the cheapest tier that can still
-separate the arms, and report the verdict honestly. A probe measures
-**behavior-change** — did loading the skill change what the agent *did* — never
-quality-uplift. This skill authors and tiers probes. `scripts/probe-skill.sh`
-runs them.
+Answer one named maintenance decision: **retain, revise, remove, or insufficient
+evidence**. Choose the measurement that can answer that decision, use the caller's
+accepted cases and resource envelope, make one scoped recommendation, and stop.
+A completed evaluation does not require a positive difference.
 
-**Insight:** when a probe returns INERT because the control arm already aces the
-scenario, the measurement failed, not the skill. Weakening the producer is one
-escape and it costs realism. The cheaper escape is to **plant the defect**: build
-a scenario containing exactly one flaw the discipline catches and a skim does
-not, then grade whether the agent acted on it. Signal you manufacture is signal
-you can reproduce.
+This is an optional specialist. The repository's selected runner owns execution
+and bounds; native results own measurements; BD and Git retain their authority.
+Do not add a core skill, AO evaluation command, scheduler, dashboard, second
+tracker, or mandatory review merely to run an experiment.
 
-**The failure mode this exists to prevent:** a skill catalog whose tier badges are
-editorial. A skill nobody measured is a skill nobody can defend, and re-running a
-saturated scenario at a lower effort level produces more rows in the ledger
-without producing more knowledge.
+## Choose the question
 
-## Modes
-
-| Trigger phrases | Mode | Entry point |
+| Caller decision | Measurement | What it can establish |
 |---|---|---|
-| "measure this skill", "does this skill do anything" | author tier 1 (quiz probe) | `evals/skill-probes/<id>/` |
-| "the control arm aces it", "harden this scenario" | author tier 2 (seeded-defect probe) | [`references/seeding.md`](references/seeding.md) |
-| "the probe came back INERT" | diagnose headroom | gate `skill.probe-headroom` |
-| "run the probes" | run a tier | `scripts/probe-skill.sh` |
+| Does loading this skill change a specific observable act? | Behavioral probe with `scripts/probe-skill.sh` | Behavior change on that scenario; not correct code or productivity |
+| Does this package or version improve engineering outcomes at acceptable cost? | Repository-selected controlled coding comparison, such as `evals/skills-rpi` | Endpoint outcomes and cost on selected tasks; independent completion only when required exact-subject evidence exists |
+| Does a qualified memory update help later work? | Separate frozen-versus-updated memory transfer test | Narrow later-task reuse evidence with skill and runtime held fixed |
+| What happened in ordinary runs? | Existing native accounting and acceptance evidence | Observational failures, repairs and cost; not causal skill benefit |
 
-## Inputs
-
-Required: the skill slug, and one sentence naming the **action** the skill should
-cause — a tool call made, an artifact written, a question raised, a sequence
-followed. If the sentence names a belief instead of an action ("understands
-that…", "considers…"), stop: that is not probeable, and rewriting it as an action
-is the actual work.
-
-Optional: an existing probe id to harden.
-
-**Non-goals.** This skill does not score output quality, rank skills, claim a
-skill is good, or gate a release. It does not run `claude -p`. It does not
-generalize from N=2 — small N is directional and every artifact it produces says
-so.
-
-## The two tiers
-
-| | Tier 1 — quiz | Tier 2 — seeded task |
-|---|---|---|
-| Scenario | asks the agent a question about a situation | hands the agent work containing a planted defect |
-| Grades | which answer it gave | whether it acted on the defect |
-| Saturates | fast — frontier models answer doctrine questions correctly unaided | slowly — skimming is a real failure mode at every altitude |
-| Cost | low | higher (real task, longer transcript) |
-| Use when | the skill's whole content is a decision rule | tier 1 saturated, or the skill's value is *noticing* |
-
-Historical tier-1 groups saturate repeatedly at both `xhigh` and `low` effort —
-harder quizzes did not fix it (`validate-not-proven-v2` re-saturated). Run the
-`skill.probe-headroom` gate for the live classification; do not trust a
-hardcoded count. Tier 2 is the escape, because it
-changes what is being measured from *knowing the rule* to *applying it while busy*.
+Start from the caller's intended decision, not a mandatory quiz. Reuse an
+existing accepted decision and scope. For a behavioral question, name one
+observable action (a file written, tool used, criterion rejected); a belief such
+as “understands validation” needs translation into an action. For coding or
+memory questions, name unchanged task acceptance and the maintenance choice.
 
 ## Procedure
 
-1. **State the action.** One sentence, an observable act. Reject beliefs.
-2. **Pick the tier.** Start at tier 1 unless a prior probe for this skill is
-   saturated; then go straight to tier 2.
-3. **Build the scenario.** For tier 2, seed exactly one forcing defect using the
-   rules in [`references/seeding.md`](references/seeding.md). One defect for a
-   floor probe; N defects for a band probe.
-4. **Write the discriminator.** Deterministic, over one transcript. Exit `0`
-   present, `1` absent, `2` infra. It checks the **act**, never a mention — a
-   discriminator that greps for a word the prelude contains measures the prelude.
-5. **Calibrate on replay** against committed fixtures before spending a live run.
-6. **Run both arms** at two effort levels. Same scenario, same reps; the
-   declared `treatment_source` is the only variable — `canonical-skill` (the
-   exact SKILL.md bytes; the only mode the coverage gate counts) or
-   `injected-prelude` (prelude-only evidence, never skill coverage).
-7. **Pre-screen headroom before believing the verdict** — gate
-   `skill.probe-headroom`. A verdict over a saturated scenario is void.
-8. **Record the outcome and stop.** Pre-screen passed (`SEPARATED`/`FLOOR`):
-   append exactly one ledger row in `evals/skill-probes/LEDGER.md`. `SATURATED`:
-   append nothing to the ledger — note the scenario's retirement in the RUNBOOK.
+1. **Fix the decision and bounds.** Name the subject package/version or qualified
+   memory update, relevant cases, allowed runtime and existing aggregate time,
+   trial and cost limits. Do not infer billing enforcement from token counters.
+   Smoke runs, infrastructure retries, interrupted attempts and inner review
+   consume the same declared envelope. A new configuration or context does not
+   renew it. Do not launch live work without caller authorization and bounds.
+2. **Choose the smallest relevant measurement.** Use behavioral probes for acts,
+   coding tasks for engineering outcomes, and separate later sessions for memory.
+   There is no universal two-effort requirement. Keep the deployed model and
+   effort unless the caller's decision concerns effort. Retain easy regression
+   and cost controls; do not weaken the producer to manufacture separation.
+3. **Freeze and calibrate.** Fix task, acceptance, package, model/runtime,
+   environment and grader identities before trials. Executable oracles must
+   accept the intended solution and reject plausible incorrect/no-op solutions.
+   Include genuinely correct and incomplete cases when evaluating judgment.
+   Exposed incidents are development cases, never unseen holdouts by renaming.
+   Broken or leaked cases invalidate affected comparisons; preserve their
+   historical disposition when versioning a correction.
+4. **Run within the selected consumer's bounds.** Equalize instructions, tools
+   and environment across arms apart from the intended variable. Coding trials
+   expose the actual selected package and required resources. A worktree or a
+   prompt prohibition is not runtime isolation. Exclude operator home, production
+   tracker, session history, sibling output and solutions; capture launched
+   configuration and final artifacts outside the worker. Report an incompatible
+   adapter as such; do not build a replacement platform to rescue a result.
+5. **Read all attempts.** Use native runner results and existing accounting;
+   collection must not require another model call or handwritten evaluation.
+   Keep failed, abandoned, blocked, interrupted and missing attempts visible.
+   Wrong identity, changed acceptance, contamination or ambiguous pairing cannot
+   establish comparison proof even when a deterministic check passed.
+6. **Compare only supported facts.** Pair by task and repetition; preserve
+   repetitions within task clusters. Report case outcomes, denominators,
+   uncertainty and failure disposition. Endpoint reward, worker done claim,
+   in-workflow validator PASS and independent acceptance are different facts.
+   Missing review, usage, billing, phase or feasibility evidence stays unknown.
+7. **Recommend once and stop.** State retain, revise, remove or insufficient
+   evidence, the scope and supporting facts, and what remains unproven. A
+   concrete reproduced defect with clean controls can support a provisional
+   narrow repair; general improvement needs held-out comparison. Do not add
+   trials until green, require a positive result, or automatically publish a
+   lesson. Do not remove losing observations or relax acceptance.
+
+## Coding and memory readout
+
+Use the development adapter documented in
+[`evals/skills-rpi/readout.md`](../../evals/skills-rpi/readout.md), or the caller's
+existing equivalent. Its report is a rebuildable view, not work authority.
+The pilot's default `insufficient-evidence` recommendation is an honest limit;
+the specialist may make a narrower supported maintenance recommendation and
+must state its evidence and provisional scope.
+
+- Report endpoint success against **all assigned/observed attempts** alongside
+  any feasible-task rate. Retain infrastructure invalidity, infeasibility and
+  unknown coverage separately; do not hide them by dropping the denominator.
+- Report false completion, false acceptance and needless blocking separately
+  when independent evidence measures them. Clean cases and abstentions are
+  denominators, not opportunities to reward finding-count spray. Unknown is not
+  zero. Deterministic code truth may settle an experimental criterion, while a
+  required native handoff or exact-subject judgment remains unproven.
+- Report raw time/cost distributions and total cost of all attempts per accepted
+  outcome. Zero accepted outcomes makes that ratio undefined. Partial Harbor
+  cost is not total billing. Native input includes cached input; native output
+  includes reasoning. Keep counters distinct and never add native totals to
+  Harbor totals or assume parents exclude children. Split producer, in-workflow
+  validation, orchestration and grading only where native identity supports it.
+  State the measurement window and excluded setup/analysis overhead.
+- Use `evals/_stats` for paired task-cluster uncertainty after verifying its
+  dependencies and semantics. A pilot is descriptive unless sample size and
+  decision thresholds were justified and fixed in advance. A zero-crossing
+  interval or `no_change` is **not equivalence**; equivalence needs its own margin
+  and test. Same numeric repetitions/seeds do not prove controlled provider
+  randomness. Do not extrapolate local results across libraries or models.
+- For memory, hold skill/runtime fixed and compare frozen with independently
+  qualified updated memory in fresh later sessions, using an unseen transfer
+  task and an unrelated or invalidating control. Count acquisition, qualification,
+  retrieval and downstream trial cost separately. Package available, content
+  delivered, relevant action and later outcome are separate facts. Saving a page
+  earns no benefit credit; coding-pilot completion does not establish compounding.
+
+Raw trials and new proof belong in caller-selected protected external non-Git
+storage. Only public/sanitized fixtures cleared for that destination belong in
+Git. Preserve legacy `.agents/` evidence. Existing independent support and
+disclosure review precedes memory import; this skill does not auto-publish
+transcripts or mutate knowledge from aggregate scores (ADR-0016).
+
+## Behavioral probes: preserve their existing meaning
+
+`scripts/probe-skill.sh` remains the runner for small behavioral regression
+probes and immutable replay. It exposes an empty workspace and one injected
+SKILL.md, not a complete installed-package coding trial. Its verdict measures
+**behavior change**, never quality uplift or productive engineering completion.
+Existing ledger entries retain that meaning and their recorded limitations.
+
+| Probe form | Use when | Discriminator |
+|---|---|---|
+| Tier 1 — quiz | A decision rule is the caller's behavioral question | The answer/action on the scenario |
+| Tier 2 — seeded task | Applying a discipline in work is the question | Whether the agent acted on a realistic planted defect |
+
+Either form may be the starting point. Use
+[`references/seeding.md`](references/seeding.md) for seeded tasks. Grade the act,
+never vocabulary copied from the treatment. A floor probe detects at least one
+act; a multi-defect band needs both lower and upper bounds to catch omission and
+finding spray. Calibrate against a transcript performing the act without the
+prelude's wording and one repeating the wording without the act.
+
+The declared `treatment_source` remains the only arm variable: `canonical-skill`
+uses exact SKILL.md bytes and is the mode the coverage gate counts;
+`injected-prelude` establishes prelude-only evidence. Live runs use the selected
+authorized native producer with equal scenario and repetitions. Effort levels
+are a declared experimental choice, not a prerequisite for every question.
 
 ```bash
-# Calibrate deterministically against committed fixtures.
 bash scripts/probe-skill.sh --probe <id> --replay
-
-# Live A/B (codex exec — the sanctioned headless path).
+# Only within an already authorized live envelope:
 bash scripts/probe-skill.sh --probe <id> --live --capture --reps 3 --output out.json
-
-# Is the verdict trustworthy, or did the control arm ace it?
 bash scripts/check-skill-probe-headroom.sh
 ```
 
-### Floor and band
+The existing `skill.probe-headroom` gate in `cli/internal/probeheadroom` owns
+classification and thresholds. Its multi-effort saturation rule remains the
+legacy gate contract; do not fabricate enough runs to satisfy it or rederive
+the rule in a new report. Read and report the actual answer:
 
-- **Floor probe** — one seeded defect, assert the agent acted **at least once**.
-  Catches the total no-op: the review that produced a polished report naming
-  nothing.
-- **Band probe** — N seeded defects, assert findings land in **[N-1, N+2]**.
-  The lower bound catches rubber-stamping; the upper bound catches spray, where
-  an agent lists every conceivable concern and is credited for the one that
-  happened to be planted. A probe with only a floor rewards noise.
+- **SATURATED:** the probe cannot distinguish the targeted act. Preserve the
+  observation as a scenario limitation in the RUNBOOK; do not append a skill
+  verdict to the legacy ledger. Do not infer skill value or lack of value.
+- **FLOOR:** treatment did not act. Check the discriminator on a known passing
+  transcript. The result alone does not prove the skill cannot help elsewhere.
+- **UNMEASURED:** no usable measurement, not INERT.
+- **SEPARATED:** the gate found usable headroom. This classification itself does
+  not establish positive treatment benefit; retain the actual probe verdict.
 
-### Saturation rule — owned by the gate, not by this skill
+Legacy behavioral ledger rows cite the headroom result, model, effort and
+sample size. Append one row only under that ledger's existing admissibility
+rules; preserve a valid INERT or losing result. Small samples remain
+directional. If producer failure or truncation makes a rep `infra`
+(discriminator exit 2), exclude it from the legacy **usable behavioral rate**
+and report its count in the all-attempt accounting. Zero usable treatment reps
+is UNMEASURED, never INERT. This rate convention does not authorize dropping
+infrastructure attempts from coding-cohort accounting.
 
-The rule is **deterministic, so it does not live here.** Gate
-`skill.probe-headroom` owns it: a scenario is **SATURATED** when the control arm
-scores **≥ 0.75 at two or more effort levels** with at least 2 usable control
-reps each. The rule, its thresholds, and its exit codes are
-`cli/internal/probeheadroom`; the gate script is
-[`scripts/check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh)
-and the helper it drives is `cli/cmd/probe-headroom`. Do not restate the
-thresholds in a probe package or re-derive them by hand — read the gate's answer.
-This skill's job is what to DO with that answer:
+## Output and completion
 
-- **SATURATED** — retire the scenario and promote it to tier 2. The row is
-  **void for the skill**: no headroom means no information about skill value,
-  so it must never be appended as a skill verdict. Note the scenario
-  retirement in the RUNBOOK if useful. Never re-run it at a lower effort.
-- **FLOOR** — the treatment arm never acted at any level. Check the
-  discriminator against a hand-written passing transcript before re-seeding.
-- **UNMEASURED** — the run did not happen. Not INERT; do not record it as one.
-- **SEPARATED** — the scenario left room, so the verdict is about the skill.
+One scoped recommendation with the decision, cases, all attempts/coverage,
+paired outcomes when valid, uncertainty, cost/unknowns and failure disposition.
+For behavioral authoring, also supply the existing probe package (`probe.json`,
+`question.md`, `discriminator.sh`, `fixtures/`, and a prelude only in
+`injected-prelude` mode) and its replay result. Use the legacy ledger/RUNBOOK
+only for their existing consumers. No new per-run worksheet is required.
 
-Never resolve saturation by lowering the discriminator's bar. That converts a
-measurement problem into a false positive.
+Done when the requested measurement has reached its accepted stop, the relevant
+replay/oracle checks discriminate, missing coverage is explicit, and one
+recommendation answers the named maintenance decision. Insufficient evidence,
+an adverse result or an incompatible runtime can complete this evaluation;
+none counts as demonstrated skill benefit.
 
-## Anti-patterns
+## References
 
-| Anti-pattern | Corrective |
-|---|---|
-| Discriminator greps for a term that appears in the treatment prelude | Grade the act (file written, tool called, question raised), never the vocabulary |
-| Re-running a saturated scenario at a lower effort to find separation | Retire it; promote to tier 2, noting the ceiling in the RUNBOOK (never as a ledger row) |
-| Seeding a defect so obvious both arms catch it | Calibrate: the control arm must plausibly miss it. See `references/seeding.md` |
-| Seeding a defect so obscure neither arm catches it | The defect must be *derivable from the discipline*, not from trivia |
-| Floor-only band on a multi-defect scenario | Add the ceiling; an agent that flags everything is not detecting anything |
-| Reporting N=2 as evidence the skill works | Say "directional, not statistical" in the same sentence as the number |
-| Deleting a losing probe | Append the row when its headroom pre-screen passed. A skill measured INERT over a SEPARATED group is knowledge; a missing row is a gap; a SATURATED-group row is void and stays out |
-
-## Output
-
-A probe package under `evals/skill-probes/<id>/` (`probe.json`, `question.md`,
-`discriminator.sh`, `fixtures/`, and `treatment-prelude.md` only in
-`injected-prelude` mode), plus one appended ledger row when the headroom
-pre-screen passed — a `SATURATED` run appends no ledger row; it retires the
-scenario in the RUNBOOK.
-
-`probe.json` for a tier-2 probe declares its seeding:
-
-```json
-{
-  "id": "validate-not-proven-t2",
-  "skill": "validate",
-  "tier": "judgment",
-  "probe_tier": 2,
-  "reps": 3,
-  "seeded_defects": 1,
-  "band": [1, 3],
-  "treatment_source": "canonical-skill",
-  "behavior": "the agent returns NOT_PROVEN rather than PASS when one in-scope acceptance criterion has no evidence",
-  "discriminator": "discriminator.sh",
-  "budget_note": "N=3 — DIRECTIONAL, not statistical",
-  "honesty": "measures behavior-change on a seeded task, NOT quality-uplift"
-}
-```
-
-**Done when:** `probe-skill.sh --replay` reproduces the recorded verdict from
-committed fixtures, and either `skill.probe-headroom` classifies the scorecard
-group `SEPARATED` and exactly one ledger row was appended, or it classifies
-the group `SATURATED` and the scenario was retired with a RUNBOOK note and
-zero ledger rows.
-
-## Checks
-
-- The discriminator passes on a hand-written transcript that performs the act
-  without using the prelude's wording, and fails on one that uses the wording
-  without performing the act. Both directions, or it is not a discriminator.
-- Control and treatment prompts differ **only** by the declared
-  `treatment_source` — the canonical SKILL.md bytes, or the prelude in
-  `injected-prelude` mode.
-- The seeded defect count in `probe.json` equals the count actually present in
-  `question.md`.
-- The ledger row names the producer model and effort levels.
-- The ledger row cites a headroom pre-screen: a row over a `SATURATED` group is
-  a void row, not evidence.
-- No claim of quality-uplift appears anywhere in the output.
-
-## Provenance
-
-- Harness this extends: [`scripts/probe-skill.sh`](../../scripts/probe-skill.sh), [`evals/skill-probes/README.md`](../../evals/skill-probes/README.md).
-- Scenario retirements and capture incidents live in
-  [`evals/skill-probes/RUNBOOK.md`](../../evals/skill-probes/RUNBOOK.md) — the
-  ledger holds verdicts, the RUNBOOK holds everything a verdict must not.
-- The saturation evidence that motivated tier 2: [`evals/skill-probes/LEDGER.md`](../../evals/skill-probes/LEDGER.md) — the INERT rows dated 2026-08-04/05 annotated "scenario needs hardening, not the skill"; run the `skill.probe-headroom` gate for the live classification.
-- Coverage gate (does a result exist): [`scripts/check-skill-probe-coverage.sh`](../../scripts/check-skill-probe-coverage.sh), whose denominator is declared in `scripts/.skill-probe-denominator-exclusions`.
-- Headroom gate (could a result have existed): [`scripts/check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh) — gate id `skill.probe-headroom`, rule in `cli/internal/probeheadroom`.
-- Seeded-forcing-defect and floor/band mechanism analysis (§2.1, §2.5): not on main; read it at `git show 9872483bd:docs/research/gstack-teardown-2026-08-08.md` (branch `recover/gstack-clean-room`).
-- Overclaim discipline: ADR-0011.
-
-## Failure behavior
-
-If the live producer errors or the transcript is truncated, the rep is `infra`
-(discriminator exit 2), not `absent`. Infra failures are excluded from rates and
-named in the ledger row. A run whose usable treatment reps reach zero is
-`UNMEASURED` — never INERT. Scoring an infra failure as a miss manufactures the
-result the harness exists to prevent.
+- Behavioral runner and conventions: [`scripts/probe-skill.sh`](../../scripts/probe-skill.sh), [`evals/skill-probes/README.md`](../../evals/skill-probes/README.md).
+- Behavioral verdicts and non-verdict incidents: [`LEDGER.md`](../../evals/skill-probes/LEDGER.md), [`RUNBOOK.md`](../../evals/skill-probes/RUNBOOK.md).
+- Existing coverage and headroom gates: [`check-skill-probe-coverage.sh`](../../scripts/check-skill-probe-coverage.sh), [`check-skill-probe-headroom.sh`](../../scripts/check-skill-probe-headroom.sh).
+- Evidence and overclaim limits: ADR-0011, ADR-0016 and [`RPI traversal`](../../docs/architecture/rpi-traversal.md).

--- a/skills/skill-eval/references/seeding.md
+++ b/skills/skill-eval/references/seeding.md
@@ -4,9 +4,10 @@ A **forcing defect** is a flaw planted in a realistic work artifact that the
 skill's discipline catches and a skim does not. The probe grades whether the
 agent *acted* on it.
 
-## The calibration window
+## Diagnostic calibration
 
-A defect is useful only inside a narrow band:
+A seeded probe can help diagnose headroom. These are possible observations,
+not requirements for accepting or retaining a case:
 
 ```
 too obvious          USABLE WINDOW           too obscure
@@ -16,8 +17,9 @@ too obvious          USABLE WINDOW           too obscure
  (ceiling)                                     (floor)
 ```
 
-Both failure modes produce the same useless verdict, so calibrate before
-spending live reps. The check: **can the defect be derived from the discipline
+Ceiling and floor observations limit the question a probe can answer. Calibrate
+the discriminator on known transcripts before spending live reps. The check:
+**can the defect be derived from the discipline
 alone?** If catching it needs domain trivia the skill never taught, it is below
 the window. If catching it needs nothing but reading the first paragraph, it is
 above.
@@ -78,22 +80,27 @@ green reading. Use as a **modifier** on shapes 1–3, never alone.
    plausibly write. Implausible defects get caught by implausibility, not by the
    discipline.
 
-## Calibration procedure
+## Optional live development calibration
 
-Before any live run:
+Use live calibration only inside an already accepted trial/time envelope. It
+is development data, counts against the total cap, and does not become a hidden
+holdout. Predeclare its stop; do not keep reseeding until treatment wins.
 
 1. Draft the artifact with the defect.
-2. Run the **control arm only**, 2 reps, at the highest effort you plan to use.
-3. If the control arm catches it in **2/2** — above the window. Re-seed using a
-   stronger shape (move from 3 → 2 → 1) or bury it deeper.
+2. If needed for the decision, run a bounded control sample at the deployed
+   model and selected effort. Two reps can diagnose a scenario, not prove a rate.
+3. If the control catches it in every sampled rep, record the observed ceiling.
+   Keep it as an easy regression/cost control when relevant. A new development
+   variant is a separate version, not permission to erase an unfavorable case.
 4. If the control arm catches it in **0/2**, hand the same artifact to the
    treatment arm. If treatment is also 0/2 — below the window. The defect is not
-   derivable from the discipline; that is a defect in the *skill*, and it is a
-   real finding worth recording.
-5. Control at 0–1 of 2 with treatment at 2/2 is the window. Proceed to the full
-   run.
+   showing a positive signal in this sample. Check the discriminator and record
+   the floor; do not infer a general defect in the skill from two misses.
+5. Report the observed results whether positive, null or adverse. Freeze the
+   chosen development cases before any separately authorized comparison.
 
-Calibration costs 2 reps and saves a full run's spend on an unusable scenario.
+Count all calibration starts, including failures and treatment calibration;
+calibration does not always cost only two reps or guarantee useful separation.
 
 ## Worked shape (illustrative)
 


### PR DESCRIPTION
AgentOps previously relied on behavioral probes and retrospective summaries to assess skills. This adds a development-only evaluator that runs a frozen installed skill package on isolated Go tasks, preserves failed and interrupted attempts, and rebuilds a comparison readout from native results without another model call.

The suite contains six task families, separate executable verifiers, frozen launch identities, native session accounting, and a focused `skill-eval` maintenance workflow. The readout separates passing code from completed trials, retains incomplete cost information, and reports missing evidence without claiming equivalence or uplift. `ao eval` remains retired; no new runtime controller or required core skill is introduced.

Validation: Go build/vet/race checks and all repository CI passed. Focused reader/statistics, receipt integrity, verifier integrity, fixture calibration, generated projections, and the local aggregate runner passed. A real two-variant Docker preparation check verifies that frozen worker and verifier images survive later staging.

The bounded coding pilot retained all 24 starts and produced eight comparable pairs across six task families, with no observed paired endpoint difference. The separate eight-start memory experiment did not demonstrate incremental benefit and does not promote another guidance rule. Individual runtime limits were enforced; aggregate desktop deadline enforcement remains unproven. Raw trial evidence and credentials stay outside Git.
