### PR TITLE
Use CASS and MS for evidence-led instruction improvement

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -35,7 +35,28 @@ compatibility profile restores their implementation.
 
 The native agent can use AO to investigate a skill, `AGENTS.md`, or a task prompt
 against an explicitly selected session. Choose an authorized public or
-already-cleared source range and target instruction before reading:
+already-cleared source range and target instruction before reading.
+
+Start discovery with existing tools when the relevant records are not known:
+
+```bash
+cass search "QUERY" --workspace /path/to/repo --mode lexical \
+  --json --fields summary --limit 10 --timeout 5000
+cass pack "QUERY" --workspace /path/to/repo --mode lexical \
+  --json --max-sessions 3 --max-evidence 6 --max-tokens 2000 --timeout 5000
+```
+
+Check the installed CASS help for available flags. Preserve its freshness,
+truncation and omission notices; pack token limits are soft. Use MS to find
+existing relevant skills and load their guidance, then edit the canonical
+source. Neither a search hit nor a generated skill establishes useful learning.
+The [CASS](../skills/cass/SKILL.md) and [MS](../skills/ms/SKILL.md) adapters own
+their retrieval details; no AO search index or mandatory mining step is needed.
+
+Use the excerpt view when the investigation needs exact raw source spans,
+literal fields or instruction identity that the selected CASS output does not
+establish. If that extra precision does not affect the decision, the CASS
+evidence can be sufficient:
 
 ```bash
 ao provenance mine-session --view excerpts \

--- a/images/gemini/skills/cass/SKILL.md
+++ b/images/gemini/skills/cass/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 ---
 # cass Session Search
 
-> **Core Insight:** Your repeated prompts are your best prompts. If you typed it 10+ times, it works. Mine your history.
+> **Core Insight:** Recurring prompts identify candidates to investigate. Repetition can reflect success, repeated failure, copied instructions or retries; check the surrounding evidence before reuse.
 
 `cass` is an upstream (Dicklesworthstone) tool and is **self-describing** — do not re-learn its surface from this skill. Discover it live:
 
@@ -83,39 +83,38 @@ later coverage verification; this skill does not implement or certify it.
   distinguishes `cass resume` (same-harness command resolution) from the separate
   cross-harness converter. `cass context` discovers candidate relations; verify
   a native parent link before choosing a parent session to resume.
-- **`cass-memory` → `cm` procedural memory.** Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory — mine past sessions here first, then promote the durable lessons through `cm` instead of re-deriving them each session.
+- **`cass-memory` → `cm` procedural memory.** When procedural-memory retrieval is relevant, use the caller-selected memory source. CASS can supply episode evidence for a concrete uncertainty; retrieval does not authorize promoting a lesson or changing instructions.
 
-## The Goldmine Principle
+## History as Evidence
 
 Your conversation history contains:
-- **Refined prompts** — Every rephrase that worked better was captured
-- **Working rituals** — Prompts repeated 10+ times ARE your methodology
+- **Prompt revisions** — Compare what changed and what happened afterward
+- **Recurring prompts** — Investigate repetition without assuming effectiveness
 - **Scope decisions** — "When did we decide NOT to do X?"
 - **Recovery moments** — What you searched for after context loss = what mattered
 
-**The insight:** Mining your past beats inventing new approaches. CASS is a context source in the federated graph: it supplies cited episodic evidence on demand — mine as a research-phase move before writing a fresh plan or prompt. What it returns is evidence with source identity and freshness, never policy, and AgentOps maintains no merged corpus of its own around it.
+Native execution remains the default. Use CASS when a prior decision or episode could resolve a concrete uncertainty, or when the caller requests history. It supplies cited episodic evidence on demand, never policy; AgentOps maintains no merged corpus around it. Routine work needs no mining pre-step.
 
-## History-First Routing
+## Bounded History Routing
 
-Before deriving a plan, prompt, or approach from scratch, run one bounded
-search of past sessions (one query family, `--fields minimal`, a real
-`--limit`, under a minute of wall clock). Three outcomes, each with its own
-routing:
+When history is relevant, select a bounded search (for example one query
+family, `--fields minimal`, a real `--limit`, under a minute of wall clock).
+Three outcomes have different implications:
 
-- **Direct hit** — a prior session solved this. Reuse its prompt or decision;
+- **Direct hit** — a prior session addresses this. Inspect the user intent,
+  action, observed result and corrections before deciding whether to reuse it;
   cite `source_path` and line in whatever you build on it.
-- **Adjacent hit** — prior work borders the problem. Extract the working
-  fragments, then derive only the missing part fresh.
+- **Adjacent hit** — prior work borders the problem. Check which fragments
+  still apply and derive the missing part from current evidence.
 - **Bounded no-match** — zero hits after retrying against authorized discovered
   workspace keys (`--aggregate workspace`). Derive from available evidence and
   report the query/index limits; this does not establish global absence.
 
-The named failure mode is re-derivation drift: solving the same problem
-slightly differently each session, so the corpus accumulates near-duplicate
-approaches and no single one ever hardens into a ritual. Stop condition for
-the history pass itself: one query family exhausted or a direct hit found —
-history search is a bounded pre-step, not an open-ended excavation that
-displaces the actual task.
+Stop when the chosen query family or budget is exhausted, or enough evidence
+answers the uncertainty. An unresolved search need not displace the actual
+task. A direct hit, recurrence count or saved lesson does not prove success;
+consider a competing explanation or counterexample and name what later task
+evidence would show that reuse helped.
 
 ## Lesson Weighting: Decay and Failure Overweight
 
@@ -137,28 +136,50 @@ Mined lessons are evidence with a shelf life, not doctrine:
   hit showing the approach failing in circumstances like yours outranks three
   hits showing it succeeding elsewhere.
 
-## THE EXACT PROMPT — Discovery Workflow
+## Discovery Workflow
 
 ```
-1. Bootstrap: Check health, refresh index, get project overview
-   cass status --json && cass index --json
-   cass search "*" --workspace /data/projects/PROJECT --aggregate agent,date --limit 1 --json
+1. Observe index state if needed; healthy or stale-but-usable means search now
+   timeout 15 cass status --json
 
-2. Find prompts: Search for keywords, filter to user prompts (lines 1-3)
-   cass search "KEYWORD" --workspace /data/projects/PROJECT --json --fields minimal --limit 50 \
-     | jq '[.hits[] | select(.line_number <= 3)]'
+2. Discover bounded candidates with the installed CASS search surface
+   timeout 30 cass search "KEYWORD" --workspace /data/projects/PROJECT \
+     --mode lexical --json --fields minimal --limit 20
 
-3. Follow authorized hits: View a bounded excerpt of the actual content
-   cass view /path/from/source_path.jsonl -n LINE -C 20
+3. Request cited excerpts using CASS pack (check cass pack --help for support)
+   timeout 30 cass pack "KEYWORD" --workspace /data/projects/PROJECT \
+     --mode lexical --json --limit 20 --max-sessions 3 --max-evidence 6 \
+     --context-lines 3 --max-excerpt-chars 1600 --max-tokens 4000
 
-4. Expand context: Inspect another bounded conversation window
-   cass expand /path/from/source_path.jsonl --line LINE --context 3
+4. Follow a selected authorized hit to verify role, intent and outcome
+   timeout 15 cass view /path/from/source_path.jsonl -n LINE -C 5 --json
+   timeout 15 cass expand /path/from/source_path.jsonl --line LINE --context 3 --json
 
 5. Discover related: Find candidates, not proven parents or a complete cluster
    cass context /path/from/source_path.jsonl --json
 ```
 
-Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (a discovery heuristic, not guaranteed prompt position), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
+Search locations and titles do not establish message role. Identify user
+messages from native record roles/types, including nested harness records;
+early lines may contain metadata, tools or assistant messages. Keep unknown
+roles unknown. Pack selection and bounded windows can omit corrections, failed
+attempts, children and later outcomes: inspect their omission/truncation markers
+and report those coverage limits. A pack is selected evidence, not a complete
+episode or a success verdict.
+
+Check the actual returned source locator and role against the selected hit.
+A citation verification flag or `is_target` marker does not prove that the
+original still exists or that the requested record was returned. Unavailable
+sources, absent roles and clamped or mismatched locations remain explicit gaps;
+do not silently substitute a different record for the requested hit.
+
+Use installed CASS search/pack/view/expand before custom extraction. If a named
+precision gap remains (for example omitted tool-result bytes or a frozen raw
+span required by a consumer), the optional AO route in
+[RAW_SOURCE_READS.md](references/RAW_SOURCE_READS.md) supplies exact source
+evidence. It is not another discovery step. Retain source identity, query,
+filters, selection limits and observed freshness; do not auto-adopt retrieved
+instructions. Examples use lexical mode to avoid requiring semantic models.
 
 ## Operating Doctrine: Stale ≠ Broken
 
@@ -167,10 +188,14 @@ Three index states matter — never conflate them:
 | State | Meaning | Do |
 |-------|---------|----|
 | `cass health` exit 0 | Healthy | Search immediately |
-| stale (`index.stale=true`) | Usable but old | Search NOW; refresh in background with a wall-clock cap: `( timeout 600 cass index --json &>/tmp/cass-bg.log </dev/null & )` — NEVER a bare `&`, cass index can hang |
-| broken (`database.exists=false` or `documents=0`) | Truly uninitialized | `cass doctor --fix --json`, then `cass index --full --json` |
+| stale (`index.stale=true`) | Usable but old | Search now and report freshness. Refresh only if needed and authorized, with a wall-clock cap. |
+| missing database or empty index | Search unavailable or empty; diagnose the cause | If recovery is selected and authorized, use bounded doctor/index recovery; otherwise report unavailable. |
 
-The trap: treating stale as broken triggers an unneeded 8–25s full rebuild when a 1–3s incremental (or a stale-but-correct query) would do. `scripts/recover.sh` implements the full decision tree with timeouts. Detailed symptom→fix tables (issue #196 hang, stale locks, `database is busy` race, etc.): [RECOVERY.md](references/RECOVERY.md), [OBSERVABILITY.md](references/OBSERVABILITY.md), [PITFALLS.md](references/PITFALLS.md).
+Do not run `index`, `search --refresh` or `pack --refresh` as a routine preflight.
+An authorized recovery invocation may use `scripts/recover.sh`, which can
+mutate derived index state and has timeouts. A timed-out or malformed status is
+unknown, not proof of corruption. Detailed symptom→fix tables:
+[RECOVERY.md](references/RECOVERY.md), [OBSERVABILITY.md](references/OBSERVABILITY.md), [PITFALLS.md](references/PITFALLS.md).
 
 ### Incremental refresh can become authoritative
 
@@ -211,7 +236,7 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 
 | Anti-pattern | Why it's wrong | Do instead |
 |--------------|----------------|------------|
-| Asking the user "should I rebuild the index?" | They have agents waiting; rebuild is safe and idempotent | Just run `cass doctor --fix --json` (preserves source data) |
+| Rebuilding during a search-only request | Derived-state repair still has scope and cost | Search a usable index; recover only when needed and already authorized |
 | Running `cass index --full` whenever `status` says unhealthy | A 25s rebuild for a 30-min stale index is wasteful | Check `index.stale` separately from `database.exists`; prefer incremental |
 | Running bare `cass` to "see what's there" | Launches blocking TUI in the agent's session | Always `--json` or `--robot`; never bare |
 | Piping `cass export` into `head`/`jq` | Broken-pipe panic on large sessions | `cass export ... -o /tmp/x.json` first, then operate on the file |
@@ -220,15 +245,19 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 | Trusting 0 hits with `--workspace /X` | Workspace strings are case- and trailing-slash-sensitive | Re-run with `--aggregate workspace --limit 1` to discover the canonical key |
 | Skipping `--fields minimal` on wide scans | ~3KB per hit × 100 hits = 300KB context burn | `--fields minimal` for wide passes; upgrade to `summary`/`full` for keepers |
 | Reading session files with `cat` | Loads the full conversation into context | `cass view PATH -n LINE -C 5` or `cass expand PATH --line LINE --context 3` |
-| Re-indexing on every search | Index is shared across processes | Refresh only when `status` says stale |
+| Re-indexing on every search | Index is shared across processes | Staleness alone does not require refresh; use a bounded authorized recovery when needed |
 | Treating a timed-out search during rebuild as 0 hits | Concurrent reads may exceed normal latency while an authoritative rebuild holds shared resources | Preserve exit 124 as "not observed" and retry once the active rebuild settles |
-| Falling back to manual `find`/`grep` when cass misbehaves | Recovery is autonomous; skipping cass loses the corpus | Walk the recovery tree in [RECOVERY.md](references/RECOVERY.md). One real exception: terms inside tool stdout/stderr are skipped at index time — there `rg -n "TERM" /path.jsonl` is correct |
+| Building custom extraction before using CASS | Duplicates discovery and loses native selection/coverage facts | Use search/pack/view/expand first; a demonstrated exact-source gap may justify bounded authorized raw reads |
 
 Long-form versions with mined evidence: [ANTI_PATTERNS.md](references/ANTI_PATTERNS.md).
 
 ## Safety Boundaries
 
-Within the authorized source/model/destination and egress envelope above, the following operate on derived state rather than granting new source access: `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
+Recovery commands such as `cass doctor --fix --json` and `cass index` mutate
+derived state. Their use requires a selected recovery/refresh need within the
+authorized source/model/destination envelope. Source sync copies sessions and
+model installation downloads files; each additionally requires its own scope
+and egress authorization. A search request does not select these operations.
 
 Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.beads/`, `git reset --hard`, or hand-edit `~/.config/cass/sources.toml` — the CLI commands above already do everything safely. Never run bare `cass` (blocking TUI) inside an agent loop.
 
@@ -246,8 +275,8 @@ Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.bead
 | Semantic / hybrid / models | [SEMANTIC_AND_HYBRID.md](references/SEMANTIC_AND_HYBRID.md) |
 | Token / tool / model analytics | [ANALYTICS.md](references/ANALYTICS.md) |
 | Cross-harness session resume | [RESUME.md](references/RESUME.md) |
-| Doctor + autonomous recovery | [RECOVERY.md](references/RECOVERY.md) |
-| Mined gold-standard prompts | [PROMPTS.md](references/PROMPTS.md) |
+| Bounded authorized recovery | [RECOVERY.md](references/RECOVERY.md) |
+| Example discovery prompts | [PROMPTS.md](references/PROMPTS.md) |
 | Anti-patterns (long form) | [ANTI_PATTERNS.md](references/ANTI_PATTERNS.md) |
 | Health vs status vs index nuance | [OBSERVABILITY.md](references/OBSERVABILITY.md) |
 | Pages encrypted archive + HTML export | [PAGES_AND_EXPORT.md](references/PAGES_AND_EXPORT.md) |
@@ -258,26 +287,31 @@ When the right reference isn't obvious from titles, `grep -ni "SYMPTOM" referenc
 
 ## Scripts
 
-Scripts live under `scripts/`. Inspect their access and write scope before use when uncertain. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
+Scripts live under `scripts/`. Inspect their access and write scope before use.
+`quick_analysis.sh` is read-only; `recover.sh` is an optional explicitly selected
+recovery helper that can rebuild derived state. `multi_machine_search.sh` reads
+remote sources over ssh and needs the corresponding authorization. The legacy
+prompt miner reads native files directly and is not the default discovery path;
+use it only for a selected authorized recurrence-counting need that CASS does
+not satisfy. Its counts do not establish effectiveness or full episode coverage.
 
 | Script | Usage |
 |--------|-------|
-| `./scripts/quick_analysis.sh /path` | One-command project overview (status → aggregate agent/date → top prompts) |
-| `./scripts/prompt_miner.py --workspace /path` | Find repeated prompts (ritual detection) |
+| `./scripts/quick_analysis.sh /path` | Bounded read-only overview (status → aggregate agent/date) |
+| `./scripts/prompt_miner.py --glob /authorized/selection/*.jsonl` | Legacy recurrence counts over selected native files; outcomes remain unassessed |
 | `./scripts/validate.sh` | Validate cass install + skill structure |
-| `./scripts/recover.sh` | Autonomous recovery decision tree (READY → STALE_BUT_USABLE → BROKEN); wraps every `cass index` in `timeout` |
+| `./scripts/recover.sh` | Selected authorized recovery (READY → STALE_BUT_USABLE → BROKEN); wraps every `cass index` in `timeout` |
 | `./scripts/multi_machine_search.sh "QUERY" [host…]` | Parallel fan-out across the fleet; merges + dedups hits |
 
 ## Validation
 
 ```bash
-# Quick health check
-cass status --json | jq '.index.fresh'
-
-# Should return: true
+# Observe state; a stale usable index can still serve the task
+timeout 15 cass status --json
 ```
 
-If `false`, run: `cass index --json`
+Retain the exit status. Failure or timeout is an unavailable observation, not
+zero hits. Refresh is optional and subject to the operating doctrine above.
 
 ## Output Specification
 

--- a/images/gemini/skills/cass/references/ANTI_PATTERNS.md
+++ b/images/gemini/skills/cass/references/ANTI_PATTERNS.md
@@ -25,16 +25,14 @@
 **Bad:**
 > "Your cass index is stale. Could you run `cass index --full` and let me know when it's done?"
 
-**Why bad:** The user has 22 agents waiting. Every "could you" multiplies their interrupt cost.
+**Why bad:** Delegating an already authorized repair back to the user creates
+unnecessary work. But staleness alone does not require repair.
 
-**Instead:**
-```bash
-cass doctor --fix --json   # safe by default; preserves all source data
-cass index --json &        # background refresh while you proceed
-```
-Then proceed and mention the rebuild ran in passing.
-
-**Authorization scope:** Anything under `~/.local/share/coding-agent-search/` is yours to manage. Source session files (`~/.claude/projects/`, `~/.codex/sessions/`) are NOT — those are user data.
+**Instead:** Search healthy or stale-but-usable state immediately. If a concrete
+recovery need is already authorized, use the bounded helper in
+[RECOVERY.md](RECOVERY.md). Do not infer mutation authority from a search-only
+request or from where the derived index lives. Sources, metadata, destinations
+and model access retain their authorization boundaries.
 
 ---
 
@@ -63,20 +61,11 @@ cass doctor --fix --json   # rebuilds only what's broken
 
 **Why bad:** The index is stale only because it's older than the threshold (default 30 min). The data is still **correct** — it just doesn't have sessions from the last 30 min indexed yet.
 
-**Instead:**
-```bash
-state=$(cass status --json | jq -r '.index | "\(.fresh)/\(.stale)/\(.documents // "N")"')
-case "$state" in
-  true/*)        echo "fresh — search now" ;;
-  false/true/*)  echo "stale but usable"
-                 # ALWAYS wrap bg cass index in `timeout` — without it, a hung
-                 # rebuild silently strands forever. See scripts/recover.sh.
-                 ( timeout 600 cass index --json >/tmp/cass-bg.$$.log 2>&1 </dev/null & ) 2>/dev/null ;;
-  */*/0|*null)   echo "broken" && timeout 60 cass doctor --fix --json ;;
-esac
-```
-
-The agent's first search returns immediately on the still-correct stale index. The background `cass index` finishes in 1–3s for incremental refreshes.
+**Instead:** Search the usable index and retain observed freshness. Refresh only
+when the task needs newer records and its indexing scope is authorized, using
+a bounded invocation from [RECOVERY.md](RECOVERY.md). Do not start a second
+indexer while an earlier authorized rebuild is progressing. A failed status
+read is unknown, not evidence that the index is empty or corrupt.
 
 ---
 
@@ -152,13 +141,11 @@ Use the exact key from the bucket.
 
 **Why bad:** cass deliberately skips large tool outputs at index time to keep the corpus searchable on prompts and replies. Tool outputs are still **in the source file**.
 
-**Instead:**
-```bash
-cass search "near-by user-prompt phrase" --json --fields minimal --limit 10 \
-  | jq -r '.hits[0].source_path' | xargs rg -n "the exact tool output bytes"
-```
-
-Find the session via prompt, then `rg` for the bytes inside.
+**Instead:** Find the episode using a nearby prompt phrase, then use CASS
+pack/view/expand to inspect bounded context. If the actual required tool bytes
+remain omitted, use a selected authorized raw excerpt as described in
+[RAW_SOURCE_READS.md](RAW_SOURCE_READS.md). Missing source files and mismatched
+returned locators remain retrieval gaps; do not bulk-read every search hit.
 
 ---
 
@@ -207,17 +194,16 @@ If `_warning` is non-null, mention it. If `hits_clamped: true`, paginate. If `fa
 
 **Bad:** Pre-flight in a tight loop runs `cass index --full --json` every iteration. 25s × 60 iter = 25 min wasted.
 
-**Instead:**
-```bash
-# Once at startup
-cass status --json | jq -e '.index.fresh' >/dev/null || cass index --json
-
-# Or use watch mode and never refresh inline
-cass index --watch --json &   # one daemon, all agents share the index
-```
+**Instead:** Search immediately when the index is usable. Staleness is a coverage
+limit to report; an authorized bounded refresh is optional when newer records
+are needed. Do not add a startup refresh, watch process or preflight hook to an
+ordinary history query.
 
 ---
 
 ## Summary
 
-The pattern across these anti-patterns: **lack of trust in cass**. Trust the autonomous-recovery commands. Trust the safe-by-default `doctor --fix`. Trust the stale-but-correct lexical index. Trust the server to filter. Then your agent stops bothering the user.
+Use CASS's native retrieval surface, distinguish stale from unavailable, and
+verify selected source context. Recovery is a separate bounded operation within
+the caller's authority; search hits and citation flags do not prove source
+continuity, message roles or successful outcomes.

--- a/images/gemini/skills/cass/references/COMMANDS.md
+++ b/images/gemini/skills/cass/references/COMMANDS.md
@@ -21,8 +21,8 @@
 
 ```bash
 cass status --json              # Health check — is index current?
-cass index --json               # Incremental refresh (fast, use first)
-cass index --full --json        # Full rebuild (when stale)
+timeout 600 cass index --json   # Optional authorized refresh when needed
+timeout 600 cass index --full --json # Selected recovery only; staleness is not enough
 cass capabilities --json        # What this install supports
 cass diag --json                # Detailed diagnostics
 cass doctor                     # Repair (safe, won't delete sources)

--- a/images/gemini/skills/cass/references/PATTERNS.md
+++ b/images/gemini/skills/cass/references/PATTERNS.md
@@ -21,8 +21,8 @@
 
 | Goal | Pattern |
 |------|---------|
-| User prompts (lines 1-5) | `select(.line_number <= 3)` |
-| Subagent sessions | `contains("subagent")` |
+| User prompts | Inspect source record roles; line positions and titles are not roles |
+| Candidate subagent paths | `contains("subagent")`; verify native parent/child metadata |
 | Total match count | `.total_matches` |
 | Safe access with default | `// []` or `// "default"` |
 | Sort descending | `sort_by(-.field)` |
@@ -51,23 +51,24 @@
 | jq '.total_matches'
 ```
 
-### User Prompt Extraction (The Most Important Pattern)
+### User Prompt Extraction
 
-User prompts appear at lines 1-5. Filter by `line_number`:
+Search hits locate candidates; they are not a role filter. Use the returned
+path and line with bounded `cass pack`, `view` or `expand`, then identify the
+role from the actual record. Early lines can be metadata or assistant content,
+and user messages can occur anywhere. Verify that the returned path/line
+matches the requested hit; missing files, absent roles and clamped windows
+remain retrieval gaps.
 
 ```bash
-# Get user prompts only
-| jq '[.hits[] | select(.line_number <= 3)]'
-
-# With formatted output
-| jq '[.hits[] | select(.line_number <= 3)] | .[] | {path: .source_path, line: .line_number, title: .title[0:80]}'
-
-# Just titles (for scanning)
-| jq '[.hits[] | select(.line_number <= 3) | .title]'
-
-# Count user prompts
-| jq '[.hits[] | select(.line_number <= 3)] | length'
+cass search "KEYWORD" --workspace /path --mode lexical --json --fields minimal --limit 20
+cass view /path/from/hit.jsonl -n LINE -C 3 --json
+cass expand /path/from/hit.jsonl --line LINE --context 3 --json
 ```
+
+See [Raw Session File Parsing](#raw-session-file-parsing) for role-based
+examples over an already selected, authorized excerpt. A title count is not a
+count of user prompts.
 
 ### Subagent Session Extraction
 
@@ -78,8 +79,8 @@ User prompts appear at lines 1-5. Filter by `line_number`:
 # Just paths (unique)
 | jq '[.hits[] | select(.source_path | contains("subagent"))] | .[].source_path' -r | sort -u
 
-# User prompts in subagent sessions
-| jq '[.hits[] | select(.source_path | contains("subagent")) | select(.line_number <= 3)]'
+# Candidate locations to inspect for native roles
+| jq '[.hits[] | select(.source_path | contains("subagent")) | {source_path, line_number}]'
 ```
 
 ### Aggregation Parsing
@@ -104,72 +105,74 @@ cass search "*" --workspace /path --aggregate date --limit 1 --json \
 
 ## Pattern Detection
 
-### Find Repeated Prompts (Ritual Detection)
+### Find Recurring Candidate Titles
 
 ```bash
-# Group prompts by title, count, sort by frequency
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | sort_by(-.count) | .[0:20]'
+# Count titles within this limited hit set; retain locations for review.
+cass search "KEYWORD" --workspace /path --json --fields summary --limit 50 \
+  | jq '[.hits[] | {title, source_path, line_number}]
+    | group_by(.title)
+    | map({title: .[0].title, hit_count: length, locations: .})
+    | sort_by(-.hit_count) | .[0:20]'
 ```
 
-### Filter by Count Threshold
-
-```bash
-# Only patterns appearing 5+ times
-| jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | map(select(.count >= 5)) | sort_by(-.count)'
-```
-
-### Check Total Matches (Is It a Ritual?)
-
-```bash
-cass search "First read ALL" --workspace /path --json --limit 100 | jq '.total_matches'
-# > 10 = ritual, document it
-# < 3 = one-off, ignore
-```
+Repeated titles can represent multiple hits in one session, copied text or
+retries. They do not establish distinct prompt counts, user roles or success.
+Inspect a selected candidate's intent, outcome and corrections before reuse.
+Rare failures and scope decisions can matter even when the count is one.
 
 ---
 
 ## Raw Session File Parsing
 
+Prefer CASS pack/view/expand. These examples apply only to an already selected,
+authorized and bounded native excerpt named `excerpt.jsonl`, when a demonstrated
+precision gap requires raw records. Never run them over an entire session by
+default. The [source-format reference](SESSION_FORMATS.md) owns harness details;
+unknown formats remain unknown.
+
 ### Claude Code Format
 
 ```bash
 # Extract user messages
-jq 'select(.type == "user") | .message.content' session.jsonl
+jq 'select(.type == "user") | .message.content' excerpt.jsonl
 
 # Handle content arrays (common)
-jq 'select(.type == "user") | .message.content | if type == "array" then [.[] | select(.type == "text") | .text] | join(" ") else . end' session.jsonl
+jq 'select(.type == "user") | .message.content | if type == "array" then [.[] | select(.type == "text") | .text] | join(" ") else . end' excerpt.jsonl
 
 # With timestamps
-jq 'select(.type == "user") | {ts: .timestamp, content: .message.content}' session.jsonl
+jq 'select(.type == "user") | {ts: .timestamp, content: .message.content}' excerpt.jsonl
 
-# First user prompt only (the ritual opener)
-jq -s '[.[] | select(.type == "user")][0] | .message.content' session.jsonl
+# First user record in this excerpt (not necessarily the session opener)
+jq -s '[.[] | select(.type == "user")][0] | .message.content' excerpt.jsonl
 
 # All user messages sorted
-jq -s '[.[] | select(.type == "user")] | sort_by(.timestamp)' session.jsonl
+jq -s '[.[] | select(.type == "user")] | sort_by(.timestamp)' excerpt.jsonl
 ```
 
-### Codex/Gemini Format
+### Flat Codex/Gemini Format
 
 ```bash
 # Extract user messages
-jq 'select(.role == "user") | .content' session.jsonl
+jq 'select(.role == "user") | .content' excerpt.jsonl
 
 # With timestamp
-jq 'select(.role == "user") | {ts: (.timestamp // .created_at), content}' session.jsonl
+jq 'select(.role == "user") | {ts: (.timestamp // .created_at), content}' excerpt.jsonl
 
 # First user prompt
-jq -s '[.[] | select(.role == "user")][0] | .content' session.jsonl
+jq -s '[.[] | select(.role == "user")][0] | .content' excerpt.jsonl
 ```
 
-### Detect Format and Extract
+### Current Codex Records
 
 ```bash
-# Check format
-head -1 session.jsonl | jq -e '.type == "user"' && echo "claude_code"
-head -1 session.jsonl | jq -e '.role == "user"' && echo "codex"
+jq 'select(.type == "response_item" and .payload.type == "message" and .payload.role == "user")
+  | {ts: .timestamp, content: .payload.content}' excerpt.jsonl
 ```
+
+Inspect record shape before selecting a parser. A metadata record at the start
+cannot determine the role of subsequent messages. Avoid counting both a native
+message and a duplicated event representation as separate user turns.
 
 ---
 
@@ -179,34 +182,32 @@ head -1 session.jsonl | jq -e '.role == "user"' && echo "codex"
 
 ```bash
 # All tool calls
-jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use") | {name, input}' session.jsonl
+jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use") | {name, input}' excerpt.jsonl
 
 # Specific tool (e.g., Write)
-jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use" and .name == "Write")' session.jsonl
+jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use" and .name == "Write")' excerpt.jsonl
 
 # Tool results
-jq 'select(.type == "tool_result")' session.jsonl
+jq 'select(.type == "tool_result")' excerpt.jsonl
 
 # Count tool calls by type
-jq -s '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' session.jsonl
+jq -s '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' excerpt.jsonl
 ```
 
 ---
 
 ## Subagent Prompt Extraction
 
-Subagent logs have THE prompt at line 2:
+Use the selected hit's locator, not a fixed line number. A subagent filename is
+a discovery clue; confirm native identity and relationships before attribution.
 
 ```bash
-# View line 2 via cass
-cass view /path/to/subagents/agent-XXXXX.jsonl -n 2 -C 1
-
-# Extract with sed + jq
-sed -n '2p' /path/to/subagents/agent-XXXXX.jsonl | jq '.message.content'
-
-# Extract with jq slurp
-jq -s '.[1].message.content' /path/to/subagents/agent-XXXXX.jsonl
+cass view /path/to/subagents/agent-XXXXX.jsonl -n LINE -C 3 --json
+cass expand /path/to/subagents/agent-XXXXX.jsonl --line LINE --context 3 --json
 ```
+
+Verify the record role and returned locator. Then apply the appropriate
+role-based parser to a selected authorized excerpt if necessary.
 
 ---
 
@@ -244,20 +245,16 @@ jq -s '.[1].message.content' /path/to/subagents/agent-XXXXX.jsonl
 
 ## Composite Recipes
 
-### Full Prompt Mining Pipeline
+### Bounded Evidence Pack
 
 ```bash
-# 1. Search all sessions
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '
-    [.hits[] | select(.line_number <= 3) | .title[0:80]]
-    | group_by(.)
-    | map({prompt: .[0], count: length})
-    | sort_by(-.count)
-    | map(select(.count >= 2))
-    | .[0:30]
-  '
+timeout 30 cass pack "KEYWORD" --workspace /path --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
+
+Inspect selection and omission markers and actual returned locators. A citation
+verification flag is not proof that the source still exists, that a requested
+record was returned or that the excerpt establishes an outcome.
 
 ### Extract Conversation Flow from Session
 
@@ -266,7 +263,7 @@ jq -s '[.[] | {
   type: (.type // .role),
   ts: (.timestamp // .created_at),
   preview: (if .message then .message.content else .content end | tostring[0:100])
-}]' session.jsonl
+}]' excerpt.jsonl
 ```
 
 ### Find Sessions with Specific Tool Usage
@@ -276,19 +273,16 @@ cass search "Write" --workspace /path --json --fields minimal --limit 50 \
   | jq '[.hits[] | .source_path] | unique'
 ```
 
-### Complete Source Path → First Prompt Pipeline
+### Follow a Selected Hit
 
 ```bash
-# 1. Get source paths
-cass search "KEYWORD" --workspace /path --json --fields minimal --limit 20 \
-  | jq '.hits[].source_path' -r > /tmp/paths.txt
-
-# 2. Extract first prompt from each
-while read path; do
-  echo "=== $path ==="
-  jq -s '[.[] | select(.type == "user")][0] | .message.content[0:200]' "$path" 2>/dev/null
-done < /tmp/paths.txt
+cass search "KEYWORD" --workspace /path --json --fields minimal --limit 20
+# Select a relevant hit within the authorized source scope, then inspect it.
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
+
+Do not bulk-open every returned path or assume the first user message is the
+relevant prompt. Report missing or mismatched source records explicitly.
 
 ---
 
@@ -303,7 +297,7 @@ When a complex jq command fails silently or returns nothing:
 
 ```bash
 # Complex filter fails silently:
-| jq '[.hits[] | select(.line_number <= 3 and .source_path | contains("subagent"))] | ...'
+| jq '[.hits[] | select(.source_path | contains("subagent"))] | ...'
 # No output, no error. Now what?
 
 # SIMPLIFY FIRST:
@@ -325,18 +319,14 @@ When a complex jq command fails silently or returns nothing:
 # Add projection
 | jq '[.hits[] | {path: .source_path, line: .line_number}]'
 
-# Add filter
-| jq '[.hits[] | select(.line_number <= 3)]'
-
-# Combine (last)
-| jq '[.hits[] | select(.line_number <= 3) | select(.source_path | contains("subagent"))]'
+# Add a candidate path filter
+| jq '[.hits[] | select(.source_path | contains("subagent"))]'
 ```
 
 ### Check Intermediate Counts
 
 ```bash
 | jq '.hits | length'                        # Total hits
-| jq '[.hits[] | select(.line_number <= 3)] | length'   # After line filter
 | jq '[.hits[] | select(.source_path | contains("subagent"))] | length'  # After path filter
 ```
 
@@ -346,7 +336,7 @@ When a complex jq command fails silently or returns nothing:
 
 | Task | One-Liner |
 |------|-----------|
-| User prompt titles | `jq '[.hits[] \| select(.line_number <= 3) \| .title]'` |
+| Candidate titles | `jq '[.hits[].title]'`; not role or outcome evidence |
 | Source paths only | `jq '.hits[].source_path' -r` |
 | Agent counts | `jq '.aggregations.agent.buckets'` |
 | Date counts | `jq '.aggregations.date.buckets'` |

--- a/images/gemini/skills/cass/references/PITFALLS.md
+++ b/images/gemini/skills/cass/references/PITFALLS.md
@@ -25,7 +25,7 @@
 | Exit code 2 | Special characters in query | Quote query or use nearby anchor |
 | Broken pipe on export | Piping large output | Export to file first with `-o` |
 | Tool calls hidden | Missing flag | Add `--include-tools` to export |
-| Stale results | Index needs refresh | Run `cass index --json` |
+| Stale results | Newer records may be missing | Search usable state now; refresh only if needed and authorized, with a time cap |
 | jq returns null | Wrong field name | Use `jq 'keys'` to check structure |
 | Can see in file, cass finds nothing | Content not indexed | Fallback to `rg` on raw file |
 
@@ -37,8 +37,10 @@
 
 ```bash
 cass status --json              # Check state
-cass index --json               # Incremental refresh (try first)
-cass index --full --json        # Full rebuild (if still stale)
+# Search stale-but-usable state now; record its freshness.
+# Optional only when needed and authorized:
+timeout 600 cass index --json
+# Persistent staleness alone does not justify a full rebuild.
 ```
 
 ### Index Shows 0 Conversations

--- a/images/gemini/skills/cass/references/PROMPTS.md
+++ b/images/gemini/skills/cass/references/PROMPTS.md
@@ -1,16 +1,16 @@
-# Mined Gold-Standard Prompts
+# Example Discovery Prompts
 
-> **Source:** Real prompts from this user's session corpus that have been *re-used 5+ times*. These are tested, working entry points to cass — copy/paste, then adapt the keyword.
+> Adapt these examples to an authorized source scope and a bounded question. Reuse counts do not establish success; inspect source roles, outcomes and corrections.
 
 ## Contents
 
 - [Discovery Openers](#discovery-openers)
 - [Compile-A-File Prompts (Aggregation Tasks)](#compile-a-file-prompts-aggregation-tasks)
-- [Subagent Mining (Line 2 = THE Prompt)](#subagent-mining-line-2--the-prompt)
+- [Subagent Mining](#subagent-mining)
 - [Cross-Machine Recall](#cross-machine-recall)
 - ["What Worked Last Time?"](#what-worked-last-time)
 - [Decision Archaeology](#decision-archaeology)
-- [Ritual Detection](#ritual-detection)
+- [Recurring Candidates](#recurring-candidates)
 - [Cost & Usage Reports](#cost--usage-reports)
 - [Sentinel Phrases (Triggers for /cass)](#sentinel-phrases-triggers-for-cass)
 - [Anti-Templates](#anti-templates)
@@ -53,17 +53,21 @@ Use cass to extract every "first read ALL of AGENTS.md" prompt across this works
 
 ---
 
-## Subagent Mining (Line 2 = THE Prompt)
+## Subagent Mining
 
 ```
-Use cass to find all subagent sessions in the last 30 days where the prompt mentions "deep dive" — give me the line-2 text from each.
+Use cass to find up to three relevant subagent sessions in the last 30 days
+where the prompt mentions <TASK>. Verify the message roles and native
+relationships; show cited excerpts and disclose missing or mismatched sources.
 ```
 
 Implementation:
 ```bash
-cass search "deep dive" --workspace /path --json --fields minimal --limit 50 \
-  | jq -r '[.hits[] | select(.source_path | contains("subagent"))] | unique_by(.source_path) | .[].source_path' \
-  | xargs -I{} sh -c 'echo "=== {} ==="; sed -n "2p" "{}" | jq -r ".message.content"' 
+cass search "<TASK>" --workspace /path --days 30 --mode lexical --json --fields minimal --limit 20
+cass pack "<TASK>" --workspace /path --days 30 --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
+# Follow a selected candidate's actual locator; there is no fixed prompt line.
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
 
 ---
@@ -81,14 +85,19 @@ Search cass on css, csd, ts1, and ts2 for any mention of <KEYWORD> and dedup by 
 ## "What Worked Last Time?"
 
 ```
-Use cass to find the most-recent successful run of <TASK> and resume that session.
+Use cass to find a recent run of <TASK>. Inspect intent, outcome and later
+corrections before calling it successful. Show enough source context to judge
+whether it applies now; only resume a verified native session when requested.
 ```
 
 ```bash
-HIT=$(cass search "<TASK>" --workspace /repo --json --fields summary --limit 1 \
-        | jq -r '.hits[0].source_path')
-cass resume "$HIT" --shell
+cass pack "<TASK>" --workspace /repo --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
+
+A relevance-ranked first hit is not necessarily recent or successful. Check
+returned timestamps and source records. Use [RESUME.md](RESUME.md) only for a
+selected resume request.
 
 ---
 
@@ -104,18 +113,22 @@ Find the earliest session where we discussed adopting <LIBRARY>, and the convers
 
 ---
 
-## Ritual Detection
+## Recurring Candidates
 
 ```
-What prompts have I used 10+ times across all my agent sessions? Surface the top 20.
+Within this project, find recurring prompts relevant to <TASK>. Review up to
+three episodes for intent, outcome and corrections. Include a competing
+explanation or counterexample; do not infer success from repetition.
 ```
 
 ```bash
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]]
-        | group_by(.) | map({prompt: .[0], count: length})
-        | sort_by(-.count) | .[0:20]'
+cass search "<TASK>" --workspace /path --mode lexical --json --fields summary --limit 20
 ```
+
+See [PATTERNS.md](PATTERNS.md#pattern-detection) for limited hit counts. Titles
+and repeated indexed hits are not counts of distinct user messages. Check native
+roles and observed results before proposing reuse; rule changes need separate
+authority and later task evidence is needed to establish usefulness.
 
 ---
 
@@ -149,7 +162,7 @@ These literal phrases are reliable triggers for the skill in this user's vocabul
 - "scope archaeology"
 - "what worked last time"
 
-When you hear any of these, jump straight to the [Two-Step Bootstrap](../SKILL.md#two-step-bootstrap-replaces-always-first) and start mining.
+When the caller requests this work, use the [bounded discovery workflow](../SKILL.md#discovery-workflow) within the authorized scope. Ordinary work has no mandatory history step.
 
 ---
 
@@ -162,4 +175,4 @@ These prompts trigger /cass but produce *poor* results — rewrite them before e
 | "Search cass for everything about X" | unbounded; will return 10k hits | Add `--workspace /repo` and `--days 30` |
 | "Find all sessions" | no filter; useless | Pick a keyword OR an aggregate (`--aggregate agent,date`) |
 | "What's in the index?" | not actionable | `cass status --json` + `cass search "*" --aggregate workspace --limit 1 --json` |
-| "Re-extract all my prompts" | duplicates work cass already does | `cass search "*" --json --limit 500 \| jq '... select(.line_number <= 3)'` |
+| "Re-extract all my prompts" | an indexed sample does not prove full source coverage | Select a scope and budget; use CASS pack/view/expand and verify native roles, reporting unread or unavailable portions |

--- a/images/gemini/skills/cass/references/RAW_SOURCE_READS.md
+++ b/images/gemini/skills/cass/references/RAW_SOURCE_READS.md
@@ -1,6 +1,10 @@
 # Bounded raw source reads
 
-CASS search, `view` and `expand` locate excerpts. `ao session read-source`
+Use installed CASS search/pack/view/expand first for discovery and cited excerpts.
+Choose this optional AO route only for a demonstrated precision gap, such as
+required raw tool-output bytes or a consumer's frozen-span requirement. A missing
+original or mismatched locator remains a retrieval gap; raw extraction cannot
+reconstruct unavailable source content. `ao session read-source`
 returns explicit raw bytes after checking caller-selected policy; it does not
 parse records or replace the existing `ao provenance mine-session` tool-call
 contract. Raw bytes include prose, operator corrections, malformed records and

--- a/images/gemini/skills/cass/references/RECIPES.md
+++ b/images/gemini/skills/cass/references/RECIPES.md
@@ -1,13 +1,13 @@
 # Workflow Recipes
 
-> **Priority:** Your prompts first. They're replicable. Agent execution varies.
+> **Priority:** Resolve a concrete uncertainty with cited intent, action and outcome evidence.
 
 ## Contents
 
 | Recipe | When |
 |--------|------|
-| [Session Bootstrap](#session-bootstrap) | Start of every cass session |
-| [Ritual Discovery](#ritual-discovery) | Find reusable prompts |
+| [Search Readiness](#search-readiness) | Observe state when needed |
+| [Recurring Candidates](#recurring-candidates) | Investigate repeated prompts |
 | [User Prompt Extraction](#user-prompt-extraction) | What did I ask? |
 | [Subagent Mining](#subagent-mining) | Find extraction prompts |
 | [Scope Archaeology](#scope-archaeology) | When did we decide X? |
@@ -21,92 +21,72 @@
 
 ---
 
-## Session Bootstrap
+## Search Readiness
 
-**Always start here:**
+After source, task, model and destination authorization, search a healthy or
+stale-but-usable index immediately. Record freshness; do not automatically
+refresh, rebuild or add `--refresh`. If unavailable, report that state or use
+[bounded recovery](RECOVERY.md) only when needed and authorized.
 
 ```bash
-# 1. Health check
-cass status --json
-
-# 2. Refresh index
-cass index --json
-
-# 3. Project overview
-cass search "*" --workspace /data/projects/PROJECT --aggregate agent,date --limit 1 --json
+timeout 15 cass status --json
+# Optional overview when useful to the question
+timeout 30 cass search "*" --workspace /data/projects/PROJECT --mode lexical \
+  --aggregate agent,date --fields minimal --limit 1 --json
 ```
 
 ---
 
-## Ritual Discovery
+## Recurring Candidates
 
-**Goal:** Find prompts you used repeatedly (these work).
+**Goal:** Investigate a recurring prompt without assuming that repetition means
+it worked. Search for a task-relevant phrase, then review selected episodes.
 
 ```bash
-# Count suspected ritual
-cass search "First read ALL" --workspace /path --json --limit 100 | jq '.total_matches'
-# > 10 = RITUAL — document it
-
-# Find most repeated prompts
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | sort_by(-.count) | .[0:20]'
+timeout 30 cass search "TASK PHRASE" --workspace /path --mode lexical \
+  --json --fields summary --limit 20
+timeout 30 cass pack "TASK PHRASE" --workspace /path --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
 
-### Common Rituals to Search
-
-| Pattern | Purpose |
-|---------|---------|
-| `"First read ALL"` | Context loading |
-| `"read AGENTS.md"` | Project rules |
-| `"comprehensive deep dive"` | Thorough analysis |
-| `"think super hard"` | Quality mode |
-| `"ultrathink"` | Quality mode |
-| `"extract all"` | Data extraction |
+Compare the user intent, action, result and later corrections. Recurrence may
+come from copied instructions, repeated failure or retries. Check a competing
+explanation or counterexample before reuse; later task evidence is needed to
+show usefulness. No count threshold promotes a prompt into a rule.
 
 ---
 
 ## User Prompt Extraction
 
-**Goal:** Find what you asked, in what order.
+**Goal:** Find what the user asked and preserve its actual source identity.
 
 ```bash
-# User prompts mention keyword (lines 1-3)
-cass search "KEYWORD" --workspace /path --json --limit 100 \
-  | jq '[.hits[] | select(.line_number <= 3)] | .[] | {path: .source_path, line: .line_number, title: .title[0:80]}'
-
-# Count user prompts with term
-cass search "KEYWORD" --workspace /path --json --limit 100 \
-  | jq '[.hits[] | select(.line_number <= 3)] | length'
-
-# View actual prompt
-cass view /path/from/hit.jsonl -n 1 -C 5
+cass search "KEYWORD" --workspace /path --mode lexical --json --fields minimal --limit 20
+# Use the selected hit's path and line, not a presumed session opener.
+cass view /path/from/hit.jsonl -n LINE -C 3 --json
+cass expand /path/from/hit.jsonl --line LINE --context 3 --json
 ```
+
+User roles come from native message records, including nested harness fields.
+Line numbers and titles are not role evidence. Confirm that the returned
+locator matches the request; unknown roles, absent sources and clamped windows
+remain gaps. Selected excerpts do not establish all prompts or chronology for
+unread parts of a session.
 
 ---
 
 ## Subagent Mining
 
-**Goal:** Extract deep dive prompts — line 2 of subagent logs is THE prompt.
+**Goal:** Inspect a relevant subagent prompt and its observed outcome.
 
 ```bash
-# Find subagent sessions
-cass search "deep dive" --workspace /path --json --fields minimal \
-  | jq '[.hits[] | select(.source_path | contains("subagent"))] | .[].source_path' -r | sort -u
-
-# View the prompt (line 2)
-cass view /path/to/subagents/agent-XXXXX.jsonl -n 2 -C 1
-
-# Extract just the text
-sed -n '2p' /path/to/subagents/agent-XXXXX.jsonl | jq '.message.content'
+cass search "TASK PHRASE" --workspace /path --json --fields minimal --limit 20 \
+  | jq '[.hits[] | select(.source_path | contains("subagent")) | {source_path, line_number}]'
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
 
-### Subagent Structure
-
-```
-Line 1: Metadata
-Line 2: THE PROMPT (gold — copy-paste ready)
-Line 3+: Execution
-```
+The filename is only a candidate filter. Verify the actual record role and
+native parent/child metadata; the prompt is not guaranteed to occupy line 2.
 
 ---
 
@@ -199,7 +179,7 @@ cass search "*" --workspace /path --json --limit 200 \
 
 ## Session Clustering
 
-**Goal:** Find all related work from one good hit.
+**Goal:** Discover candidate related work from one relevant hit.
 
 ```bash
 # 1. Find one relevant session
@@ -212,7 +192,7 @@ cass context /path/from/hit.jsonl --json
 # 3. Iterate over related_sessions
 ```
 
-**Why:** Work happens in clusters. One good session → whole cluster.
+Related-session output is not a complete cluster or proof of native parentage.
 
 ---
 
@@ -261,30 +241,26 @@ cass search "cass search" --workspace /path --json --fields minimal
 cass search "aggregate" --workspace /path --json --fields minimal
 ```
 
-**Insight:** Queries that appear multiple times = queries that worked.
+Repeated queries are candidates. Inspect the resulting hits and the task outcome; repetition alone may indicate failed searches.
 
 ---
 
 ## Full Example
 
 ```bash
-# 1. Health
-cass status --json
+# 1. Discover within a selected authorized workspace and bounded query family.
+timeout 30 cass search "scope decision" --workspace /data/projects/PROJECT \
+  --mode lexical --json --fields minimal --limit 20
 
-# 2. Overview (925 sessions)
-cass search "*" --workspace /data/projects/beads_rust --aggregate agent --limit 1 --json
+# 2. Ask CASS for a small cited selection.
+timeout 30 cass pack "scope decision" --workspace /data/projects/PROJECT \
+  --mode lexical --json --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 
-# 3. Find ritual opener
-cass search "First read ALL of AGENTS.md" --workspace /data/projects/beads_rust --json --limit 100 \
-  | jq '.total_matches'
-# Result: 50+ = RITUAL
-
-# 4. Extract ritual
-cass view $(cass search "First read ALL" --workspace /data/projects/beads_rust --json --limit 1 | jq -r '.hits[0].source_path') -n 1 -C 5
-
-# 5. Find scope decisions
-cass search "EXCLUDE" --workspace /data/projects/beads_rust --json --limit 50
-
-# 6. Discover related
-cass context /path/to/interesting/session.jsonl --json
+# 3. Follow a relevant returned locator and check native role/intent/outcome.
+timeout 15 cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
+
+Retain query, filters, limit, freshness, selected locators and omissions. Missing
+sources or mismatched returned locations are not repaired by assuming an indexed
+snippet is the original record. Reuse only what the observed evidence supports;
+a justified no-change or insufficient-evidence result is valid.

--- a/images/gemini/skills/cass/references/RECOVERY.md
+++ b/images/gemini/skills/cass/references/RECOVERY.md
@@ -1,6 +1,6 @@
-# Doctor & Autonomous Recovery
+# Doctor & Bounded Authorized Recovery
 
-> **The contract:** `cass doctor --fix --json` is **safe by default**. It rebuilds derived data (Tantivy index, FTS table) from source SQLite — it never deletes source session files. Use it without asking the user.
+> **The contract:** Select recovery only when needed and authorized for its sources, model, destination and derived-state writes. Healthy and stale-but-usable indexes can be searched immediately. A search-only request does not authorize refresh/rebuild; unknown status is not proof of corruption. Preserve source sessions and bound recovery commands with a wall-clock cap.
 
 ## Contents
 
@@ -9,7 +9,7 @@
 - [Real-World Recovery Recipes](#real-world-recovery-recipes)
 - [What `--fix` Does NOT Do](#what---fix-does-not-do)
 - [Disk Cleanup (ALWAYS ask first)](#disk-cleanup-always-ask-first)
-- [Pre-Flight Hook Pattern](#pre-flight-hook-pattern)
+- [Optional Recovery Invocation](#optional-recovery-invocation)
 
 ---
 
@@ -18,8 +18,8 @@
 ```bash
 cass doctor --json                       # Read-only diagnosis
 cass doctor --json --verbose             # Show passed checks too
-cass doctor --fix --json                 # Apply safe rebuilds (USE THIS)
-cass doctor --fix --force-rebuild --json # Same + force index rebuild even if healthy
+timeout 600 cass doctor --fix --json     # Apply selected authorized repairs
+timeout 600 cass doctor --fix --force-rebuild --json # Force only for a diagnosed need
 ```
 
 `--fix` runs a 7-step protocol:
@@ -64,7 +64,7 @@ Backup format: `agent_search.db.corrupt.20260315_154822_759` (sortable timestamp
 Parse `failures[]` (top-level array of failed check names) for blocking issues. Anything in `auto_fix_actions` happened automatically. **Do not look for a `.summary` key — it doesn't exist.**
 
 ```bash
-cass doctor --fix --json | jq '{
+timeout 600 cass doctor --fix --json | jq '{
   ok: .healthy,
   issues_found, issues_fixed,
   applied: .auto_fix_actions,
@@ -84,7 +84,7 @@ cass status --json | jq '.database.messages, .index.documents'
 # 664027  0
 
 # Fix
-cass doctor --fix --json | jq '.auto_fix_actions'
+timeout 600 cass doctor --fix --json | jq '.auto_fix_actions'
 # ["Rebuilt search index from database"]
 ```
 
@@ -96,7 +96,7 @@ cass status --json | jq '.database.open_error'
 # "database disk image is malformed"
 
 # Fix
-cass doctor --fix --json
+timeout 600 cass doctor --fix --json
 # Backs up bad DB to .corrupt.<ts>, then rebuilds index from corrupt-salvage if possible
 ```
 
@@ -108,7 +108,7 @@ ps -p $(cass status --json | jq -r '.active_index.pid // empty')
 # (no such process)
 
 # Fix (doctor handles >1h-old locks; for fresher locks, force it)
-cass doctor --fix --force-rebuild --json
+timeout 600 cass doctor --fix --force-rebuild --json
 ```
 
 ### Incremental index hangs at current:0 (OPEN issue #196)
@@ -116,7 +116,7 @@ cass doctor --fix --force-rebuild --json
 ```bash
 # Workaround until fixed upstream
 pkill -f "cass index"
-cass index --full --force-rebuild --json
+timeout 600 cass index --full --force-rebuild --json
 ```
 
 `cass status` keeps showing `rebuilding` after the kill? `cass doctor --fix` clears the run lock.
@@ -151,7 +151,7 @@ cass search "common-term-from-your-corpus" --limit 1 --json --robot-meta \
 # Wait for any concurrent cass processes to settle
 sleep 30
 # A trivial incremental run is usually enough to land the timestamp
-cass index --json
+timeout 600 cass index --json
 ```
 
 If a concurrent rebuild is still active (`cass status --json | jq '.rebuild.active'`), the timestamp will be written when it completes. Don't fight it.
@@ -168,7 +168,7 @@ If a concurrent rebuild is still active (`cass status --json | jq '.rebuild.acti
 - **Re-download semantic models** — that requires `cass models install`
 - **Cross network boundaries** — only operates on local data dir
 
-So you can run `cass doctor --fix` autonomously without permission. Document the action in your response, but don't ask first.
+When recovery is already authorized, run the selected bounded repair and report the result without asking again. Source preservation alone does not grant recovery scope or permission to read additional sources.
 
 ---
 
@@ -196,41 +196,19 @@ Surface the disk usage, list candidates with sizes/ages, and let the user decide
 
 ---
 
-## Pre-Flight Hook Pattern
+## Optional Recovery Invocation
 
-For agents that should never run against a broken index:
+Do not install a search hook or start an index watcher as part of retrieval.
+When recovery is needed and its full derived-state scope is already authorized,
+inspect and invoke the existing helper:
 
 ```bash
-#!/usr/bin/env bash
-# pre-cass-search.sh
-# Decision tree: fresh → ok, stale-but-usable → bg refresh + ok, broken → doctor
-set -uo pipefail
-
-# 50ms preflight: exit 0 means already-fresh
-if cass health --json >/dev/null 2>&1; then
-  exit 0
-fi
-
-# Health failed — read full status to differentiate stale vs broken
-state=$(cass status --json 2>/dev/null \
-  | jq -r '"\(.index.stale // false),\(.database.exists // false),\(.database.messages // 0),\(.index.documents // 0)"')
-
-case "$state" in
-  true,true,*)
-    # stale index, DB present — usable; refresh in background
-    cass index --json >/tmp/cass-bg.log 2>&1 &
-    disown || true
-    exit 0
-    ;;
-  *)
-    # broken / uninitialized / DB missing — try to repair (doctor never deletes sources)
-    if cass doctor --fix --json >&2; then
-      cass health --json >/dev/null 2>&1 && exit 0 || exit 1
-    else
-      exit 1
-    fi
-    ;;
-esac
+# This may refresh a stale index or repair/rebuild derived state.
+CASS_STATUS_TIMEOUT=15 CASS_REBUILD_TIMEOUT=600 ./scripts/recover.sh
 ```
 
-Wire into Claude Code as a `PreToolUse` hook scoped to `cass search`. Use the same shape as `scripts/recover.sh` for the inline decision tree.
+The helper's individual index calls are capped. A stale usable index is still
+searchable; refreshing is an optional selected operation, not a prerequisite.
+If a status read is unavailable or an existing rebuild is progressing, retain
+that uncertainty rather than stacking another repair. See
+[OBSERVABILITY.md](OBSERVABILITY.md#authoritative-fallback-and-concurrent-read-latency).

--- a/images/gemini/skills/ms/SKILL.md
+++ b/images/gemini/skills/ms/SKILL.md
@@ -38,6 +38,26 @@ output_contract: search and load results plus source identity on stdout; the loc
 - Keep `ms` retrieval-only for production skill work. It returns search and load
   results; the caller owns authoring, validation, and every subsequent decision.
 
+## Session evidence and instruction changes
+
+For a requested instruction-improvement task, use CASS to discover relevant
+episodes and `ms` to find existing guidance that could explain the behavior or
+already address it. Load only the relevant skills, then inspect their canonical
+source before proposing an edit. An `AGENTS.md` or task-prompt change does not
+require inventing a skill or loading an unrelated one.
+
+Upstream MS also offers `build --from-cass`; this adapter deliberately does not
+invoke that authoring path. Inspect `ms build --help` if the caller selects it
+separately. A generated skill, search rank,
+repeated prompt, or recorded outcome is not proof of downstream improvement.
+
+CASS search/pack supplies candidate evidence. Use AO's bounded excerpt view only
+when the investigation needs exact raw spans, literal fields or instruction
+identity that the selected CASS output does not establish. These are optional
+capabilities, not a required sequence on every task. The caller owns a supported
+candidate edit or no-change judgment, independent review and later usefulness
+testing; retrieval never awards that outcome itself.
+
 ## Quick Start
 
 Find a skill (MCP-primary — BM25, currently strictly better than CLI search), then load the FULL runnable SKILL.md in one call (always `full: true` when you mean to use it):

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -411,8 +411,8 @@
     {
       "name": "cass",
       "source_skill": "skills/cass",
-      "source_hash": "6ff52d3728af7875ca201e7d61c630ea8501e5716dd4b299bc3e10aba14e50aa",
-      "generated_hash": "8c46de3b047459826bea613e85e7cf6686e79a41d359031043e47bd62a3e9a8d"
+      "source_hash": "2c8d3783703884fabde9766d4f3207603d400e514d7f5d4bdb5fe906eb7f9b01",
+      "generated_hash": "d68b1068af6bcbd050c2659554688e369e423e08bd3c57821e1d059e6dd330e6"
     },
     {
       "name": "cc-hooks",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -411,8 +411,8 @@
     {
       "name": "cass",
       "source_skill": "skills/cass",
-      "source_hash": "e10c9c9a3be283974857bd95a1db54a2b949d6d23a11bb6c2e990368c5d11be4",
-      "generated_hash": "fd146a3d0765ff13af36928b0630021a64787a85c27ce202c05dc272c5a39116"
+      "source_hash": "6ff52d3728af7875ca201e7d61c630ea8501e5716dd4b299bc3e10aba14e50aa",
+      "generated_hash": "8c46de3b047459826bea613e85e7cf6686e79a41d359031043e47bd62a3e9a8d"
     },
     {
       "name": "cc-hooks",
@@ -519,8 +519,8 @@
     {
       "name": "ms",
       "source_skill": "skills/ms",
-      "source_hash": "8634a28c128d80d574da339747315ed4af5e047081c20d7647f69d08f7c88e71",
-      "generated_hash": "004f0940e893cf08447b3327c332d8beab5c78bb14e30a3cdc8ff72b01a0edee"
+      "source_hash": "2bb8f7245062980ea8fae4d89f6b2d0d61abd7f1f16b7841ce40d7a2ecb73157",
+      "generated_hash": "f2d55ab48b5a296af30a3928c39e4678f69b3804775a1c2cfe86a59cfcc084a5"
     },
     {
       "name": "ntm",

--- a/skills-codex/cass/.agentops-generated.json
+++ b/skills-codex/cass/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cass",
   "layout": "modular",
-  "source_hash": "6ff52d3728af7875ca201e7d61c630ea8501e5716dd4b299bc3e10aba14e50aa",
-  "generated_hash": "8c46de3b047459826bea613e85e7cf6686e79a41d359031043e47bd62a3e9a8d"
+  "source_hash": "2c8d3783703884fabde9766d4f3207603d400e514d7f5d4bdb5fe906eb7f9b01",
+  "generated_hash": "d68b1068af6bcbd050c2659554688e369e423e08bd3c57821e1d059e6dd330e6"
 }

--- a/skills-codex/cass/.agentops-generated.json
+++ b/skills-codex/cass/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/cass",
   "layout": "modular",
-  "source_hash": "e10c9c9a3be283974857bd95a1db54a2b949d6d23a11bb6c2e990368c5d11be4",
-  "generated_hash": "fd146a3d0765ff13af36928b0630021a64787a85c27ce202c05dc272c5a39116"
+  "source_hash": "6ff52d3728af7875ca201e7d61c630ea8501e5716dd4b299bc3e10aba14e50aa",
+  "generated_hash": "8c46de3b047459826bea613e85e7cf6686e79a41d359031043e47bd62a3e9a8d"
 }

--- a/skills-codex/cass/SELF-TEST.md
+++ b/skills-codex/cass/SELF-TEST.md
@@ -98,7 +98,7 @@ ls -la .claude/skills/cass/scripts/
 ```bash
 # Verify cass is working
 cass status --json | jq '.index.fresh'
-# Should return: true
+# Fresh or stale-but-usable permits search; retain the observed state.
 
 # Test the core workflow
 cass search "*" --workspace /data/projects/YOUR_PROJECT --aggregate agent,date --limit 1 --json
@@ -110,11 +110,11 @@ cass search "*" --workspace /data/projects/YOUR_PROJECT --aggregate agent,date -
 
 When triggered, the skill should:
 
-1. **Bootstrap** — Check health, refresh index
-2. **Provide THE EXACT PROMPT** — The discovery workflow
+1. **Check readiness when needed** — Search a healthy or stale-but-usable index without routine refresh
+2. **Bound the question** — History retrieval resolves a concrete uncertainty; ordinary work needs no history step
 3. **Use token-efficient flags** — `--fields minimal`, `--limit N`
-4. **Filter user prompts** — `jq select(.line_number <= 3)`
-5. **Follow the loop** — Search → Follow source_path → Expand/Export
+4. **Verify native roles** — Early metadata/assistant records are excluded; late user records remain candidates
+5. **Follow evidence** — Search → Pack → View/Expand; verify returned locations, report omissions, and treat recurrence as a candidate signal
 
 ---
 
@@ -124,5 +124,5 @@ When triggered, the skill should:
 |---------|-------|-----|
 | Skill doesn't trigger | Vague user query | Use explicit phrases like "search sessions", "mine prompts" |
 | 0 results | Workspace path mismatch | Use `--aggregate workspace` to discover exact path |
-| Stale results | Index not refreshed | Run `cass index --json` |
+| Stale results | Recent records may be absent | Search usable state now; refresh only if needed and authorized, within a cap |
 | Export panics | Piped output | Always use `-o /tmp/out.json` |

--- a/skills-codex/cass/SKILL.md
+++ b/skills-codex/cass/SKILL.md
@@ -4,7 +4,7 @@ description: 'Mine past agent sessions for working prompts, decisions, and patte
 ---
 # cass Session Search
 
-> **Core Insight:** Your repeated prompts are your best prompts. If you typed it 10+ times, it works. Mine your history.
+> **Core Insight:** Recurring prompts identify candidates to investigate. Repetition can reflect success, repeated failure, copied instructions or retries; check the surrounding evidence before reuse.
 
 `cass` is an upstream (Dicklesworthstone) tool and is **self-describing** — do not re-learn its surface from this skill. Discover it live:
 
@@ -61,39 +61,38 @@ later coverage verification; this skill does not implement or certify it.
   distinguishes `cass resume` (same-harness command resolution) from the separate
   cross-harness converter. `cass context` discovers candidate relations; verify
   a native parent link before choosing a parent session to resume.
-- **`cass-memory` → `cm` procedural memory.** Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory — mine past sessions here first, then promote the durable lessons through `cm` instead of re-deriving them each session.
+- **`cass-memory` → `cm` procedural memory.** When procedural-memory retrieval is relevant, use the caller-selected memory source. CASS can supply episode evidence for a concrete uncertainty; retrieval does not authorize promoting a lesson or changing instructions.
 
-## The Goldmine Principle
+## History as Evidence
 
 Your conversation history contains:
-- **Refined prompts** — Every rephrase that worked better was captured
-- **Working rituals** — Prompts repeated 10+ times ARE your methodology
+- **Prompt revisions** — Compare what changed and what happened afterward
+- **Recurring prompts** — Investigate repetition without assuming effectiveness
 - **Scope decisions** — "When did we decide NOT to do X?"
 - **Recovery moments** — What you searched for after context loss = what mattered
 
-**The insight:** Mining your past beats inventing new approaches. CASS is a context source in the federated graph: it supplies cited episodic evidence on demand — mine as a research-phase move before writing a fresh plan or prompt. What it returns is evidence with source identity and freshness, never policy, and AgentOps maintains no merged corpus of its own around it.
+Native execution remains the default. Use CASS when a prior decision or episode could resolve a concrete uncertainty, or when the caller requests history. It supplies cited episodic evidence on demand, never policy; AgentOps maintains no merged corpus around it. Routine work needs no mining pre-step.
 
-## History-First Routing
+## Bounded History Routing
 
-Before deriving a plan, prompt, or approach from scratch, run one bounded
-search of past sessions (one query family, `--fields minimal`, a real
-`--limit`, under a minute of wall clock). Three outcomes, each with its own
-routing:
+When history is relevant, select a bounded search (for example one query
+family, `--fields minimal`, a real `--limit`, under a minute of wall clock).
+Three outcomes have different implications:
 
-- **Direct hit** — a prior session solved this. Reuse its prompt or decision;
+- **Direct hit** — a prior session addresses this. Inspect the user intent,
+  action, observed result and corrections before deciding whether to reuse it;
   cite `source_path` and line in whatever you build on it.
-- **Adjacent hit** — prior work borders the problem. Extract the working
-  fragments, then derive only the missing part fresh.
+- **Adjacent hit** — prior work borders the problem. Check which fragments
+  still apply and derive the missing part from current evidence.
 - **Bounded no-match** — zero hits after retrying against authorized discovered
   workspace keys (`--aggregate workspace`). Derive from available evidence and
   report the query/index limits; this does not establish global absence.
 
-The named failure mode is re-derivation drift: solving the same problem
-slightly differently each session, so the corpus accumulates near-duplicate
-approaches and no single one ever hardens into a ritual. Stop condition for
-the history pass itself: one query family exhausted or a direct hit found —
-history search is a bounded pre-step, not an open-ended excavation that
-displaces the actual task.
+Stop when the chosen query family or budget is exhausted, or enough evidence
+answers the uncertainty. An unresolved search need not displace the actual
+task. A direct hit, recurrence count or saved lesson does not prove success;
+consider a competing explanation or counterexample and name what later task
+evidence would show that reuse helped.
 
 ## Lesson Weighting: Decay and Failure Overweight
 
@@ -115,28 +114,50 @@ Mined lessons are evidence with a shelf life, not doctrine:
   hit showing the approach failing in circumstances like yours outranks three
   hits showing it succeeding elsewhere.
 
-## THE EXACT PROMPT — Discovery Workflow
+## Discovery Workflow
 
 ```
-1. Bootstrap: Check health, refresh index, get project overview
-   cass status --json && cass index --json
-   cass search "*" --workspace /data/projects/PROJECT --aggregate agent,date --limit 1 --json
+1. Observe index state if needed; healthy or stale-but-usable means search now
+   timeout 15 cass status --json
 
-2. Find prompts: Search for keywords, filter to user prompts (lines 1-3)
-   cass search "KEYWORD" --workspace /data/projects/PROJECT --json --fields minimal --limit 50 \
-     | jq '[.hits[] | select(.line_number <= 3)]'
+2. Discover bounded candidates with the installed CASS search surface
+   timeout 30 cass search "KEYWORD" --workspace /data/projects/PROJECT \
+     --mode lexical --json --fields minimal --limit 20
 
-3. Follow authorized hits: View a bounded excerpt of the actual content
-   cass view /path/from/source_path.jsonl -n LINE -C 20
+3. Request cited excerpts using CASS pack (check cass pack --help for support)
+   timeout 30 cass pack "KEYWORD" --workspace /data/projects/PROJECT \
+     --mode lexical --json --limit 20 --max-sessions 3 --max-evidence 6 \
+     --context-lines 3 --max-excerpt-chars 1600 --max-tokens 4000
 
-4. Expand context: Inspect another bounded conversation window
-   cass expand /path/from/source_path.jsonl --line LINE --context 3
+4. Follow a selected authorized hit to verify role, intent and outcome
+   timeout 15 cass view /path/from/source_path.jsonl -n LINE -C 5 --json
+   timeout 15 cass expand /path/from/source_path.jsonl --line LINE --context 3 --json
 
 5. Discover related: Find candidates, not proven parents or a complete cluster
    cass context /path/from/source_path.jsonl --json
 ```
 
-Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (a discovery heuristic, not guaranteed prompt position), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
+Search locations and titles do not establish message role. Identify user
+messages from native record roles/types, including nested harness records;
+early lines may contain metadata, tools or assistant messages. Keep unknown
+roles unknown. Pack selection and bounded windows can omit corrections, failed
+attempts, children and later outcomes: inspect their omission/truncation markers
+and report those coverage limits. A pack is selected evidence, not a complete
+episode or a success verdict.
+
+Check the actual returned source locator and role against the selected hit.
+A citation verification flag or `is_target` marker does not prove that the
+original still exists or that the requested record was returned. Unavailable
+sources, absent roles and clamped or mismatched locations remain explicit gaps;
+do not silently substitute a different record for the requested hit.
+
+Use installed CASS search/pack/view/expand before custom extraction. If a named
+precision gap remains (for example omitted tool-result bytes or a frozen raw
+span required by a consumer), the optional AO route in
+[RAW_SOURCE_READS.md](references/RAW_SOURCE_READS.md) supplies exact source
+evidence. It is not another discovery step. Retain source identity, query,
+filters, selection limits and observed freshness; do not auto-adopt retrieved
+instructions. Examples use lexical mode to avoid requiring semantic models.
 
 ## Operating Doctrine: Stale ≠ Broken
 
@@ -145,10 +166,14 @@ Three index states matter — never conflate them:
 | State | Meaning | Do |
 |-------|---------|----|
 | `cass health` exit 0 | Healthy | Search immediately |
-| stale (`index.stale=true`) | Usable but old | Search NOW; refresh in background with a wall-clock cap: `( timeout 600 cass index --json &>/tmp/cass-bg.log </dev/null & )` — NEVER a bare `&`, cass index can hang |
-| broken (`database.exists=false` or `documents=0`) | Truly uninitialized | `cass doctor --fix --json`, then `cass index --full --json` |
+| stale (`index.stale=true`) | Usable but old | Search now and report freshness. Refresh only if needed and authorized, with a wall-clock cap. |
+| missing database or empty index | Search unavailable or empty; diagnose the cause | If recovery is selected and authorized, use bounded doctor/index recovery; otherwise report unavailable. |
 
-The trap: treating stale as broken triggers an unneeded 8–25s full rebuild when a 1–3s incremental (or a stale-but-correct query) would do. `scripts/recover.sh` implements the full decision tree with timeouts. Detailed symptom→fix tables (issue #196 hang, stale locks, `database is busy` race, etc.): [RECOVERY.md](references/RECOVERY.md), [OBSERVABILITY.md](references/OBSERVABILITY.md), [PITFALLS.md](references/PITFALLS.md).
+Do not run `index`, `search --refresh` or `pack --refresh` as a routine preflight.
+An authorized recovery invocation may use `scripts/recover.sh`, which can
+mutate derived index state and has timeouts. A timed-out or malformed status is
+unknown, not proof of corruption. Detailed symptom→fix tables:
+[RECOVERY.md](references/RECOVERY.md), [OBSERVABILITY.md](references/OBSERVABILITY.md), [PITFALLS.md](references/PITFALLS.md).
 
 ### Incremental refresh can become authoritative
 
@@ -189,7 +214,7 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 
 | Anti-pattern | Why it's wrong | Do instead |
 |--------------|----------------|------------|
-| Asking the user "should I rebuild the index?" | They have agents waiting; rebuild is safe and idempotent | Just run `cass doctor --fix --json` (preserves source data) |
+| Rebuilding during a search-only request | Derived-state repair still has scope and cost | Search a usable index; recover only when needed and already authorized |
 | Running `cass index --full` whenever `status` says unhealthy | A 25s rebuild for a 30-min stale index is wasteful | Check `index.stale` separately from `database.exists`; prefer incremental |
 | Running bare `cass` to "see what's there" | Launches blocking TUI in the agent's session | Always `--json` or `--robot`; never bare |
 | Piping `cass export` into `head`/`jq` | Broken-pipe panic on large sessions | `cass export ... -o /tmp/x.json` first, then operate on the file |
@@ -198,15 +223,19 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 | Trusting 0 hits with `--workspace /X` | Workspace strings are case- and trailing-slash-sensitive | Re-run with `--aggregate workspace --limit 1` to discover the canonical key |
 | Skipping `--fields minimal` on wide scans | ~3KB per hit × 100 hits = 300KB context burn | `--fields minimal` for wide passes; upgrade to `summary`/`full` for keepers |
 | Reading session files with `cat` | Loads the full conversation into context | `cass view PATH -n LINE -C 5` or `cass expand PATH --line LINE --context 3` |
-| Re-indexing on every search | Index is shared across processes | Refresh only when `status` says stale |
+| Re-indexing on every search | Index is shared across processes | Staleness alone does not require refresh; use a bounded authorized recovery when needed |
 | Treating a timed-out search during rebuild as 0 hits | Concurrent reads may exceed normal latency while an authoritative rebuild holds shared resources | Preserve exit 124 as "not observed" and retry once the active rebuild settles |
-| Falling back to manual `find`/`grep` when cass misbehaves | Recovery is autonomous; skipping cass loses the corpus | Walk the recovery tree in [RECOVERY.md](references/RECOVERY.md). One real exception: terms inside tool stdout/stderr are skipped at index time — there `rg -n "TERM" /path.jsonl` is correct |
+| Building custom extraction before using CASS | Duplicates discovery and loses native selection/coverage facts | Use search/pack/view/expand first; a demonstrated exact-source gap may justify bounded authorized raw reads |
 
 Long-form versions with mined evidence: [ANTI_PATTERNS.md](references/ANTI_PATTERNS.md).
 
 ## Safety Boundaries
 
-Within the authorized source/model/destination and egress envelope above, the following operate on derived state rather than granting new source access: `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
+Recovery commands such as `cass doctor --fix --json` and `cass index` mutate
+derived state. Their use requires a selected recovery/refresh need within the
+authorized source/model/destination envelope. Source sync copies sessions and
+model installation downloads files; each additionally requires its own scope
+and egress authorization. A search request does not select these operations.
 
 Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.beads/`, `git reset --hard`, or hand-edit `~/.config/cass/sources.toml` — the CLI commands above already do everything safely. Never run bare `cass` (blocking TUI) inside an agent loop.
 
@@ -224,8 +253,8 @@ Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.bead
 | Semantic / hybrid / models | [SEMANTIC_AND_HYBRID.md](references/SEMANTIC_AND_HYBRID.md) |
 | Token / tool / model analytics | [ANALYTICS.md](references/ANALYTICS.md) |
 | Cross-harness session resume | [RESUME.md](references/RESUME.md) |
-| Doctor + autonomous recovery | [RECOVERY.md](references/RECOVERY.md) |
-| Mined gold-standard prompts | [PROMPTS.md](references/PROMPTS.md) |
+| Bounded authorized recovery | [RECOVERY.md](references/RECOVERY.md) |
+| Example discovery prompts | [PROMPTS.md](references/PROMPTS.md) |
 | Anti-patterns (long form) | [ANTI_PATTERNS.md](references/ANTI_PATTERNS.md) |
 | Health vs status vs index nuance | [OBSERVABILITY.md](references/OBSERVABILITY.md) |
 | Pages encrypted archive + HTML export | [PAGES_AND_EXPORT.md](references/PAGES_AND_EXPORT.md) |
@@ -236,26 +265,31 @@ When the right reference isn't obvious from titles, `grep -ni "SYMPTOM" referenc
 
 ## Scripts
 
-Scripts live under `scripts/`. Inspect their access and write scope before use when uncertain. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
+Scripts live under `scripts/`. Inspect their access and write scope before use.
+`quick_analysis.sh` is read-only; `recover.sh` is an optional explicitly selected
+recovery helper that can rebuild derived state. `multi_machine_search.sh` reads
+remote sources over ssh and needs the corresponding authorization. The legacy
+prompt miner reads native files directly and is not the default discovery path;
+use it only for a selected authorized recurrence-counting need that CASS does
+not satisfy. Its counts do not establish effectiveness or full episode coverage.
 
 | Script | Usage |
 |--------|-------|
-| `./scripts/quick_analysis.sh /path` | One-command project overview (status → aggregate agent/date → top prompts) |
-| `./scripts/prompt_miner.py --workspace /path` | Find repeated prompts (ritual detection) |
+| `./scripts/quick_analysis.sh /path` | Bounded read-only overview (status → aggregate agent/date) |
+| `./scripts/prompt_miner.py --glob /authorized/selection/*.jsonl` | Legacy recurrence counts over selected native files; outcomes remain unassessed |
 | `./scripts/validate.sh` | Validate cass install + skill structure |
-| `./scripts/recover.sh` | Autonomous recovery decision tree (READY → STALE_BUT_USABLE → BROKEN); wraps every `cass index` in `timeout` |
+| `./scripts/recover.sh` | Selected authorized recovery (READY → STALE_BUT_USABLE → BROKEN); wraps every `cass index` in `timeout` |
 | `./scripts/multi_machine_search.sh "QUERY" [host…]` | Parallel fan-out across the fleet; merges + dedups hits |
 
 ## Validation
 
 ```bash
-# Quick health check
-cass status --json | jq '.index.fresh'
-
-# Should return: true
+# Observe state; a stale usable index can still serve the task
+timeout 15 cass status --json
 ```
 
-If `false`, run: `cass index --json`
+Retain the exit status. Failure or timeout is an unavailable observation, not
+zero hits. Refresh is optional and subject to the operating doctrine above.
 
 ## Output Specification
 

--- a/skills-codex/cass/references/ANTI_PATTERNS.md
+++ b/skills-codex/cass/references/ANTI_PATTERNS.md
@@ -25,16 +25,14 @@
 **Bad:**
 > "Your cass index is stale. Could you run `cass index --full` and let me know when it's done?"
 
-**Why bad:** The user has 22 agents waiting. Every "could you" multiplies their interrupt cost.
+**Why bad:** Delegating an already authorized repair back to the user creates
+unnecessary work. But staleness alone does not require repair.
 
-**Instead:**
-```bash
-cass doctor --fix --json   # safe by default; preserves all source data
-cass index --json &        # background refresh while you proceed
-```
-Then proceed and mention the rebuild ran in passing.
-
-**Authorization scope:** Anything under `~/.local/share/coding-agent-search/` is yours to manage. Source session files (`~/.claude/projects/`, `~/.codex/sessions/`) are NOT — those are user data.
+**Instead:** Search healthy or stale-but-usable state immediately. If a concrete
+recovery need is already authorized, use the bounded helper in
+[RECOVERY.md](RECOVERY.md). Do not infer mutation authority from a search-only
+request or from where the derived index lives. Sources, metadata, destinations
+and model access retain their authorization boundaries.
 
 ---
 
@@ -63,20 +61,11 @@ cass doctor --fix --json   # rebuilds only what's broken
 
 **Why bad:** The index is stale only because it's older than the threshold (default 30 min). The data is still **correct** — it just doesn't have sessions from the last 30 min indexed yet.
 
-**Instead:**
-```bash
-state=$(cass status --json | jq -r '.index | "\(.fresh)/\(.stale)/\(.documents // "N")"')
-case "$state" in
-  true/*)        echo "fresh — search now" ;;
-  false/true/*)  echo "stale but usable"
-                 # ALWAYS wrap bg cass index in `timeout` — without it, a hung
-                 # rebuild silently strands forever. See scripts/recover.sh.
-                 ( timeout 600 cass index --json >/tmp/cass-bg.$$.log 2>&1 </dev/null & ) 2>/dev/null ;;
-  */*/0|*null)   echo "broken" && timeout 60 cass doctor --fix --json ;;
-esac
-```
-
-The agent's first search returns immediately on the still-correct stale index. The background `cass index` finishes in 1–3s for incremental refreshes.
+**Instead:** Search the usable index and retain observed freshness. Refresh only
+when the task needs newer records and its indexing scope is authorized, using
+a bounded invocation from [RECOVERY.md](RECOVERY.md). Do not start a second
+indexer while an earlier authorized rebuild is progressing. A failed status
+read is unknown, not evidence that the index is empty or corrupt.
 
 ---
 
@@ -152,13 +141,11 @@ Use the exact key from the bucket.
 
 **Why bad:** cass deliberately skips large tool outputs at index time to keep the corpus searchable on prompts and replies. Tool outputs are still **in the source file**.
 
-**Instead:**
-```bash
-cass search "near-by user-prompt phrase" --json --fields minimal --limit 10 \
-  | jq -r '.hits[0].source_path' | xargs rg -n "the exact tool output bytes"
-```
-
-Find the session via prompt, then `rg` for the bytes inside.
+**Instead:** Find the episode using a nearby prompt phrase, then use CASS
+pack/view/expand to inspect bounded context. If the actual required tool bytes
+remain omitted, use a selected authorized raw excerpt as described in
+[RAW_SOURCE_READS.md](RAW_SOURCE_READS.md). Missing source files and mismatched
+returned locators remain retrieval gaps; do not bulk-read every search hit.
 
 ---
 
@@ -207,17 +194,16 @@ If `_warning` is non-null, mention it. If `hits_clamped: true`, paginate. If `fa
 
 **Bad:** Pre-flight in a tight loop runs `cass index --full --json` every iteration. 25s × 60 iter = 25 min wasted.
 
-**Instead:**
-```bash
-# Once at startup
-cass status --json | jq -e '.index.fresh' >/dev/null || cass index --json
-
-# Or use watch mode and never refresh inline
-cass index --watch --json &   # one daemon, all agents share the index
-```
+**Instead:** Search immediately when the index is usable. Staleness is a coverage
+limit to report; an authorized bounded refresh is optional when newer records
+are needed. Do not add a startup refresh, watch process or preflight hook to an
+ordinary history query.
 
 ---
 
 ## Summary
 
-The pattern across these anti-patterns: **lack of trust in cass**. Trust the autonomous-recovery commands. Trust the safe-by-default `doctor --fix`. Trust the stale-but-correct lexical index. Trust the server to filter. Then your agent stops bothering the user.
+Use CASS's native retrieval surface, distinguish stale from unavailable, and
+verify selected source context. Recovery is a separate bounded operation within
+the caller's authority; search hits and citation flags do not prove source
+continuity, message roles or successful outcomes.

--- a/skills-codex/cass/references/COMMANDS.md
+++ b/skills-codex/cass/references/COMMANDS.md
@@ -21,8 +21,8 @@
 
 ```bash
 cass status --json              # Health check — is index current?
-cass index --json               # Incremental refresh (fast, use first)
-cass index --full --json        # Full rebuild (when stale)
+timeout 600 cass index --json   # Optional authorized refresh when needed
+timeout 600 cass index --full --json # Selected recovery only; staleness is not enough
 cass capabilities --json        # What this install supports
 cass diag --json                # Detailed diagnostics
 cass doctor                     # Repair (safe, won't delete sources)

--- a/skills-codex/cass/references/PATTERNS.md
+++ b/skills-codex/cass/references/PATTERNS.md
@@ -21,8 +21,8 @@
 
 | Goal | Pattern |
 |------|---------|
-| User prompts (lines 1-5) | `select(.line_number <= 3)` |
-| Subagent sessions | `contains("subagent")` |
+| User prompts | Inspect source record roles; line positions and titles are not roles |
+| Candidate subagent paths | `contains("subagent")`; verify native parent/child metadata |
 | Total match count | `.total_matches` |
 | Safe access with default | `// []` or `// "default"` |
 | Sort descending | `sort_by(-.field)` |
@@ -51,23 +51,24 @@
 | jq '.total_matches'
 ```
 
-### User Prompt Extraction (The Most Important Pattern)
+### User Prompt Extraction
 
-User prompts appear at lines 1-5. Filter by `line_number`:
+Search hits locate candidates; they are not a role filter. Use the returned
+path and line with bounded `cass pack`, `view` or `expand`, then identify the
+role from the actual record. Early lines can be metadata or assistant content,
+and user messages can occur anywhere. Verify that the returned path/line
+matches the requested hit; missing files, absent roles and clamped windows
+remain retrieval gaps.
 
 ```bash
-# Get user prompts only
-| jq '[.hits[] | select(.line_number <= 3)]'
-
-# With formatted output
-| jq '[.hits[] | select(.line_number <= 3)] | .[] | {path: .source_path, line: .line_number, title: .title[0:80]}'
-
-# Just titles (for scanning)
-| jq '[.hits[] | select(.line_number <= 3) | .title]'
-
-# Count user prompts
-| jq '[.hits[] | select(.line_number <= 3)] | length'
+cass search "KEYWORD" --workspace /path --mode lexical --json --fields minimal --limit 20
+cass view /path/from/hit.jsonl -n LINE -C 3 --json
+cass expand /path/from/hit.jsonl --line LINE --context 3 --json
 ```
+
+See [Raw Session File Parsing](#raw-session-file-parsing) for role-based
+examples over an already selected, authorized excerpt. A title count is not a
+count of user prompts.
 
 ### Subagent Session Extraction
 
@@ -78,8 +79,8 @@ User prompts appear at lines 1-5. Filter by `line_number`:
 # Just paths (unique)
 | jq '[.hits[] | select(.source_path | contains("subagent"))] | .[].source_path' -r | sort -u
 
-# User prompts in subagent sessions
-| jq '[.hits[] | select(.source_path | contains("subagent")) | select(.line_number <= 3)]'
+# Candidate locations to inspect for native roles
+| jq '[.hits[] | select(.source_path | contains("subagent")) | {source_path, line_number}]'
 ```
 
 ### Aggregation Parsing
@@ -104,72 +105,74 @@ cass search "*" --workspace /path --aggregate date --limit 1 --json \
 
 ## Pattern Detection
 
-### Find Repeated Prompts (Ritual Detection)
+### Find Recurring Candidate Titles
 
 ```bash
-# Group prompts by title, count, sort by frequency
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | sort_by(-.count) | .[0:20]'
+# Count titles within this limited hit set; retain locations for review.
+cass search "KEYWORD" --workspace /path --json --fields summary --limit 50 \
+  | jq '[.hits[] | {title, source_path, line_number}]
+    | group_by(.title)
+    | map({title: .[0].title, hit_count: length, locations: .})
+    | sort_by(-.hit_count) | .[0:20]'
 ```
 
-### Filter by Count Threshold
-
-```bash
-# Only patterns appearing 5+ times
-| jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | map(select(.count >= 5)) | sort_by(-.count)'
-```
-
-### Check Total Matches (Is It a Ritual?)
-
-```bash
-cass search "First read ALL" --workspace /path --json --limit 100 | jq '.total_matches'
-# > 10 = ritual, document it
-# < 3 = one-off, ignore
-```
+Repeated titles can represent multiple hits in one session, copied text or
+retries. They do not establish distinct prompt counts, user roles or success.
+Inspect a selected candidate's intent, outcome and corrections before reuse.
+Rare failures and scope decisions can matter even when the count is one.
 
 ---
 
 ## Raw Session File Parsing
 
+Prefer CASS pack/view/expand. These examples apply only to an already selected,
+authorized and bounded native excerpt named `excerpt.jsonl`, when a demonstrated
+precision gap requires raw records. Never run them over an entire session by
+default. The [source-format reference](SESSION_FORMATS.md) owns harness details;
+unknown formats remain unknown.
+
 ### Claude Code Format
 
 ```bash
 # Extract user messages
-jq 'select(.type == "user") | .message.content' session.jsonl
+jq 'select(.type == "user") | .message.content' excerpt.jsonl
 
 # Handle content arrays (common)
-jq 'select(.type == "user") | .message.content | if type == "array" then [.[] | select(.type == "text") | .text] | join(" ") else . end' session.jsonl
+jq 'select(.type == "user") | .message.content | if type == "array" then [.[] | select(.type == "text") | .text] | join(" ") else . end' excerpt.jsonl
 
 # With timestamps
-jq 'select(.type == "user") | {ts: .timestamp, content: .message.content}' session.jsonl
+jq 'select(.type == "user") | {ts: .timestamp, content: .message.content}' excerpt.jsonl
 
-# First user prompt only (the ritual opener)
-jq -s '[.[] | select(.type == "user")][0] | .message.content' session.jsonl
+# First user record in this excerpt (not necessarily the session opener)
+jq -s '[.[] | select(.type == "user")][0] | .message.content' excerpt.jsonl
 
 # All user messages sorted
-jq -s '[.[] | select(.type == "user")] | sort_by(.timestamp)' session.jsonl
+jq -s '[.[] | select(.type == "user")] | sort_by(.timestamp)' excerpt.jsonl
 ```
 
-### Codex/Gemini Format
+### Flat Codex/Gemini Format
 
 ```bash
 # Extract user messages
-jq 'select(.role == "user") | .content' session.jsonl
+jq 'select(.role == "user") | .content' excerpt.jsonl
 
 # With timestamp
-jq 'select(.role == "user") | {ts: (.timestamp // .created_at), content}' session.jsonl
+jq 'select(.role == "user") | {ts: (.timestamp // .created_at), content}' excerpt.jsonl
 
 # First user prompt
-jq -s '[.[] | select(.role == "user")][0] | .content' session.jsonl
+jq -s '[.[] | select(.role == "user")][0] | .content' excerpt.jsonl
 ```
 
-### Detect Format and Extract
+### Current Codex Records
 
 ```bash
-# Check format
-head -1 session.jsonl | jq -e '.type == "user"' && echo "claude_code"
-head -1 session.jsonl | jq -e '.role == "user"' && echo "codex"
+jq 'select(.type == "response_item" and .payload.type == "message" and .payload.role == "user")
+  | {ts: .timestamp, content: .payload.content}' excerpt.jsonl
 ```
+
+Inspect record shape before selecting a parser. A metadata record at the start
+cannot determine the role of subsequent messages. Avoid counting both a native
+message and a duplicated event representation as separate user turns.
 
 ---
 
@@ -179,34 +182,32 @@ head -1 session.jsonl | jq -e '.role == "user"' && echo "codex"
 
 ```bash
 # All tool calls
-jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use") | {name, input}' session.jsonl
+jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use") | {name, input}' excerpt.jsonl
 
 # Specific tool (e.g., Write)
-jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use" and .name == "Write")' session.jsonl
+jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use" and .name == "Write")' excerpt.jsonl
 
 # Tool results
-jq 'select(.type == "tool_result")' session.jsonl
+jq 'select(.type == "tool_result")' excerpt.jsonl
 
 # Count tool calls by type
-jq -s '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' session.jsonl
+jq -s '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' excerpt.jsonl
 ```
 
 ---
 
 ## Subagent Prompt Extraction
 
-Subagent logs have THE prompt at line 2:
+Use the selected hit's locator, not a fixed line number. A subagent filename is
+a discovery clue; confirm native identity and relationships before attribution.
 
 ```bash
-# View line 2 via cass
-cass view /path/to/subagents/agent-XXXXX.jsonl -n 2 -C 1
-
-# Extract with sed + jq
-sed -n '2p' /path/to/subagents/agent-XXXXX.jsonl | jq '.message.content'
-
-# Extract with jq slurp
-jq -s '.[1].message.content' /path/to/subagents/agent-XXXXX.jsonl
+cass view /path/to/subagents/agent-XXXXX.jsonl -n LINE -C 3 --json
+cass expand /path/to/subagents/agent-XXXXX.jsonl --line LINE --context 3 --json
 ```
+
+Verify the record role and returned locator. Then apply the appropriate
+role-based parser to a selected authorized excerpt if necessary.
 
 ---
 
@@ -244,20 +245,16 @@ jq -s '.[1].message.content' /path/to/subagents/agent-XXXXX.jsonl
 
 ## Composite Recipes
 
-### Full Prompt Mining Pipeline
+### Bounded Evidence Pack
 
 ```bash
-# 1. Search all sessions
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '
-    [.hits[] | select(.line_number <= 3) | .title[0:80]]
-    | group_by(.)
-    | map({prompt: .[0], count: length})
-    | sort_by(-.count)
-    | map(select(.count >= 2))
-    | .[0:30]
-  '
+timeout 30 cass pack "KEYWORD" --workspace /path --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
+
+Inspect selection and omission markers and actual returned locators. A citation
+verification flag is not proof that the source still exists, that a requested
+record was returned or that the excerpt establishes an outcome.
 
 ### Extract Conversation Flow from Session
 
@@ -266,7 +263,7 @@ jq -s '[.[] | {
   type: (.type // .role),
   ts: (.timestamp // .created_at),
   preview: (if .message then .message.content else .content end | tostring[0:100])
-}]' session.jsonl
+}]' excerpt.jsonl
 ```
 
 ### Find Sessions with Specific Tool Usage
@@ -276,19 +273,16 @@ cass search "Write" --workspace /path --json --fields minimal --limit 50 \
   | jq '[.hits[] | .source_path] | unique'
 ```
 
-### Complete Source Path → First Prompt Pipeline
+### Follow a Selected Hit
 
 ```bash
-# 1. Get source paths
-cass search "KEYWORD" --workspace /path --json --fields minimal --limit 20 \
-  | jq '.hits[].source_path' -r > /tmp/paths.txt
-
-# 2. Extract first prompt from each
-while read path; do
-  echo "=== $path ==="
-  jq -s '[.[] | select(.type == "user")][0] | .message.content[0:200]' "$path" 2>/dev/null
-done < /tmp/paths.txt
+cass search "KEYWORD" --workspace /path --json --fields minimal --limit 20
+# Select a relevant hit within the authorized source scope, then inspect it.
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
+
+Do not bulk-open every returned path or assume the first user message is the
+relevant prompt. Report missing or mismatched source records explicitly.
 
 ---
 
@@ -303,7 +297,7 @@ When a complex jq command fails silently or returns nothing:
 
 ```bash
 # Complex filter fails silently:
-| jq '[.hits[] | select(.line_number <= 3 and .source_path | contains("subagent"))] | ...'
+| jq '[.hits[] | select(.source_path | contains("subagent"))] | ...'
 # No output, no error. Now what?
 
 # SIMPLIFY FIRST:
@@ -325,18 +319,14 @@ When a complex jq command fails silently or returns nothing:
 # Add projection
 | jq '[.hits[] | {path: .source_path, line: .line_number}]'
 
-# Add filter
-| jq '[.hits[] | select(.line_number <= 3)]'
-
-# Combine (last)
-| jq '[.hits[] | select(.line_number <= 3) | select(.source_path | contains("subagent"))]'
+# Add a candidate path filter
+| jq '[.hits[] | select(.source_path | contains("subagent"))]'
 ```
 
 ### Check Intermediate Counts
 
 ```bash
 | jq '.hits | length'                        # Total hits
-| jq '[.hits[] | select(.line_number <= 3)] | length'   # After line filter
 | jq '[.hits[] | select(.source_path | contains("subagent"))] | length'  # After path filter
 ```
 
@@ -346,7 +336,7 @@ When a complex jq command fails silently or returns nothing:
 
 | Task | One-Liner |
 |------|-----------|
-| User prompt titles | `jq '[.hits[] \| select(.line_number <= 3) \| .title]'` |
+| Candidate titles | `jq '[.hits[].title]'`; not role or outcome evidence |
 | Source paths only | `jq '.hits[].source_path' -r` |
 | Agent counts | `jq '.aggregations.agent.buckets'` |
 | Date counts | `jq '.aggregations.date.buckets'` |

--- a/skills-codex/cass/references/PITFALLS.md
+++ b/skills-codex/cass/references/PITFALLS.md
@@ -25,7 +25,7 @@
 | Exit code 2 | Special characters in query | Quote query or use nearby anchor |
 | Broken pipe on export | Piping large output | Export to file first with `-o` |
 | Tool calls hidden | Missing flag | Add `--include-tools` to export |
-| Stale results | Index needs refresh | Run `cass index --json` |
+| Stale results | Newer records may be missing | Search usable state now; refresh only if needed and authorized, with a time cap |
 | jq returns null | Wrong field name | Use `jq 'keys'` to check structure |
 | Can see in file, cass finds nothing | Content not indexed | Fallback to `rg` on raw file |
 
@@ -37,8 +37,10 @@
 
 ```bash
 cass status --json              # Check state
-cass index --json               # Incremental refresh (try first)
-cass index --full --json        # Full rebuild (if still stale)
+# Search stale-but-usable state now; record its freshness.
+# Optional only when needed and authorized:
+timeout 600 cass index --json
+# Persistent staleness alone does not justify a full rebuild.
 ```
 
 ### Index Shows 0 Conversations

--- a/skills-codex/cass/references/PROMPTS.md
+++ b/skills-codex/cass/references/PROMPTS.md
@@ -1,16 +1,16 @@
-# Mined Gold-Standard Prompts
+# Example Discovery Prompts
 
-> **Source:** Real prompts from this user's session corpus that have been *re-used 5+ times*. These are tested, working entry points to cass — copy/paste, then adapt the keyword.
+> Adapt these examples to an authorized source scope and a bounded question. Reuse counts do not establish success; inspect source roles, outcomes and corrections.
 
 ## Contents
 
 - [Discovery Openers](#discovery-openers)
 - [Compile-A-File Prompts (Aggregation Tasks)](#compile-a-file-prompts-aggregation-tasks)
-- [Subagent Mining (Line 2 = THE Prompt)](#subagent-mining-line-2--the-prompt)
+- [Subagent Mining](#subagent-mining)
 - [Cross-Machine Recall](#cross-machine-recall)
 - ["What Worked Last Time?"](#what-worked-last-time)
 - [Decision Archaeology](#decision-archaeology)
-- [Ritual Detection](#ritual-detection)
+- [Recurring Candidates](#recurring-candidates)
 - [Cost & Usage Reports](#cost--usage-reports)
 - [Sentinel Phrases (Triggers for /cass)](#sentinel-phrases-triggers-for-cass)
 - [Anti-Templates](#anti-templates)
@@ -53,17 +53,21 @@ Use cass to extract every "first read ALL of AGENTS.md" prompt across this works
 
 ---
 
-## Subagent Mining (Line 2 = THE Prompt)
+## Subagent Mining
 
 ```
-Use cass to find all subagent sessions in the last 30 days where the prompt mentions "deep dive" — give me the line-2 text from each.
+Use cass to find up to three relevant subagent sessions in the last 30 days
+where the prompt mentions <TASK>. Verify the message roles and native
+relationships; show cited excerpts and disclose missing or mismatched sources.
 ```
 
 Implementation:
 ```bash
-cass search "deep dive" --workspace /path --json --fields minimal --limit 50 \
-  | jq -r '[.hits[] | select(.source_path | contains("subagent"))] | unique_by(.source_path) | .[].source_path' \
-  | xargs -I{} sh -c 'echo "=== {} ==="; sed -n "2p" "{}" | jq -r ".message.content"' 
+cass search "<TASK>" --workspace /path --days 30 --mode lexical --json --fields minimal --limit 20
+cass pack "<TASK>" --workspace /path --days 30 --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
+# Follow a selected candidate's actual locator; there is no fixed prompt line.
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
 
 ---
@@ -81,14 +85,19 @@ Search cass on css, csd, ts1, and ts2 for any mention of <KEYWORD> and dedup by 
 ## "What Worked Last Time?"
 
 ```
-Use cass to find the most-recent successful run of <TASK> and resume that session.
+Use cass to find a recent run of <TASK>. Inspect intent, outcome and later
+corrections before calling it successful. Show enough source context to judge
+whether it applies now; only resume a verified native session when requested.
 ```
 
 ```bash
-HIT=$(cass search "<TASK>" --workspace /repo --json --fields summary --limit 1 \
-        | jq -r '.hits[0].source_path')
-cass resume "$HIT" --shell
+cass pack "<TASK>" --workspace /repo --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
+
+A relevance-ranked first hit is not necessarily recent or successful. Check
+returned timestamps and source records. Use [RESUME.md](RESUME.md) only for a
+selected resume request.
 
 ---
 
@@ -104,18 +113,22 @@ Find the earliest session where we discussed adopting <LIBRARY>, and the convers
 
 ---
 
-## Ritual Detection
+## Recurring Candidates
 
 ```
-What prompts have I used 10+ times across all my agent sessions? Surface the top 20.
+Within this project, find recurring prompts relevant to <TASK>. Review up to
+three episodes for intent, outcome and corrections. Include a competing
+explanation or counterexample; do not infer success from repetition.
 ```
 
 ```bash
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]]
-        | group_by(.) | map({prompt: .[0], count: length})
-        | sort_by(-.count) | .[0:20]'
+cass search "<TASK>" --workspace /path --mode lexical --json --fields summary --limit 20
 ```
+
+See [PATTERNS.md](PATTERNS.md#pattern-detection) for limited hit counts. Titles
+and repeated indexed hits are not counts of distinct user messages. Check native
+roles and observed results before proposing reuse; rule changes need separate
+authority and later task evidence is needed to establish usefulness.
 
 ---
 
@@ -149,7 +162,7 @@ These literal phrases are reliable triggers for the skill in this user's vocabul
 - "scope archaeology"
 - "what worked last time"
 
-When you hear any of these, jump straight to the [Two-Step Bootstrap](../SKILL.md#two-step-bootstrap-replaces-always-first) and start mining.
+When the caller requests this work, use the [bounded discovery workflow](../SKILL.md#discovery-workflow) within the authorized scope. Ordinary work has no mandatory history step.
 
 ---
 
@@ -162,4 +175,4 @@ These prompts trigger /cass but produce *poor* results — rewrite them before e
 | "Search cass for everything about X" | unbounded; will return 10k hits | Add `--workspace /repo` and `--days 30` |
 | "Find all sessions" | no filter; useless | Pick a keyword OR an aggregate (`--aggregate agent,date`) |
 | "What's in the index?" | not actionable | `cass status --json` + `cass search "*" --aggregate workspace --limit 1 --json` |
-| "Re-extract all my prompts" | duplicates work cass already does | `cass search "*" --json --limit 500 \| jq '... select(.line_number <= 3)'` |
+| "Re-extract all my prompts" | an indexed sample does not prove full source coverage | Select a scope and budget; use CASS pack/view/expand and verify native roles, reporting unread or unavailable portions |

--- a/skills-codex/cass/references/RAW_SOURCE_READS.md
+++ b/skills-codex/cass/references/RAW_SOURCE_READS.md
@@ -1,6 +1,10 @@
 # Bounded raw source reads
 
-CASS search, `view` and `expand` locate excerpts. `ao session read-source`
+Use installed CASS search/pack/view/expand first for discovery and cited excerpts.
+Choose this optional AO route only for a demonstrated precision gap, such as
+required raw tool-output bytes or a consumer's frozen-span requirement. A missing
+original or mismatched locator remains a retrieval gap; raw extraction cannot
+reconstruct unavailable source content. `ao session read-source`
 returns explicit raw bytes after checking caller-selected policy; it does not
 parse records or replace the existing `ao provenance mine-session` tool-call
 contract. Raw bytes include prose, operator corrections, malformed records and

--- a/skills-codex/cass/references/RECIPES.md
+++ b/skills-codex/cass/references/RECIPES.md
@@ -1,13 +1,13 @@
 # Workflow Recipes
 
-> **Priority:** Your prompts first. They're replicable. Agent execution varies.
+> **Priority:** Resolve a concrete uncertainty with cited intent, action and outcome evidence.
 
 ## Contents
 
 | Recipe | When |
 |--------|------|
-| [Session Bootstrap](#session-bootstrap) | Start of every cass session |
-| [Ritual Discovery](#ritual-discovery) | Find reusable prompts |
+| [Search Readiness](#search-readiness) | Observe state when needed |
+| [Recurring Candidates](#recurring-candidates) | Investigate repeated prompts |
 | [User Prompt Extraction](#user-prompt-extraction) | What did I ask? |
 | [Subagent Mining](#subagent-mining) | Find extraction prompts |
 | [Scope Archaeology](#scope-archaeology) | When did we decide X? |
@@ -21,92 +21,72 @@
 
 ---
 
-## Session Bootstrap
+## Search Readiness
 
-**Always start here:**
+After source, task, model and destination authorization, search a healthy or
+stale-but-usable index immediately. Record freshness; do not automatically
+refresh, rebuild or add `--refresh`. If unavailable, report that state or use
+[bounded recovery](RECOVERY.md) only when needed and authorized.
 
 ```bash
-# 1. Health check
-cass status --json
-
-# 2. Refresh index
-cass index --json
-
-# 3. Project overview
-cass search "*" --workspace /data/projects/PROJECT --aggregate agent,date --limit 1 --json
+timeout 15 cass status --json
+# Optional overview when useful to the question
+timeout 30 cass search "*" --workspace /data/projects/PROJECT --mode lexical \
+  --aggregate agent,date --fields minimal --limit 1 --json
 ```
 
 ---
 
-## Ritual Discovery
+## Recurring Candidates
 
-**Goal:** Find prompts you used repeatedly (these work).
+**Goal:** Investigate a recurring prompt without assuming that repetition means
+it worked. Search for a task-relevant phrase, then review selected episodes.
 
 ```bash
-# Count suspected ritual
-cass search "First read ALL" --workspace /path --json --limit 100 | jq '.total_matches'
-# > 10 = RITUAL — document it
-
-# Find most repeated prompts
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | sort_by(-.count) | .[0:20]'
+timeout 30 cass search "TASK PHRASE" --workspace /path --mode lexical \
+  --json --fields summary --limit 20
+timeout 30 cass pack "TASK PHRASE" --workspace /path --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
 
-### Common Rituals to Search
-
-| Pattern | Purpose |
-|---------|---------|
-| `"First read ALL"` | Context loading |
-| `"read AGENTS.md"` | Project rules |
-| `"comprehensive deep dive"` | Thorough analysis |
-| `"think super hard"` | Quality mode |
-| `"ultrathink"` | Quality mode |
-| `"extract all"` | Data extraction |
+Compare the user intent, action, result and later corrections. Recurrence may
+come from copied instructions, repeated failure or retries. Check a competing
+explanation or counterexample before reuse; later task evidence is needed to
+show usefulness. No count threshold promotes a prompt into a rule.
 
 ---
 
 ## User Prompt Extraction
 
-**Goal:** Find what you asked, in what order.
+**Goal:** Find what the user asked and preserve its actual source identity.
 
 ```bash
-# User prompts mention keyword (lines 1-3)
-cass search "KEYWORD" --workspace /path --json --limit 100 \
-  | jq '[.hits[] | select(.line_number <= 3)] | .[] | {path: .source_path, line: .line_number, title: .title[0:80]}'
-
-# Count user prompts with term
-cass search "KEYWORD" --workspace /path --json --limit 100 \
-  | jq '[.hits[] | select(.line_number <= 3)] | length'
-
-# View actual prompt
-cass view /path/from/hit.jsonl -n 1 -C 5
+cass search "KEYWORD" --workspace /path --mode lexical --json --fields minimal --limit 20
+# Use the selected hit's path and line, not a presumed session opener.
+cass view /path/from/hit.jsonl -n LINE -C 3 --json
+cass expand /path/from/hit.jsonl --line LINE --context 3 --json
 ```
+
+User roles come from native message records, including nested harness fields.
+Line numbers and titles are not role evidence. Confirm that the returned
+locator matches the request; unknown roles, absent sources and clamped windows
+remain gaps. Selected excerpts do not establish all prompts or chronology for
+unread parts of a session.
 
 ---
 
 ## Subagent Mining
 
-**Goal:** Extract deep dive prompts — line 2 of subagent logs is THE prompt.
+**Goal:** Inspect a relevant subagent prompt and its observed outcome.
 
 ```bash
-# Find subagent sessions
-cass search "deep dive" --workspace /path --json --fields minimal \
-  | jq '[.hits[] | select(.source_path | contains("subagent"))] | .[].source_path' -r | sort -u
-
-# View the prompt (line 2)
-cass view /path/to/subagents/agent-XXXXX.jsonl -n 2 -C 1
-
-# Extract just the text
-sed -n '2p' /path/to/subagents/agent-XXXXX.jsonl | jq '.message.content'
+cass search "TASK PHRASE" --workspace /path --json --fields minimal --limit 20 \
+  | jq '[.hits[] | select(.source_path | contains("subagent")) | {source_path, line_number}]'
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
 
-### Subagent Structure
-
-```
-Line 1: Metadata
-Line 2: THE PROMPT (gold — copy-paste ready)
-Line 3+: Execution
-```
+The filename is only a candidate filter. Verify the actual record role and
+native parent/child metadata; the prompt is not guaranteed to occupy line 2.
 
 ---
 
@@ -199,7 +179,7 @@ cass search "*" --workspace /path --json --limit 200 \
 
 ## Session Clustering
 
-**Goal:** Find all related work from one good hit.
+**Goal:** Discover candidate related work from one relevant hit.
 
 ```bash
 # 1. Find one relevant session
@@ -212,7 +192,7 @@ cass context /path/from/hit.jsonl --json
 # 3. Iterate over related_sessions
 ```
 
-**Why:** Work happens in clusters. One good session → whole cluster.
+Related-session output is not a complete cluster or proof of native parentage.
 
 ---
 
@@ -261,30 +241,26 @@ cass search "cass search" --workspace /path --json --fields minimal
 cass search "aggregate" --workspace /path --json --fields minimal
 ```
 
-**Insight:** Queries that appear multiple times = queries that worked.
+Repeated queries are candidates. Inspect the resulting hits and the task outcome; repetition alone may indicate failed searches.
 
 ---
 
 ## Full Example
 
 ```bash
-# 1. Health
-cass status --json
+# 1. Discover within a selected authorized workspace and bounded query family.
+timeout 30 cass search "scope decision" --workspace /data/projects/PROJECT \
+  --mode lexical --json --fields minimal --limit 20
 
-# 2. Overview (925 sessions)
-cass search "*" --workspace /data/projects/beads_rust --aggregate agent --limit 1 --json
+# 2. Ask CASS for a small cited selection.
+timeout 30 cass pack "scope decision" --workspace /data/projects/PROJECT \
+  --mode lexical --json --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 
-# 3. Find ritual opener
-cass search "First read ALL of AGENTS.md" --workspace /data/projects/beads_rust --json --limit 100 \
-  | jq '.total_matches'
-# Result: 50+ = RITUAL
-
-# 4. Extract ritual
-cass view $(cass search "First read ALL" --workspace /data/projects/beads_rust --json --limit 1 | jq -r '.hits[0].source_path') -n 1 -C 5
-
-# 5. Find scope decisions
-cass search "EXCLUDE" --workspace /data/projects/beads_rust --json --limit 50
-
-# 6. Discover related
-cass context /path/to/interesting/session.jsonl --json
+# 3. Follow a relevant returned locator and check native role/intent/outcome.
+timeout 15 cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
+
+Retain query, filters, limit, freshness, selected locators and omissions. Missing
+sources or mismatched returned locations are not repaired by assuming an indexed
+snippet is the original record. Reuse only what the observed evidence supports;
+a justified no-change or insufficient-evidence result is valid.

--- a/skills-codex/cass/references/RECOVERY.md
+++ b/skills-codex/cass/references/RECOVERY.md
@@ -1,6 +1,6 @@
-# Doctor & Autonomous Recovery
+# Doctor & Bounded Authorized Recovery
 
-> **The contract:** `cass doctor --fix --json` is **safe by default**. It rebuilds derived data (Tantivy index, FTS table) from source SQLite — it never deletes source session files. Use it without asking the user.
+> **The contract:** Select recovery only when needed and authorized for its sources, model, destination and derived-state writes. Healthy and stale-but-usable indexes can be searched immediately. A search-only request does not authorize refresh/rebuild; unknown status is not proof of corruption. Preserve source sessions and bound recovery commands with a wall-clock cap.
 
 ## Contents
 
@@ -9,7 +9,7 @@
 - [Real-World Recovery Recipes](#real-world-recovery-recipes)
 - [What `--fix` Does NOT Do](#what---fix-does-not-do)
 - [Disk Cleanup (ALWAYS ask first)](#disk-cleanup-always-ask-first)
-- [Pre-Flight Hook Pattern](#pre-flight-hook-pattern)
+- [Optional Recovery Invocation](#optional-recovery-invocation)
 
 ---
 
@@ -18,8 +18,8 @@
 ```bash
 cass doctor --json                       # Read-only diagnosis
 cass doctor --json --verbose             # Show passed checks too
-cass doctor --fix --json                 # Apply safe rebuilds (USE THIS)
-cass doctor --fix --force-rebuild --json # Same + force index rebuild even if healthy
+timeout 600 cass doctor --fix --json     # Apply selected authorized repairs
+timeout 600 cass doctor --fix --force-rebuild --json # Force only for a diagnosed need
 ```
 
 `--fix` runs a 7-step protocol:
@@ -64,7 +64,7 @@ Backup format: `agent_search.db.corrupt.20260315_154822_759` (sortable timestamp
 Parse `failures[]` (top-level array of failed check names) for blocking issues. Anything in `auto_fix_actions` happened automatically. **Do not look for a `.summary` key — it doesn't exist.**
 
 ```bash
-cass doctor --fix --json | jq '{
+timeout 600 cass doctor --fix --json | jq '{
   ok: .healthy,
   issues_found, issues_fixed,
   applied: .auto_fix_actions,
@@ -84,7 +84,7 @@ cass status --json | jq '.database.messages, .index.documents'
 # 664027  0
 
 # Fix
-cass doctor --fix --json | jq '.auto_fix_actions'
+timeout 600 cass doctor --fix --json | jq '.auto_fix_actions'
 # ["Rebuilt search index from database"]
 ```
 
@@ -96,7 +96,7 @@ cass status --json | jq '.database.open_error'
 # "database disk image is malformed"
 
 # Fix
-cass doctor --fix --json
+timeout 600 cass doctor --fix --json
 # Backs up bad DB to .corrupt.<ts>, then rebuilds index from corrupt-salvage if possible
 ```
 
@@ -108,7 +108,7 @@ ps -p $(cass status --json | jq -r '.active_index.pid // empty')
 # (no such process)
 
 # Fix (doctor handles >1h-old locks; for fresher locks, force it)
-cass doctor --fix --force-rebuild --json
+timeout 600 cass doctor --fix --force-rebuild --json
 ```
 
 ### Incremental index hangs at current:0 (OPEN issue #196)
@@ -116,7 +116,7 @@ cass doctor --fix --force-rebuild --json
 ```bash
 # Workaround until fixed upstream
 pkill -f "cass index"
-cass index --full --force-rebuild --json
+timeout 600 cass index --full --force-rebuild --json
 ```
 
 `cass status` keeps showing `rebuilding` after the kill? `cass doctor --fix` clears the run lock.
@@ -151,7 +151,7 @@ cass search "common-term-from-your-corpus" --limit 1 --json --robot-meta \
 # Wait for any concurrent cass processes to settle
 sleep 30
 # A trivial incremental run is usually enough to land the timestamp
-cass index --json
+timeout 600 cass index --json
 ```
 
 If a concurrent rebuild is still active (`cass status --json | jq '.rebuild.active'`), the timestamp will be written when it completes. Don't fight it.
@@ -168,7 +168,7 @@ If a concurrent rebuild is still active (`cass status --json | jq '.rebuild.acti
 - **Re-download semantic models** — that requires `cass models install`
 - **Cross network boundaries** — only operates on local data dir
 
-So you can run `cass doctor --fix` autonomously without permission. Document the action in your response, but don't ask first.
+When recovery is already authorized, run the selected bounded repair and report the result without asking again. Source preservation alone does not grant recovery scope or permission to read additional sources.
 
 ---
 
@@ -196,41 +196,19 @@ Surface the disk usage, list candidates with sizes/ages, and let the user decide
 
 ---
 
-## Pre-Flight Hook Pattern
+## Optional Recovery Invocation
 
-For agents that should never run against a broken index:
+Do not install a search hook or start an index watcher as part of retrieval.
+When recovery is needed and its full derived-state scope is already authorized,
+inspect and invoke the existing helper:
 
 ```bash
-#!/usr/bin/env bash
-# pre-cass-search.sh
-# Decision tree: fresh → ok, stale-but-usable → bg refresh + ok, broken → doctor
-set -uo pipefail
-
-# 50ms preflight: exit 0 means already-fresh
-if cass health --json >/dev/null 2>&1; then
-  exit 0
-fi
-
-# Health failed — read full status to differentiate stale vs broken
-state=$(cass status --json 2>/dev/null \
-  | jq -r '"\(.index.stale // false),\(.database.exists // false),\(.database.messages // 0),\(.index.documents // 0)"')
-
-case "$state" in
-  true,true,*)
-    # stale index, DB present — usable; refresh in background
-    cass index --json >/tmp/cass-bg.log 2>&1 &
-    disown || true
-    exit 0
-    ;;
-  *)
-    # broken / uninitialized / DB missing — try to repair (doctor never deletes sources)
-    if cass doctor --fix --json >&2; then
-      cass health --json >/dev/null 2>&1 && exit 0 || exit 1
-    else
-      exit 1
-    fi
-    ;;
-esac
+# This may refresh a stale index or repair/rebuild derived state.
+CASS_STATUS_TIMEOUT=15 CASS_REBUILD_TIMEOUT=600 ./scripts/recover.sh
 ```
 
-Wire into Claude Code as a `PreToolUse` hook scoped to `cass search`. Use the same shape as `scripts/recover.sh` for the inline decision tree.
+The helper's individual index calls are capped. A stale usable index is still
+searchable; refreshing is an optional selected operation, not a prerequisite.
+If a status read is unavailable or an existing rebuild is progressing, retain
+that uncertainty rather than stacking another repair. See
+[OBSERVABILITY.md](OBSERVABILITY.md#authoritative-fallback-and-concurrent-read-latency).

--- a/skills-codex/cass/scripts/prompt_miner.py
+++ b/skills-codex/cass/scripts/prompt_miner.py
@@ -3,8 +3,9 @@
 Prompt Miner — Extract and cluster prompts across agent session logs.
 
 Mines user prompts from Claude Code, Codex CLI, and Gemini CLI sessions,
-clusters them by similarity, and identifies "ritual" prompts (repeated patterns
-that indicate working workflows).
+groups identical text after whitespace normalization, and reports recurring
+candidates. Counts do not establish success; retries and copied instructions
+can recur too. Prefer CASS search/pack for discovery and cited evidence.
 
 Usage:
     python prompt_miner.py --workspace /data/projects/PROJECT [OPTIONS]
@@ -16,7 +17,7 @@ Examples:
     # Mine all sessions with custom glob
     python prompt_miner.py --glob "~/.claude/projects/**/*.jsonl" --top 50
 
-    # Only show rituals (10+ occurrences)
+    # Only show frequent candidates (10+ occurrences; outcomes unassessed)
     python prompt_miner.py --workspace /path --min-count 10
 
     # Output as JSON for further processing
@@ -68,23 +69,19 @@ def parse_iso(ts: str) -> Optional[datetime]:
 
 
 def extract_text_from_content(content) -> str:
-    """Extract text from various content formats."""
+    """Extract explicit user text, excluding tool results nested in user envelopes."""
     if isinstance(content, str):
         return content
     elif isinstance(content, list):
         parts = []
         for c in content:
-            if isinstance(c, dict):
-                if "text" in c:
+            if isinstance(c, dict) and c.get("type") in ("text", "input_text"):
+                if isinstance(c.get("text"), str):
                     parts.append(str(c["text"]))
-                elif "content" in c:
-                    parts.append(extract_text_from_content(c["content"]))
         return " ".join(parts)
     elif isinstance(content, dict):
-        if "text" in content:
+        if content.get("type") in ("text", "input_text") and isinstance(content.get("text"), str):
             return str(content["text"])
-        elif "content" in content:
-            return extract_text_from_content(content["content"])
     return ""
 
 
@@ -141,11 +138,23 @@ def mine_prompts(
                             msg = obj.get("message", {})
                             if not isinstance(msg, dict):
                                 continue
+                            if msg.get("role", "user") != "user":
+                                continue
                             content = msg.get("content", "")
                             text = extract_text_from_content(content)
                             ts = obj.get("timestamp")
 
-                        # Codex/Gemini format
+                        # Current Codex response_item records carry the role in payload.
+                        elif obj.get("type") == "response_item":
+                            payload = obj.get("payload", {})
+                            if not isinstance(payload, dict) or payload.get("role") != "user":
+                                continue
+                            if payload.get("type") != "message":
+                                continue
+                            text = extract_text_from_content(payload.get("content", ""))
+                            ts = obj.get("timestamp")
+
+                        # Flat Codex/Gemini format
                         elif obj.get("role") == "user" and "content" in obj:
                             text = extract_text_from_content(obj["content"])
                             ts = obj.get("timestamp") or obj.get("created_at")
@@ -200,7 +209,7 @@ def find_repeated_prompts(
                 "first_seen": data["first_seen"].isoformat() if data["first_seen"] else None,
                 "last_seen": data["last_seen"].isoformat() if data["last_seen"] else None,
                 "example_paths": data["paths"],
-                "is_ritual": data["count"] >= 10
+                "outcome": "unassessed"
             })
 
     results.sort(key=lambda x: -x["count"])
@@ -260,7 +269,7 @@ Examples:
     parser.add_argument(
         "--rituals-only",
         action="store_true",
-        help="Only show ritual prompts (10+ occurrences)"
+        help="Legacy alias for --min-count 10; recurrence does not establish success"
     )
 
     args = parser.parse_args()
@@ -305,12 +314,11 @@ Examples:
             "repeated_prompts": repeated
         }, indent=2, default=str))
     else:
-        print(f"\nTop {len(repeated)} repeated prompts (count >= {min_count}):\n")
+        print(f"\nTop {len(repeated)} recurring candidates (count >= {min_count}; outcomes unassessed):\n")
         for item in repeated:
-            ritual_marker = " [RITUAL]" if item["is_ritual"] else ""
             display = truncate(item["prompt"], 100)
             agents = ", ".join(item["agents"])
-            print(f"{item['count']:3d}x ({agents}){ritual_marker}: {display}")
+            print(f"{item['count']:3d}x ({agents}): {display}")
 
 
 if __name__ == "__main__":

--- a/skills-codex/cass/scripts/quick_analysis.sh
+++ b/skills-codex/cass/scripts/quick_analysis.sh
@@ -7,31 +7,12 @@
 #
 # Output:
 #     - Index health
-#     - Session counts by agent
+#     - Indexed hits by agent
 #     - Activity by date
-#     - Top 5 ritual opener candidates
 #
-# Requires: cass, jq
+# Read-only. Requires: cass, jq, GNU timeout (or gtimeout).
 
 set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROMPT_MINER="$SCRIPT_DIR/prompt_miner.py"
-
-# Bound `cass index` so a hung or contended rebuild can't stall this overview
-# (SKILL.md doctrine: cass index can hang; always wall-clock cap it). Prefer GNU
-# timeout, fall back to gtimeout (macOS coreutils), else run uncapped with a
-# warning rather than failing outright.
-run_cass_index() {
-  if command -v timeout >/dev/null 2>&1; then
-    timeout 600 cass index --json
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout 600 cass index --json
-  else
-    echo "warning: 'timeout' not found; running cass index uncapped" >&2
-    cass index --json
-  fi
-}
 
 WORKSPACE="${1:-}"
 
@@ -57,6 +38,25 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
+if command -v timeout >/dev/null 2>&1; then
+    CASS_TIMEOUT=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+    CASS_TIMEOUT=gtimeout
+else
+    echo "Error: GNU timeout or gtimeout is required for bounded reads" >&2
+    exit 1
+fi
+
+failed=0
+read_cass() {
+    local rc
+    "$CASS_TIMEOUT" 15 cass "$@" || {
+        rc=$?
+        echo "CASS observation unavailable (exit $rc): $1" >&2
+        return "$rc"
+    }
+}
+
 echo "=============================================="
 echo "CASS QUICK ANALYSIS: $WORKSPACE"
 echo "=============================================="
@@ -64,54 +64,35 @@ echo ""
 
 # 1. Health check
 echo "--- Index Health ---"
-cass status --robot-format json 2>/dev/null | jq '{
+read_cass status --robot-format json | jq -e '{
     conversations: .database.conversations,
     messages: .database.messages,
     index_fresh: .index.fresh,
     rebuilding: (.index.rebuilding // .rebuild.active // false),
     recommended: .recommended_action
-}' 2>/dev/null || echo "Error: Could not get cass status"
+}' || { echo "Index state unavailable; no recovery attempted" >&2; failed=1; }
 echo ""
 
-# 2. Refresh index (quick, incremental)
-echo "--- Refreshing Index ---"
-run_cass_index 2>/dev/null | jq '.indexed // "Index refreshed"' -r 2>/dev/null || echo "Index refresh attempted"
+# 2. Agent breakdown (aggregation counts are hits, not distinct sessions)
+echo "--- Indexed Hits by Agent ---"
+read_cass search "*" --workspace "$WORKSPACE" --mode lexical --aggregate agent --limit 1 --fields minimal --json \
+    | jq -r '.aggregations.agent.buckets[] | "\(.key): \(.count) hits"' \
+    || { echo "Agent counts unavailable" >&2; failed=1; }
 echo ""
 
-# 3. Agent breakdown
-echo "--- Sessions by Agent ---"
-cass search "*" --workspace "$WORKSPACE" --aggregate agent --limit 1 --json 2>/dev/null \
-    | jq '.aggregations.agent.buckets[] | "\(.key): \(.count) sessions"' -r 2>/dev/null \
-    || echo "No sessions found for this workspace"
-echo ""
-
-# 4. Date breakdown (last 7 days of activity)
+# 3. Date breakdown (last 7 days of activity)
 echo "--- Recent Activity (by date) ---"
-cass search "*" --workspace "$WORKSPACE" --aggregate date --limit 1 --json 2>/dev/null \
-    | jq '.aggregations.date.buckets | sort_by(.key) | reverse | .[0:7] | .[] | "\(.key): \(.count) hits"' -r 2>/dev/null \
-    || echo "No date information available"
+read_cass search "*" --workspace "$WORKSPACE" --mode lexical --aggregate date --limit 1 --fields minimal --json \
+    | jq -r '.aggregations.date.buckets | sort_by(.key) | reverse | .[0:7] | .[] | "\(.key): \(.count) hits"' \
+    || { echo "Date counts unavailable" >&2; failed=1; }
 echo ""
 
-# 5. Ritual opener candidates (prompts at lines 1-3 that appear multiple times)
-echo "--- Ritual Opener Candidates ---"
-echo "(Prompts appearing at session start, sorted by frequency)"
-echo ""
-
-# Search for common ritual opener patterns
-for pattern in "First read ALL" "AGENTS.md" "comprehensive deep dive" "ultrathink" "think super hard"; do
-    count=$(cass search "$pattern" --workspace "$WORKSPACE" --json --limit 100 2>/dev/null \
-        | jq '.total_matches // 0' 2>/dev/null || echo "0")
-    if [ "$count" -gt 2 ]; then
-        printf "  %3dx: \"%s\"\n" "$count" "$pattern"
-    fi
-done
-echo ""
-
-# 6. Quick tips
+# 4. Quick tips
 echo "--- Next Steps ---"
-echo "1. Find ritual opener:    cass search \"First read ALL\" --workspace $WORKSPACE --json --limit 5"
-echo "2. View a session:        cass view /path/to/session.jsonl -n 1 -C 10"
-echo "3. Find user prompts:     cass search \"KEYWORD\" --workspace $WORKSPACE --json | jq '[.hits[] | select(.line_number <= 3)]'"
-echo "4. Mine all prompts:      python \"$PROMPT_MINER\" --workspace $WORKSPACE"
+echo "Search a task-relevant keyword with an explicit workspace, limit and time cap."
+echo "Use cass pack/view/expand for cited excerpts; verify user roles in native records."
+echo "Repetition is a candidate signal, not evidence that an approach worked."
+echo "Empty aggregates describe this indexed workspace only; failed reads are unavailable."
 echo ""
 echo "=============================================="
+exit "$failed"

--- a/skills-codex/cass/scripts/recover.sh
+++ b/skills-codex/cass/scripts/recover.sh
@@ -47,11 +47,19 @@ cass_state() {
     return 2
   fi
   printf '%s' "$out" \
-    | jq -er 'select(type == "object" and (.index | type == "object") and (.database | type == "object")) | [
-        (.index.fresh // false),
-        (.database.exists // false),
-        (.index.documents // 0),
-        (.database.messages // 0),
+    | jq -er 'select(
+        type == "object"
+        and (.index | type == "object")
+        and (.database | type == "object")
+        and (.index.fresh | type == "boolean")
+        and (.database.exists | type == "boolean")
+        and (.index.documents | type == "number" and . >= 0 and floor == .)
+        and (.database.messages | type == "number" and . >= 0 and floor == .)
+      ) | [
+        .index.fresh,
+        .database.exists,
+        .index.documents,
+        .database.messages,
         (.recommended_action // "")
       ] | @tsv' 2>/dev/null \
     || return 2

--- a/skills-codex/cass/scripts/recover.sh
+++ b/skills-codex/cass/scripts/recover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# recover.sh — autonomous cass recovery, no user prompt required
+# recover.sh — selected authorized cass recovery
 #
 # Decision tree:
 #   1) If healthy: exit 0
@@ -7,9 +7,10 @@
 #   3) If broken: doctor --fix, then verify
 #   4) If still broken after fix: print actionable diagnostic and exit 1
 #
-# Used by: PreToolUse hooks before cass search; cron pre-flight; agent loops.
+# Invoke only for a diagnosed recovery/refresh need with indexing authorized.
+# Search-only requests do not need this helper.
 #
-# Safe by default. Never touches source session files.
+# Preserves source session files; may refresh or rebuild derived index state.
 
 set -uo pipefail
 # NOT -e: a non-zero exit from cass/jq is informational, not fatal — we want
@@ -39,26 +40,25 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 cass_state() {
-  # Always emits 5 tab-separated values, even when cass times out or returns garbage.
+  # Unobserved state must not be converted into an empty/corrupt database.
   local out
-  out=$(timeout "$STATUS_TIMEOUT" cass status --json 2>/dev/null) || out=""
+  out=$(timeout "$STATUS_TIMEOUT" cass status --json 2>/dev/null) || return 2
   if [ -z "$out" ]; then
-    printf 'false\tfalse\t0\t0\t\n'
-    return
+    return 2
   fi
   printf '%s' "$out" \
-    | jq -r '[
+    | jq -er 'select(type == "object" and (.index | type == "object") and (.database | type == "object")) | [
         (.index.fresh // false),
         (.database.exists // false),
         (.index.documents // 0),
         (.database.messages // 0),
         (.recommended_action // "")
       ] | @tsv' 2>/dev/null \
-    || printf 'false\tfalse\t0\t0\t\n'
+    || return 2
 }
 
 # Read state once. Use || true so an empty stream doesn't trip downstream.
-state_line=$(cass_state)
+state_line=$(cass_state) || { echo "UNAVAILABLE: index state not observed; no repair attempted" >&2; exit 2; }
 IFS=$'\t' read -r FRESH DB_EXISTS DOCS MSGS REC <<< "$state_line" || true
 FRESH=${FRESH:-false}
 DB_EXISTS=${DB_EXISTS:-false}
@@ -102,7 +102,7 @@ else
 fi
 
 # Verify
-state_line=$(cass_state)
+state_line=$(cass_state) || { echo "UNAVAILABLE: state after doctor not observed; no further repair attempted" >&2; exit 2; }
 IFS=$'\t' read -r FRESH DB_EXISTS DOCS MSGS REC <<< "$state_line" || true
 
 if [ "${DB_EXISTS:-false}" = "true" ] && [ "${DOCS:-0}" != "0" ]; then
@@ -124,7 +124,7 @@ esac
 
 # Even on exit 0 the JSON may report success:false (the last_indexed_at race
 # documented in coding_agent_session_search-zz8ni). Always verify by re-reading state.
-state_line=$(cass_state)
+state_line=$(cass_state) || { echo "UNAVAILABLE: state after rebuild not observed" >&2; exit 2; }
 IFS=$'\t' read -r FRESH DB_EXISTS DOCS MSGS REC <<< "$state_line" || true
 if [ "${DB_EXISTS:-false}" = "true" ] && [ "${DOCS:-0}" != "0" ]; then
   echo "RECOVERED: index is queryable (fresh marker may still be stale; that's harmless)" >&2

--- a/skills-codex/cass/skill.spec.json
+++ b/skills-codex/cass/skill.spec.json
@@ -5,8 +5,8 @@
   "quality_score": 0.95,
   "sections": [
     { "id": "title",       "title": "cass Session Search",                  "type": "intro",     "priority": "required" },
-    { "id": "goldmine",    "title": "The Goldmine Principle",               "type": "overview",  "priority": "required" },
-    { "id": "discovery",   "title": "THE EXACT PROMPT — Discovery Workflow", "type": "procedure", "priority": "required" },
+    { "id": "history",     "title": "History as Evidence",               "type": "overview",  "priority": "required" },
+    { "id": "discovery",   "title": "Discovery Workflow", "type": "procedure", "priority": "required" },
     { "id": "versionpin",  "title": "Version Pinning Caveat",               "type": "constraints", "priority": "required" },
     { "id": "bootstrap",   "title": "Two-Step Bootstrap",                   "type": "procedure", "priority": "required" },
     { "id": "recovery",    "title": "Stuck-Index & Recovery Decision Tree", "type": "procedure", "priority": "required" },
@@ -25,7 +25,7 @@
   ],
   "references": [
     { "file": "references/COMMANDS.md",            "topic": "complete cass command reference" },
-    { "file": "references/RECOVERY.md",            "topic": "stuck-index recovery and no-permission repair moves" },
+    { "file": "references/RECOVERY.md",            "topic": "bounded authorized recovery for diagnosed index problems" },
     { "file": "references/SEMANTIC_AND_HYBRID.md", "topic": "enabling semantic / hybrid search modes" },
     { "file": "references/REMOTE_SOURCES.md",      "topic": "cross-machine corpus and configured sources" },
     { "file": "references/ANTI_PATTERNS.md",       "topic": "search anti-patterns to avoid" },
@@ -65,7 +65,7 @@
       "full": 5200
     }
   },
-  "output_contract": "Search hits over past agent sessions (prompts, decisions, patterns) via `cass search`, a `cass status`/index-health report, JSON/aggregation output for parsing, or a resume command for a matched session. Index operations are wall-clock-capped so the bootstrap never blocks.",
+  "output_contract": "Search hits over past agent sessions (prompts, decisions, patterns) via `cass search`, a `cass status`/index-health report, JSON/aggregation output for parsing, or a resume command for a matched session. Retrieval is bounded; index recovery is optional, selected and authorized.",
   "evidence": {
     "sources": [
       "skills/cass/SKILL.md",

--- a/skills-codex/ms/.agentops-generated.json
+++ b/skills-codex/ms/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/ms",
   "layout": "modular",
-  "source_hash": "8634a28c128d80d574da339747315ed4af5e047081c20d7647f69d08f7c88e71",
-  "generated_hash": "004f0940e893cf08447b3327c332d8beab5c78bb14e30a3cdc8ff72b01a0edee"
+  "source_hash": "2bb8f7245062980ea8fae4d89f6b2d0d61abd7f1f16b7841ce40d7a2ecb73157",
+  "generated_hash": "f2d55ab48b5a296af30a3928c39e4678f69b3804775a1c2cfe86a59cfcc084a5"
 }

--- a/skills-codex/ms/SKILL.md
+++ b/skills-codex/ms/SKILL.md
@@ -18,6 +18,26 @@ description: 'meta_skill (ms) — the skill-search/load engine over both corpora
 - Keep `ms` retrieval-only for production skill work. It returns search and load
   results; the caller owns authoring, validation, and every subsequent decision.
 
+## Session evidence and instruction changes
+
+For a requested instruction-improvement task, use CASS to discover relevant
+episodes and `ms` to find existing guidance that could explain the behavior or
+already address it. Load only the relevant skills, then inspect their canonical
+source before proposing an edit. An `AGENTS.md` or task-prompt change does not
+require inventing a skill or loading an unrelated one.
+
+Upstream MS also offers `build --from-cass`; this adapter deliberately does not
+invoke that authoring path. Inspect `ms build --help` if the caller selects it
+separately. A generated skill, search rank,
+repeated prompt, or recorded outcome is not proof of downstream improvement.
+
+CASS search/pack supplies candidate evidence. Use AO's bounded excerpt view only
+when the investigation needs exact raw spans, literal fields or instruction
+identity that the selected CASS output does not establish. These are optional
+capabilities, not a required sequence on every task. The caller owns a supported
+candidate edit or no-change judgment, independent review and later usefulness
+testing; retrieval never awards that outcome itself.
+
 ## Quick Start
 
 Find a skill (MCP-primary — BM25, currently strictly better than CLI search), then load the FULL runnable SKILL.md in one call (always `full: true` when you mean to use it):

--- a/skills/cass/SELF-TEST.md
+++ b/skills/cass/SELF-TEST.md
@@ -98,7 +98,7 @@ ls -la .claude/skills/cass/scripts/
 ```bash
 # Verify cass is working
 cass status --json | jq '.index.fresh'
-# Should return: true
+# Fresh or stale-but-usable permits search; retain the observed state.
 
 # Test the core workflow
 cass search "*" --workspace /data/projects/YOUR_PROJECT --aggregate agent,date --limit 1 --json
@@ -110,11 +110,11 @@ cass search "*" --workspace /data/projects/YOUR_PROJECT --aggregate agent,date -
 
 When triggered, the skill should:
 
-1. **Bootstrap** — Check health, refresh index
-2. **Provide THE EXACT PROMPT** — The discovery workflow
+1. **Check readiness when needed** — Search a healthy or stale-but-usable index without routine refresh
+2. **Bound the question** — History retrieval resolves a concrete uncertainty; ordinary work needs no history step
 3. **Use token-efficient flags** — `--fields minimal`, `--limit N`
-4. **Filter user prompts** — `jq select(.line_number <= 3)`
-5. **Follow the loop** — Search → Follow source_path → Expand/Export
+4. **Verify native roles** — Early metadata/assistant records are excluded; late user records remain candidates
+5. **Follow evidence** — Search → Pack → View/Expand; verify returned locations, report omissions, and treat recurrence as a candidate signal
 
 ---
 
@@ -124,5 +124,5 @@ When triggered, the skill should:
 |---------|-------|-----|
 | Skill doesn't trigger | Vague user query | Use explicit phrases like "search sessions", "mine prompts" |
 | 0 results | Workspace path mismatch | Use `--aggregate workspace` to discover exact path |
-| Stale results | Index not refreshed | Run `cass index --json` |
+| Stale results | Recent records may be absent | Search usable state now; refresh only if needed and authorized, within a cap |
 | Export panics | Piped output | Always use `-o /tmp/out.json` |

--- a/skills/cass/SKILL.md
+++ b/skills/cass/SKILL.md
@@ -26,7 +26,7 @@ metadata:
 ---
 # cass Session Search
 
-> **Core Insight:** Your repeated prompts are your best prompts. If you typed it 10+ times, it works. Mine your history.
+> **Core Insight:** Recurring prompts identify candidates to investigate. Repetition can reflect success, repeated failure, copied instructions or retries; check the surrounding evidence before reuse.
 
 `cass` is an upstream (Dicklesworthstone) tool and is **self-describing** — do not re-learn its surface from this skill. Discover it live:
 
@@ -83,39 +83,38 @@ later coverage verification; this skill does not implement or certify it.
   distinguishes `cass resume` (same-harness command resolution) from the separate
   cross-harness converter. `cass context` discovers candidate relations; verify
   a native parent link before choosing a parent session to resume.
-- **`cass-memory` → `cm` procedural memory.** Use when starting non-trivial work, mining lessons, or preventing repeated mistakes with cm procedural memory — mine past sessions here first, then promote the durable lessons through `cm` instead of re-deriving them each session.
+- **`cass-memory` → `cm` procedural memory.** When procedural-memory retrieval is relevant, use the caller-selected memory source. CASS can supply episode evidence for a concrete uncertainty; retrieval does not authorize promoting a lesson or changing instructions.
 
-## The Goldmine Principle
+## History as Evidence
 
 Your conversation history contains:
-- **Refined prompts** — Every rephrase that worked better was captured
-- **Working rituals** — Prompts repeated 10+ times ARE your methodology
+- **Prompt revisions** — Compare what changed and what happened afterward
+- **Recurring prompts** — Investigate repetition without assuming effectiveness
 - **Scope decisions** — "When did we decide NOT to do X?"
 - **Recovery moments** — What you searched for after context loss = what mattered
 
-**The insight:** Mining your past beats inventing new approaches. CASS is a context source in the federated graph: it supplies cited episodic evidence on demand — mine as a research-phase move before writing a fresh plan or prompt. What it returns is evidence with source identity and freshness, never policy, and AgentOps maintains no merged corpus of its own around it.
+Native execution remains the default. Use CASS when a prior decision or episode could resolve a concrete uncertainty, or when the caller requests history. It supplies cited episodic evidence on demand, never policy; AgentOps maintains no merged corpus around it. Routine work needs no mining pre-step.
 
-## History-First Routing
+## Bounded History Routing
 
-Before deriving a plan, prompt, or approach from scratch, run one bounded
-search of past sessions (one query family, `--fields minimal`, a real
-`--limit`, under a minute of wall clock). Three outcomes, each with its own
-routing:
+When history is relevant, select a bounded search (for example one query
+family, `--fields minimal`, a real `--limit`, under a minute of wall clock).
+Three outcomes have different implications:
 
-- **Direct hit** — a prior session solved this. Reuse its prompt or decision;
+- **Direct hit** — a prior session addresses this. Inspect the user intent,
+  action, observed result and corrections before deciding whether to reuse it;
   cite `source_path` and line in whatever you build on it.
-- **Adjacent hit** — prior work borders the problem. Extract the working
-  fragments, then derive only the missing part fresh.
+- **Adjacent hit** — prior work borders the problem. Check which fragments
+  still apply and derive the missing part from current evidence.
 - **Bounded no-match** — zero hits after retrying against authorized discovered
   workspace keys (`--aggregate workspace`). Derive from available evidence and
   report the query/index limits; this does not establish global absence.
 
-The named failure mode is re-derivation drift: solving the same problem
-slightly differently each session, so the corpus accumulates near-duplicate
-approaches and no single one ever hardens into a ritual. Stop condition for
-the history pass itself: one query family exhausted or a direct hit found —
-history search is a bounded pre-step, not an open-ended excavation that
-displaces the actual task.
+Stop when the chosen query family or budget is exhausted, or enough evidence
+answers the uncertainty. An unresolved search need not displace the actual
+task. A direct hit, recurrence count or saved lesson does not prove success;
+consider a competing explanation or counterexample and name what later task
+evidence would show that reuse helped.
 
 ## Lesson Weighting: Decay and Failure Overweight
 
@@ -137,28 +136,50 @@ Mined lessons are evidence with a shelf life, not doctrine:
   hit showing the approach failing in circumstances like yours outranks three
   hits showing it succeeding elsewhere.
 
-## THE EXACT PROMPT — Discovery Workflow
+## Discovery Workflow
 
 ```
-1. Bootstrap: Check health, refresh index, get project overview
-   cass status --json && cass index --json
-   cass search "*" --workspace /data/projects/PROJECT --aggregate agent,date --limit 1 --json
+1. Observe index state if needed; healthy or stale-but-usable means search now
+   timeout 15 cass status --json
 
-2. Find prompts: Search for keywords, filter to user prompts (lines 1-3)
-   cass search "KEYWORD" --workspace /data/projects/PROJECT --json --fields minimal --limit 50 \
-     | jq '[.hits[] | select(.line_number <= 3)]'
+2. Discover bounded candidates with the installed CASS search surface
+   timeout 30 cass search "KEYWORD" --workspace /data/projects/PROJECT \
+     --mode lexical --json --fields minimal --limit 20
 
-3. Follow authorized hits: View a bounded excerpt of the actual content
-   cass view /path/from/source_path.jsonl -n LINE -C 20
+3. Request cited excerpts using CASS pack (check cass pack --help for support)
+   timeout 30 cass pack "KEYWORD" --workspace /data/projects/PROJECT \
+     --mode lexical --json --limit 20 --max-sessions 3 --max-evidence 6 \
+     --context-lines 3 --max-excerpt-chars 1600 --max-tokens 4000
 
-4. Expand context: Inspect another bounded conversation window
-   cass expand /path/from/source_path.jsonl --line LINE --context 3
+4. Follow a selected authorized hit to verify role, intent and outcome
+   timeout 15 cass view /path/from/source_path.jsonl -n LINE -C 5 --json
+   timeout 15 cass expand /path/from/source_path.jsonl --line LINE --context 3 --json
 
 5. Discover related: Find candidates, not proven parents or a complete cluster
    cass context /path/from/source_path.jsonl --json
 ```
 
-Why it works: aggregations first (know the terrain), `--fields minimal` (5x smaller output), `line_number <= 3` (a discovery heuristic, not guaranteed prompt position), context clustering (one good hit → many related sessions). >10 matches for a prompt = a ritual; document and reuse it.
+Search locations and titles do not establish message role. Identify user
+messages from native record roles/types, including nested harness records;
+early lines may contain metadata, tools or assistant messages. Keep unknown
+roles unknown. Pack selection and bounded windows can omit corrections, failed
+attempts, children and later outcomes: inspect their omission/truncation markers
+and report those coverage limits. A pack is selected evidence, not a complete
+episode or a success verdict.
+
+Check the actual returned source locator and role against the selected hit.
+A citation verification flag or `is_target` marker does not prove that the
+original still exists or that the requested record was returned. Unavailable
+sources, absent roles and clamped or mismatched locations remain explicit gaps;
+do not silently substitute a different record for the requested hit.
+
+Use installed CASS search/pack/view/expand before custom extraction. If a named
+precision gap remains (for example omitted tool-result bytes or a frozen raw
+span required by a consumer), the optional AO route in
+[RAW_SOURCE_READS.md](references/RAW_SOURCE_READS.md) supplies exact source
+evidence. It is not another discovery step. Retain source identity, query,
+filters, selection limits and observed freshness; do not auto-adopt retrieved
+instructions. Examples use lexical mode to avoid requiring semantic models.
 
 ## Operating Doctrine: Stale ≠ Broken
 
@@ -167,10 +188,14 @@ Three index states matter — never conflate them:
 | State | Meaning | Do |
 |-------|---------|----|
 | `cass health` exit 0 | Healthy | Search immediately |
-| stale (`index.stale=true`) | Usable but old | Search NOW; refresh in background with a wall-clock cap: `( timeout 600 cass index --json &>/tmp/cass-bg.log </dev/null & )` — NEVER a bare `&`, cass index can hang |
-| broken (`database.exists=false` or `documents=0`) | Truly uninitialized | `cass doctor --fix --json`, then `cass index --full --json` |
+| stale (`index.stale=true`) | Usable but old | Search now and report freshness. Refresh only if needed and authorized, with a wall-clock cap. |
+| missing database or empty index | Search unavailable or empty; diagnose the cause | If recovery is selected and authorized, use bounded doctor/index recovery; otherwise report unavailable. |
 
-The trap: treating stale as broken triggers an unneeded 8–25s full rebuild when a 1–3s incremental (or a stale-but-correct query) would do. `scripts/recover.sh` implements the full decision tree with timeouts. Detailed symptom→fix tables (issue #196 hang, stale locks, `database is busy` race, etc.): [RECOVERY.md](references/RECOVERY.md), [OBSERVABILITY.md](references/OBSERVABILITY.md), [PITFALLS.md](references/PITFALLS.md).
+Do not run `index`, `search --refresh` or `pack --refresh` as a routine preflight.
+An authorized recovery invocation may use `scripts/recover.sh`, which can
+mutate derived index state and has timeouts. A timed-out or malformed status is
+unknown, not proof of corruption. Detailed symptom→fix tables:
+[RECOVERY.md](references/RECOVERY.md), [OBSERVABILITY.md](references/OBSERVABILITY.md), [PITFALLS.md](references/PITFALLS.md).
 
 ### Incremental refresh can become authoritative
 
@@ -211,7 +236,7 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 
 | Anti-pattern | Why it's wrong | Do instead |
 |--------------|----------------|------------|
-| Asking the user "should I rebuild the index?" | They have agents waiting; rebuild is safe and idempotent | Just run `cass doctor --fix --json` (preserves source data) |
+| Rebuilding during a search-only request | Derived-state repair still has scope and cost | Search a usable index; recover only when needed and already authorized |
 | Running `cass index --full` whenever `status` says unhealthy | A 25s rebuild for a 30-min stale index is wasteful | Check `index.stale` separately from `database.exists`; prefer incremental |
 | Running bare `cass` to "see what's there" | Launches blocking TUI in the agent's session | Always `--json` or `--robot`; never bare |
 | Piping `cass export` into `head`/`jq` | Broken-pipe panic on large sessions | `cass export ... -o /tmp/x.json` first, then operate on the file |
@@ -220,15 +245,19 @@ cass evolves quickly; the released binary may lack HEAD features. When a flag re
 | Trusting 0 hits with `--workspace /X` | Workspace strings are case- and trailing-slash-sensitive | Re-run with `--aggregate workspace --limit 1` to discover the canonical key |
 | Skipping `--fields minimal` on wide scans | ~3KB per hit × 100 hits = 300KB context burn | `--fields minimal` for wide passes; upgrade to `summary`/`full` for keepers |
 | Reading session files with `cat` | Loads the full conversation into context | `cass view PATH -n LINE -C 5` or `cass expand PATH --line LINE --context 3` |
-| Re-indexing on every search | Index is shared across processes | Refresh only when `status` says stale |
+| Re-indexing on every search | Index is shared across processes | Staleness alone does not require refresh; use a bounded authorized recovery when needed |
 | Treating a timed-out search during rebuild as 0 hits | Concurrent reads may exceed normal latency while an authoritative rebuild holds shared resources | Preserve exit 124 as "not observed" and retry once the active rebuild settles |
-| Falling back to manual `find`/`grep` when cass misbehaves | Recovery is autonomous; skipping cass loses the corpus | Walk the recovery tree in [RECOVERY.md](references/RECOVERY.md). One real exception: terms inside tool stdout/stderr are skipped at index time — there `rg -n "TERM" /path.jsonl` is correct |
+| Building custom extraction before using CASS | Duplicates discovery and loses native selection/coverage facts | Use search/pack/view/expand first; a demonstrated exact-source gap may justify bounded authorized raw reads |
 
 Long-form versions with mined evidence: [ANTI_PATTERNS.md](references/ANTI_PATTERNS.md).
 
 ## Safety Boundaries
 
-Within the authorized source/model/destination and egress envelope above, the following operate on derived state rather than granting new source access: `cass doctor --fix --json`, `cass index --full --force-rebuild --json`, `cass sources doctor/sync`, `cass models install/verify`.
+Recovery commands such as `cass doctor --fix --json` and `cass index` mutate
+derived state. Their use requires a selected recovery/refresh need within the
+authorized source/model/destination envelope. Source sync copies sessions and
+model installation downloads files; each additionally requires its own scope
+and egress authorization. A search request does not select these operations.
 
 Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.beads/`, `git reset --hard`, or hand-edit `~/.config/cass/sources.toml` — the CLI commands above already do everything safely. Never run bare `cass` (blocking TUI) inside an agent loop.
 
@@ -246,8 +275,8 @@ Do NOT without explicit permission: delete `core.NNNNN` coredumps, delete `.bead
 | Semantic / hybrid / models | [SEMANTIC_AND_HYBRID.md](references/SEMANTIC_AND_HYBRID.md) |
 | Token / tool / model analytics | [ANALYTICS.md](references/ANALYTICS.md) |
 | Cross-harness session resume | [RESUME.md](references/RESUME.md) |
-| Doctor + autonomous recovery | [RECOVERY.md](references/RECOVERY.md) |
-| Mined gold-standard prompts | [PROMPTS.md](references/PROMPTS.md) |
+| Bounded authorized recovery | [RECOVERY.md](references/RECOVERY.md) |
+| Example discovery prompts | [PROMPTS.md](references/PROMPTS.md) |
 | Anti-patterns (long form) | [ANTI_PATTERNS.md](references/ANTI_PATTERNS.md) |
 | Health vs status vs index nuance | [OBSERVABILITY.md](references/OBSERVABILITY.md) |
 | Pages encrypted archive + HTML export | [PAGES_AND_EXPORT.md](references/PAGES_AND_EXPORT.md) |
@@ -258,26 +287,31 @@ When the right reference isn't obvious from titles, `grep -ni "SYMPTOM" referenc
 
 ## Scripts
 
-Scripts live under `scripts/`. Inspect their access and write scope before use when uncertain. Consistent with the Safety Boundaries above, `recover.sh` and `quick_analysis.sh` may rebuild **derived index state** autonomously (pre-authorized: `doctor --fix`, `index --full`) and `multi_machine_search.sh` reads remote sources over ssh; none destroy source sessions, and nothing destructive (coredump/`.beads` deletion, `git reset --hard`, source edits) runs without explicit confirmation.
+Scripts live under `scripts/`. Inspect their access and write scope before use.
+`quick_analysis.sh` is read-only; `recover.sh` is an optional explicitly selected
+recovery helper that can rebuild derived state. `multi_machine_search.sh` reads
+remote sources over ssh and needs the corresponding authorization. The legacy
+prompt miner reads native files directly and is not the default discovery path;
+use it only for a selected authorized recurrence-counting need that CASS does
+not satisfy. Its counts do not establish effectiveness or full episode coverage.
 
 | Script | Usage |
 |--------|-------|
-| `./scripts/quick_analysis.sh /path` | One-command project overview (status → aggregate agent/date → top prompts) |
-| `./scripts/prompt_miner.py --workspace /path` | Find repeated prompts (ritual detection) |
+| `./scripts/quick_analysis.sh /path` | Bounded read-only overview (status → aggregate agent/date) |
+| `./scripts/prompt_miner.py --glob /authorized/selection/*.jsonl` | Legacy recurrence counts over selected native files; outcomes remain unassessed |
 | `./scripts/validate.sh` | Validate cass install + skill structure |
-| `./scripts/recover.sh` | Autonomous recovery decision tree (READY → STALE_BUT_USABLE → BROKEN); wraps every `cass index` in `timeout` |
+| `./scripts/recover.sh` | Selected authorized recovery (READY → STALE_BUT_USABLE → BROKEN); wraps every `cass index` in `timeout` |
 | `./scripts/multi_machine_search.sh "QUERY" [host…]` | Parallel fan-out across the fleet; merges + dedups hits |
 
 ## Validation
 
 ```bash
-# Quick health check
-cass status --json | jq '.index.fresh'
-
-# Should return: true
+# Observe state; a stale usable index can still serve the task
+timeout 15 cass status --json
 ```
 
-If `false`, run: `cass index --json`
+Retain the exit status. Failure or timeout is an unavailable observation, not
+zero hits. Refresh is optional and subject to the operating doctrine above.
 
 ## Output Specification
 

--- a/skills/cass/references/ANTI_PATTERNS.md
+++ b/skills/cass/references/ANTI_PATTERNS.md
@@ -25,16 +25,14 @@
 **Bad:**
 > "Your cass index is stale. Could you run `cass index --full` and let me know when it's done?"
 
-**Why bad:** The user has 22 agents waiting. Every "could you" multiplies their interrupt cost.
+**Why bad:** Delegating an already authorized repair back to the user creates
+unnecessary work. But staleness alone does not require repair.
 
-**Instead:**
-```bash
-cass doctor --fix --json   # safe by default; preserves all source data
-cass index --json &        # background refresh while you proceed
-```
-Then proceed and mention the rebuild ran in passing.
-
-**Authorization scope:** Anything under `~/.local/share/coding-agent-search/` is yours to manage. Source session files (`~/.claude/projects/`, `~/.codex/sessions/`) are NOT — those are user data.
+**Instead:** Search healthy or stale-but-usable state immediately. If a concrete
+recovery need is already authorized, use the bounded helper in
+[RECOVERY.md](RECOVERY.md). Do not infer mutation authority from a search-only
+request or from where the derived index lives. Sources, metadata, destinations
+and model access retain their authorization boundaries.
 
 ---
 
@@ -63,20 +61,11 @@ cass doctor --fix --json   # rebuilds only what's broken
 
 **Why bad:** The index is stale only because it's older than the threshold (default 30 min). The data is still **correct** — it just doesn't have sessions from the last 30 min indexed yet.
 
-**Instead:**
-```bash
-state=$(cass status --json | jq -r '.index | "\(.fresh)/\(.stale)/\(.documents // "N")"')
-case "$state" in
-  true/*)        echo "fresh — search now" ;;
-  false/true/*)  echo "stale but usable"
-                 # ALWAYS wrap bg cass index in `timeout` — without it, a hung
-                 # rebuild silently strands forever. See scripts/recover.sh.
-                 ( timeout 600 cass index --json >/tmp/cass-bg.$$.log 2>&1 </dev/null & ) 2>/dev/null ;;
-  */*/0|*null)   echo "broken" && timeout 60 cass doctor --fix --json ;;
-esac
-```
-
-The agent's first search returns immediately on the still-correct stale index. The background `cass index` finishes in 1–3s for incremental refreshes.
+**Instead:** Search the usable index and retain observed freshness. Refresh only
+when the task needs newer records and its indexing scope is authorized, using
+a bounded invocation from [RECOVERY.md](RECOVERY.md). Do not start a second
+indexer while an earlier authorized rebuild is progressing. A failed status
+read is unknown, not evidence that the index is empty or corrupt.
 
 ---
 
@@ -152,13 +141,11 @@ Use the exact key from the bucket.
 
 **Why bad:** cass deliberately skips large tool outputs at index time to keep the corpus searchable on prompts and replies. Tool outputs are still **in the source file**.
 
-**Instead:**
-```bash
-cass search "near-by user-prompt phrase" --json --fields minimal --limit 10 \
-  | jq -r '.hits[0].source_path' | xargs rg -n "the exact tool output bytes"
-```
-
-Find the session via prompt, then `rg` for the bytes inside.
+**Instead:** Find the episode using a nearby prompt phrase, then use CASS
+pack/view/expand to inspect bounded context. If the actual required tool bytes
+remain omitted, use a selected authorized raw excerpt as described in
+[RAW_SOURCE_READS.md](RAW_SOURCE_READS.md). Missing source files and mismatched
+returned locators remain retrieval gaps; do not bulk-read every search hit.
 
 ---
 
@@ -207,17 +194,16 @@ If `_warning` is non-null, mention it. If `hits_clamped: true`, paginate. If `fa
 
 **Bad:** Pre-flight in a tight loop runs `cass index --full --json` every iteration. 25s × 60 iter = 25 min wasted.
 
-**Instead:**
-```bash
-# Once at startup
-cass status --json | jq -e '.index.fresh' >/dev/null || cass index --json
-
-# Or use watch mode and never refresh inline
-cass index --watch --json &   # one daemon, all agents share the index
-```
+**Instead:** Search immediately when the index is usable. Staleness is a coverage
+limit to report; an authorized bounded refresh is optional when newer records
+are needed. Do not add a startup refresh, watch process or preflight hook to an
+ordinary history query.
 
 ---
 
 ## Summary
 
-The pattern across these anti-patterns: **lack of trust in cass**. Trust the autonomous-recovery commands. Trust the safe-by-default `doctor --fix`. Trust the stale-but-correct lexical index. Trust the server to filter. Then your agent stops bothering the user.
+Use CASS's native retrieval surface, distinguish stale from unavailable, and
+verify selected source context. Recovery is a separate bounded operation within
+the caller's authority; search hits and citation flags do not prove source
+continuity, message roles or successful outcomes.

--- a/skills/cass/references/COMMANDS.md
+++ b/skills/cass/references/COMMANDS.md
@@ -21,8 +21,8 @@
 
 ```bash
 cass status --json              # Health check — is index current?
-cass index --json               # Incremental refresh (fast, use first)
-cass index --full --json        # Full rebuild (when stale)
+timeout 600 cass index --json   # Optional authorized refresh when needed
+timeout 600 cass index --full --json # Selected recovery only; staleness is not enough
 cass capabilities --json        # What this install supports
 cass diag --json                # Detailed diagnostics
 cass doctor                     # Repair (safe, won't delete sources)

--- a/skills/cass/references/PATTERNS.md
+++ b/skills/cass/references/PATTERNS.md
@@ -21,8 +21,8 @@
 
 | Goal | Pattern |
 |------|---------|
-| User prompts (lines 1-5) | `select(.line_number <= 3)` |
-| Subagent sessions | `contains("subagent")` |
+| User prompts | Inspect source record roles; line positions and titles are not roles |
+| Candidate subagent paths | `contains("subagent")`; verify native parent/child metadata |
 | Total match count | `.total_matches` |
 | Safe access with default | `// []` or `// "default"` |
 | Sort descending | `sort_by(-.field)` |
@@ -51,23 +51,24 @@
 | jq '.total_matches'
 ```
 
-### User Prompt Extraction (The Most Important Pattern)
+### User Prompt Extraction
 
-User prompts appear at lines 1-5. Filter by `line_number`:
+Search hits locate candidates; they are not a role filter. Use the returned
+path and line with bounded `cass pack`, `view` or `expand`, then identify the
+role from the actual record. Early lines can be metadata or assistant content,
+and user messages can occur anywhere. Verify that the returned path/line
+matches the requested hit; missing files, absent roles and clamped windows
+remain retrieval gaps.
 
 ```bash
-# Get user prompts only
-| jq '[.hits[] | select(.line_number <= 3)]'
-
-# With formatted output
-| jq '[.hits[] | select(.line_number <= 3)] | .[] | {path: .source_path, line: .line_number, title: .title[0:80]}'
-
-# Just titles (for scanning)
-| jq '[.hits[] | select(.line_number <= 3) | .title]'
-
-# Count user prompts
-| jq '[.hits[] | select(.line_number <= 3)] | length'
+cass search "KEYWORD" --workspace /path --mode lexical --json --fields minimal --limit 20
+cass view /path/from/hit.jsonl -n LINE -C 3 --json
+cass expand /path/from/hit.jsonl --line LINE --context 3 --json
 ```
+
+See [Raw Session File Parsing](#raw-session-file-parsing) for role-based
+examples over an already selected, authorized excerpt. A title count is not a
+count of user prompts.
 
 ### Subagent Session Extraction
 
@@ -78,8 +79,8 @@ User prompts appear at lines 1-5. Filter by `line_number`:
 # Just paths (unique)
 | jq '[.hits[] | select(.source_path | contains("subagent"))] | .[].source_path' -r | sort -u
 
-# User prompts in subagent sessions
-| jq '[.hits[] | select(.source_path | contains("subagent")) | select(.line_number <= 3)]'
+# Candidate locations to inspect for native roles
+| jq '[.hits[] | select(.source_path | contains("subagent")) | {source_path, line_number}]'
 ```
 
 ### Aggregation Parsing
@@ -104,72 +105,74 @@ cass search "*" --workspace /path --aggregate date --limit 1 --json \
 
 ## Pattern Detection
 
-### Find Repeated Prompts (Ritual Detection)
+### Find Recurring Candidate Titles
 
 ```bash
-# Group prompts by title, count, sort by frequency
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | sort_by(-.count) | .[0:20]'
+# Count titles within this limited hit set; retain locations for review.
+cass search "KEYWORD" --workspace /path --json --fields summary --limit 50 \
+  | jq '[.hits[] | {title, source_path, line_number}]
+    | group_by(.title)
+    | map({title: .[0].title, hit_count: length, locations: .})
+    | sort_by(-.hit_count) | .[0:20]'
 ```
 
-### Filter by Count Threshold
-
-```bash
-# Only patterns appearing 5+ times
-| jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | map(select(.count >= 5)) | sort_by(-.count)'
-```
-
-### Check Total Matches (Is It a Ritual?)
-
-```bash
-cass search "First read ALL" --workspace /path --json --limit 100 | jq '.total_matches'
-# > 10 = ritual, document it
-# < 3 = one-off, ignore
-```
+Repeated titles can represent multiple hits in one session, copied text or
+retries. They do not establish distinct prompt counts, user roles or success.
+Inspect a selected candidate's intent, outcome and corrections before reuse.
+Rare failures and scope decisions can matter even when the count is one.
 
 ---
 
 ## Raw Session File Parsing
 
+Prefer CASS pack/view/expand. These examples apply only to an already selected,
+authorized and bounded native excerpt named `excerpt.jsonl`, when a demonstrated
+precision gap requires raw records. Never run them over an entire session by
+default. The [source-format reference](SESSION_FORMATS.md) owns harness details;
+unknown formats remain unknown.
+
 ### Claude Code Format
 
 ```bash
 # Extract user messages
-jq 'select(.type == "user") | .message.content' session.jsonl
+jq 'select(.type == "user") | .message.content' excerpt.jsonl
 
 # Handle content arrays (common)
-jq 'select(.type == "user") | .message.content | if type == "array" then [.[] | select(.type == "text") | .text] | join(" ") else . end' session.jsonl
+jq 'select(.type == "user") | .message.content | if type == "array" then [.[] | select(.type == "text") | .text] | join(" ") else . end' excerpt.jsonl
 
 # With timestamps
-jq 'select(.type == "user") | {ts: .timestamp, content: .message.content}' session.jsonl
+jq 'select(.type == "user") | {ts: .timestamp, content: .message.content}' excerpt.jsonl
 
-# First user prompt only (the ritual opener)
-jq -s '[.[] | select(.type == "user")][0] | .message.content' session.jsonl
+# First user record in this excerpt (not necessarily the session opener)
+jq -s '[.[] | select(.type == "user")][0] | .message.content' excerpt.jsonl
 
 # All user messages sorted
-jq -s '[.[] | select(.type == "user")] | sort_by(.timestamp)' session.jsonl
+jq -s '[.[] | select(.type == "user")] | sort_by(.timestamp)' excerpt.jsonl
 ```
 
-### Codex/Gemini Format
+### Flat Codex/Gemini Format
 
 ```bash
 # Extract user messages
-jq 'select(.role == "user") | .content' session.jsonl
+jq 'select(.role == "user") | .content' excerpt.jsonl
 
 # With timestamp
-jq 'select(.role == "user") | {ts: (.timestamp // .created_at), content}' session.jsonl
+jq 'select(.role == "user") | {ts: (.timestamp // .created_at), content}' excerpt.jsonl
 
 # First user prompt
-jq -s '[.[] | select(.role == "user")][0] | .content' session.jsonl
+jq -s '[.[] | select(.role == "user")][0] | .content' excerpt.jsonl
 ```
 
-### Detect Format and Extract
+### Current Codex Records
 
 ```bash
-# Check format
-head -1 session.jsonl | jq -e '.type == "user"' && echo "claude_code"
-head -1 session.jsonl | jq -e '.role == "user"' && echo "codex"
+jq 'select(.type == "response_item" and .payload.type == "message" and .payload.role == "user")
+  | {ts: .timestamp, content: .payload.content}' excerpt.jsonl
 ```
+
+Inspect record shape before selecting a parser. A metadata record at the start
+cannot determine the role of subsequent messages. Avoid counting both a native
+message and a duplicated event representation as separate user turns.
 
 ---
 
@@ -179,34 +182,32 @@ head -1 session.jsonl | jq -e '.role == "user"' && echo "codex"
 
 ```bash
 # All tool calls
-jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use") | {name, input}' session.jsonl
+jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use") | {name, input}' excerpt.jsonl
 
 # Specific tool (e.g., Write)
-jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use" and .name == "Write")' session.jsonl
+jq 'select(.type == "assistant") | .message.content[] | select(.type == "tool_use" and .name == "Write")' excerpt.jsonl
 
 # Tool results
-jq 'select(.type == "tool_result")' session.jsonl
+jq 'select(.type == "tool_result")' excerpt.jsonl
 
 # Count tool calls by type
-jq -s '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' session.jsonl
+jq -s '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "tool_use") | .name] | group_by(.) | map({tool: .[0], count: length}) | sort_by(-.count)' excerpt.jsonl
 ```
 
 ---
 
 ## Subagent Prompt Extraction
 
-Subagent logs have THE prompt at line 2:
+Use the selected hit's locator, not a fixed line number. A subagent filename is
+a discovery clue; confirm native identity and relationships before attribution.
 
 ```bash
-# View line 2 via cass
-cass view /path/to/subagents/agent-XXXXX.jsonl -n 2 -C 1
-
-# Extract with sed + jq
-sed -n '2p' /path/to/subagents/agent-XXXXX.jsonl | jq '.message.content'
-
-# Extract with jq slurp
-jq -s '.[1].message.content' /path/to/subagents/agent-XXXXX.jsonl
+cass view /path/to/subagents/agent-XXXXX.jsonl -n LINE -C 3 --json
+cass expand /path/to/subagents/agent-XXXXX.jsonl --line LINE --context 3 --json
 ```
+
+Verify the record role and returned locator. Then apply the appropriate
+role-based parser to a selected authorized excerpt if necessary.
 
 ---
 
@@ -244,20 +245,16 @@ jq -s '.[1].message.content' /path/to/subagents/agent-XXXXX.jsonl
 
 ## Composite Recipes
 
-### Full Prompt Mining Pipeline
+### Bounded Evidence Pack
 
 ```bash
-# 1. Search all sessions
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '
-    [.hits[] | select(.line_number <= 3) | .title[0:80]]
-    | group_by(.)
-    | map({prompt: .[0], count: length})
-    | sort_by(-.count)
-    | map(select(.count >= 2))
-    | .[0:30]
-  '
+timeout 30 cass pack "KEYWORD" --workspace /path --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
+
+Inspect selection and omission markers and actual returned locators. A citation
+verification flag is not proof that the source still exists, that a requested
+record was returned or that the excerpt establishes an outcome.
 
 ### Extract Conversation Flow from Session
 
@@ -266,7 +263,7 @@ jq -s '[.[] | {
   type: (.type // .role),
   ts: (.timestamp // .created_at),
   preview: (if .message then .message.content else .content end | tostring[0:100])
-}]' session.jsonl
+}]' excerpt.jsonl
 ```
 
 ### Find Sessions with Specific Tool Usage
@@ -276,19 +273,16 @@ cass search "Write" --workspace /path --json --fields minimal --limit 50 \
   | jq '[.hits[] | .source_path] | unique'
 ```
 
-### Complete Source Path → First Prompt Pipeline
+### Follow a Selected Hit
 
 ```bash
-# 1. Get source paths
-cass search "KEYWORD" --workspace /path --json --fields minimal --limit 20 \
-  | jq '.hits[].source_path' -r > /tmp/paths.txt
-
-# 2. Extract first prompt from each
-while read path; do
-  echo "=== $path ==="
-  jq -s '[.[] | select(.type == "user")][0] | .message.content[0:200]' "$path" 2>/dev/null
-done < /tmp/paths.txt
+cass search "KEYWORD" --workspace /path --json --fields minimal --limit 20
+# Select a relevant hit within the authorized source scope, then inspect it.
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
+
+Do not bulk-open every returned path or assume the first user message is the
+relevant prompt. Report missing or mismatched source records explicitly.
 
 ---
 
@@ -303,7 +297,7 @@ When a complex jq command fails silently or returns nothing:
 
 ```bash
 # Complex filter fails silently:
-| jq '[.hits[] | select(.line_number <= 3 and .source_path | contains("subagent"))] | ...'
+| jq '[.hits[] | select(.source_path | contains("subagent"))] | ...'
 # No output, no error. Now what?
 
 # SIMPLIFY FIRST:
@@ -325,18 +319,14 @@ When a complex jq command fails silently or returns nothing:
 # Add projection
 | jq '[.hits[] | {path: .source_path, line: .line_number}]'
 
-# Add filter
-| jq '[.hits[] | select(.line_number <= 3)]'
-
-# Combine (last)
-| jq '[.hits[] | select(.line_number <= 3) | select(.source_path | contains("subagent"))]'
+# Add a candidate path filter
+| jq '[.hits[] | select(.source_path | contains("subagent"))]'
 ```
 
 ### Check Intermediate Counts
 
 ```bash
 | jq '.hits | length'                        # Total hits
-| jq '[.hits[] | select(.line_number <= 3)] | length'   # After line filter
 | jq '[.hits[] | select(.source_path | contains("subagent"))] | length'  # After path filter
 ```
 
@@ -346,7 +336,7 @@ When a complex jq command fails silently or returns nothing:
 
 | Task | One-Liner |
 |------|-----------|
-| User prompt titles | `jq '[.hits[] \| select(.line_number <= 3) \| .title]'` |
+| Candidate titles | `jq '[.hits[].title]'`; not role or outcome evidence |
 | Source paths only | `jq '.hits[].source_path' -r` |
 | Agent counts | `jq '.aggregations.agent.buckets'` |
 | Date counts | `jq '.aggregations.date.buckets'` |

--- a/skills/cass/references/PITFALLS.md
+++ b/skills/cass/references/PITFALLS.md
@@ -25,7 +25,7 @@
 | Exit code 2 | Special characters in query | Quote query or use nearby anchor |
 | Broken pipe on export | Piping large output | Export to file first with `-o` |
 | Tool calls hidden | Missing flag | Add `--include-tools` to export |
-| Stale results | Index needs refresh | Run `cass index --json` |
+| Stale results | Newer records may be missing | Search usable state now; refresh only if needed and authorized, with a time cap |
 | jq returns null | Wrong field name | Use `jq 'keys'` to check structure |
 | Can see in file, cass finds nothing | Content not indexed | Fallback to `rg` on raw file |
 
@@ -37,8 +37,10 @@
 
 ```bash
 cass status --json              # Check state
-cass index --json               # Incremental refresh (try first)
-cass index --full --json        # Full rebuild (if still stale)
+# Search stale-but-usable state now; record its freshness.
+# Optional only when needed and authorized:
+timeout 600 cass index --json
+# Persistent staleness alone does not justify a full rebuild.
 ```
 
 ### Index Shows 0 Conversations

--- a/skills/cass/references/PROMPTS.md
+++ b/skills/cass/references/PROMPTS.md
@@ -1,16 +1,16 @@
-# Mined Gold-Standard Prompts
+# Example Discovery Prompts
 
-> **Source:** Real prompts from this user's session corpus that have been *re-used 5+ times*. These are tested, working entry points to cass — copy/paste, then adapt the keyword.
+> Adapt these examples to an authorized source scope and a bounded question. Reuse counts do not establish success; inspect source roles, outcomes and corrections.
 
 ## Contents
 
 - [Discovery Openers](#discovery-openers)
 - [Compile-A-File Prompts (Aggregation Tasks)](#compile-a-file-prompts-aggregation-tasks)
-- [Subagent Mining (Line 2 = THE Prompt)](#subagent-mining-line-2--the-prompt)
+- [Subagent Mining](#subagent-mining)
 - [Cross-Machine Recall](#cross-machine-recall)
 - ["What Worked Last Time?"](#what-worked-last-time)
 - [Decision Archaeology](#decision-archaeology)
-- [Ritual Detection](#ritual-detection)
+- [Recurring Candidates](#recurring-candidates)
 - [Cost & Usage Reports](#cost--usage-reports)
 - [Sentinel Phrases (Triggers for /cass)](#sentinel-phrases-triggers-for-cass)
 - [Anti-Templates](#anti-templates)
@@ -53,17 +53,21 @@ Use cass to extract every "first read ALL of AGENTS.md" prompt across this works
 
 ---
 
-## Subagent Mining (Line 2 = THE Prompt)
+## Subagent Mining
 
 ```
-Use cass to find all subagent sessions in the last 30 days where the prompt mentions "deep dive" — give me the line-2 text from each.
+Use cass to find up to three relevant subagent sessions in the last 30 days
+where the prompt mentions <TASK>. Verify the message roles and native
+relationships; show cited excerpts and disclose missing or mismatched sources.
 ```
 
 Implementation:
 ```bash
-cass search "deep dive" --workspace /path --json --fields minimal --limit 50 \
-  | jq -r '[.hits[] | select(.source_path | contains("subagent"))] | unique_by(.source_path) | .[].source_path' \
-  | xargs -I{} sh -c 'echo "=== {} ==="; sed -n "2p" "{}" | jq -r ".message.content"' 
+cass search "<TASK>" --workspace /path --days 30 --mode lexical --json --fields minimal --limit 20
+cass pack "<TASK>" --workspace /path --days 30 --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
+# Follow a selected candidate's actual locator; there is no fixed prompt line.
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
 
 ---
@@ -81,14 +85,19 @@ Search cass on css, csd, ts1, and ts2 for any mention of <KEYWORD> and dedup by 
 ## "What Worked Last Time?"
 
 ```
-Use cass to find the most-recent successful run of <TASK> and resume that session.
+Use cass to find a recent run of <TASK>. Inspect intent, outcome and later
+corrections before calling it successful. Show enough source context to judge
+whether it applies now; only resume a verified native session when requested.
 ```
 
 ```bash
-HIT=$(cass search "<TASK>" --workspace /repo --json --fields summary --limit 1 \
-        | jq -r '.hits[0].source_path')
-cass resume "$HIT" --shell
+cass pack "<TASK>" --workspace /repo --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
+
+A relevance-ranked first hit is not necessarily recent or successful. Check
+returned timestamps and source records. Use [RESUME.md](RESUME.md) only for a
+selected resume request.
 
 ---
 
@@ -104,18 +113,22 @@ Find the earliest session where we discussed adopting <LIBRARY>, and the convers
 
 ---
 
-## Ritual Detection
+## Recurring Candidates
 
 ```
-What prompts have I used 10+ times across all my agent sessions? Surface the top 20.
+Within this project, find recurring prompts relevant to <TASK>. Review up to
+three episodes for intent, outcome and corrections. Include a competing
+explanation or counterexample; do not infer success from repetition.
 ```
 
 ```bash
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]]
-        | group_by(.) | map({prompt: .[0], count: length})
-        | sort_by(-.count) | .[0:20]'
+cass search "<TASK>" --workspace /path --mode lexical --json --fields summary --limit 20
 ```
+
+See [PATTERNS.md](PATTERNS.md#pattern-detection) for limited hit counts. Titles
+and repeated indexed hits are not counts of distinct user messages. Check native
+roles and observed results before proposing reuse; rule changes need separate
+authority and later task evidence is needed to establish usefulness.
 
 ---
 
@@ -149,7 +162,7 @@ These literal phrases are reliable triggers for the skill in this user's vocabul
 - "scope archaeology"
 - "what worked last time"
 
-When you hear any of these, jump straight to the [Two-Step Bootstrap](../SKILL.md#two-step-bootstrap-replaces-always-first) and start mining.
+When the caller requests this work, use the [bounded discovery workflow](../SKILL.md#discovery-workflow) within the authorized scope. Ordinary work has no mandatory history step.
 
 ---
 
@@ -162,4 +175,4 @@ These prompts trigger /cass but produce *poor* results — rewrite them before e
 | "Search cass for everything about X" | unbounded; will return 10k hits | Add `--workspace /repo` and `--days 30` |
 | "Find all sessions" | no filter; useless | Pick a keyword OR an aggregate (`--aggregate agent,date`) |
 | "What's in the index?" | not actionable | `cass status --json` + `cass search "*" --aggregate workspace --limit 1 --json` |
-| "Re-extract all my prompts" | duplicates work cass already does | `cass search "*" --json --limit 500 \| jq '... select(.line_number <= 3)'` |
+| "Re-extract all my prompts" | an indexed sample does not prove full source coverage | Select a scope and budget; use CASS pack/view/expand and verify native roles, reporting unread or unavailable portions |

--- a/skills/cass/references/RAW_SOURCE_READS.md
+++ b/skills/cass/references/RAW_SOURCE_READS.md
@@ -1,6 +1,10 @@
 # Bounded raw source reads
 
-CASS search, `view` and `expand` locate excerpts. `ao session read-source`
+Use installed CASS search/pack/view/expand first for discovery and cited excerpts.
+Choose this optional AO route only for a demonstrated precision gap, such as
+required raw tool-output bytes or a consumer's frozen-span requirement. A missing
+original or mismatched locator remains a retrieval gap; raw extraction cannot
+reconstruct unavailable source content. `ao session read-source`
 returns explicit raw bytes after checking caller-selected policy; it does not
 parse records or replace the existing `ao provenance mine-session` tool-call
 contract. Raw bytes include prose, operator corrections, malformed records and

--- a/skills/cass/references/RECIPES.md
+++ b/skills/cass/references/RECIPES.md
@@ -1,13 +1,13 @@
 # Workflow Recipes
 
-> **Priority:** Your prompts first. They're replicable. Agent execution varies.
+> **Priority:** Resolve a concrete uncertainty with cited intent, action and outcome evidence.
 
 ## Contents
 
 | Recipe | When |
 |--------|------|
-| [Session Bootstrap](#session-bootstrap) | Start of every cass session |
-| [Ritual Discovery](#ritual-discovery) | Find reusable prompts |
+| [Search Readiness](#search-readiness) | Observe state when needed |
+| [Recurring Candidates](#recurring-candidates) | Investigate repeated prompts |
 | [User Prompt Extraction](#user-prompt-extraction) | What did I ask? |
 | [Subagent Mining](#subagent-mining) | Find extraction prompts |
 | [Scope Archaeology](#scope-archaeology) | When did we decide X? |
@@ -21,92 +21,72 @@
 
 ---
 
-## Session Bootstrap
+## Search Readiness
 
-**Always start here:**
+After source, task, model and destination authorization, search a healthy or
+stale-but-usable index immediately. Record freshness; do not automatically
+refresh, rebuild or add `--refresh`. If unavailable, report that state or use
+[bounded recovery](RECOVERY.md) only when needed and authorized.
 
 ```bash
-# 1. Health check
-cass status --json
-
-# 2. Refresh index
-cass index --json
-
-# 3. Project overview
-cass search "*" --workspace /data/projects/PROJECT --aggregate agent,date --limit 1 --json
+timeout 15 cass status --json
+# Optional overview when useful to the question
+timeout 30 cass search "*" --workspace /data/projects/PROJECT --mode lexical \
+  --aggregate agent,date --fields minimal --limit 1 --json
 ```
 
 ---
 
-## Ritual Discovery
+## Recurring Candidates
 
-**Goal:** Find prompts you used repeatedly (these work).
+**Goal:** Investigate a recurring prompt without assuming that repetition means
+it worked. Search for a task-relevant phrase, then review selected episodes.
 
 ```bash
-# Count suspected ritual
-cass search "First read ALL" --workspace /path --json --limit 100 | jq '.total_matches'
-# > 10 = RITUAL — document it
-
-# Find most repeated prompts
-cass search "*" --workspace /path --json --limit 500 \
-  | jq '[.hits[] | select(.line_number <= 3) | .title[0:80]] | group_by(.) | map({prompt: .[0], count: length}) | sort_by(-.count) | .[0:20]'
+timeout 30 cass search "TASK PHRASE" --workspace /path --mode lexical \
+  --json --fields summary --limit 20
+timeout 30 cass pack "TASK PHRASE" --workspace /path --mode lexical --json \
+  --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 ```
 
-### Common Rituals to Search
-
-| Pattern | Purpose |
-|---------|---------|
-| `"First read ALL"` | Context loading |
-| `"read AGENTS.md"` | Project rules |
-| `"comprehensive deep dive"` | Thorough analysis |
-| `"think super hard"` | Quality mode |
-| `"ultrathink"` | Quality mode |
-| `"extract all"` | Data extraction |
+Compare the user intent, action, result and later corrections. Recurrence may
+come from copied instructions, repeated failure or retries. Check a competing
+explanation or counterexample before reuse; later task evidence is needed to
+show usefulness. No count threshold promotes a prompt into a rule.
 
 ---
 
 ## User Prompt Extraction
 
-**Goal:** Find what you asked, in what order.
+**Goal:** Find what the user asked and preserve its actual source identity.
 
 ```bash
-# User prompts mention keyword (lines 1-3)
-cass search "KEYWORD" --workspace /path --json --limit 100 \
-  | jq '[.hits[] | select(.line_number <= 3)] | .[] | {path: .source_path, line: .line_number, title: .title[0:80]}'
-
-# Count user prompts with term
-cass search "KEYWORD" --workspace /path --json --limit 100 \
-  | jq '[.hits[] | select(.line_number <= 3)] | length'
-
-# View actual prompt
-cass view /path/from/hit.jsonl -n 1 -C 5
+cass search "KEYWORD" --workspace /path --mode lexical --json --fields minimal --limit 20
+# Use the selected hit's path and line, not a presumed session opener.
+cass view /path/from/hit.jsonl -n LINE -C 3 --json
+cass expand /path/from/hit.jsonl --line LINE --context 3 --json
 ```
+
+User roles come from native message records, including nested harness fields.
+Line numbers and titles are not role evidence. Confirm that the returned
+locator matches the request; unknown roles, absent sources and clamped windows
+remain gaps. Selected excerpts do not establish all prompts or chronology for
+unread parts of a session.
 
 ---
 
 ## Subagent Mining
 
-**Goal:** Extract deep dive prompts — line 2 of subagent logs is THE prompt.
+**Goal:** Inspect a relevant subagent prompt and its observed outcome.
 
 ```bash
-# Find subagent sessions
-cass search "deep dive" --workspace /path --json --fields minimal \
-  | jq '[.hits[] | select(.source_path | contains("subagent"))] | .[].source_path' -r | sort -u
-
-# View the prompt (line 2)
-cass view /path/to/subagents/agent-XXXXX.jsonl -n 2 -C 1
-
-# Extract just the text
-sed -n '2p' /path/to/subagents/agent-XXXXX.jsonl | jq '.message.content'
+cass search "TASK PHRASE" --workspace /path --json --fields minimal --limit 20 \
+  | jq '[.hits[] | select(.source_path | contains("subagent")) | {source_path, line_number}]'
+cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
 
-### Subagent Structure
-
-```
-Line 1: Metadata
-Line 2: THE PROMPT (gold — copy-paste ready)
-Line 3+: Execution
-```
+The filename is only a candidate filter. Verify the actual record role and
+native parent/child metadata; the prompt is not guaranteed to occupy line 2.
 
 ---
 
@@ -199,7 +179,7 @@ cass search "*" --workspace /path --json --limit 200 \
 
 ## Session Clustering
 
-**Goal:** Find all related work from one good hit.
+**Goal:** Discover candidate related work from one relevant hit.
 
 ```bash
 # 1. Find one relevant session
@@ -212,7 +192,7 @@ cass context /path/from/hit.jsonl --json
 # 3. Iterate over related_sessions
 ```
 
-**Why:** Work happens in clusters. One good session → whole cluster.
+Related-session output is not a complete cluster or proof of native parentage.
 
 ---
 
@@ -261,30 +241,26 @@ cass search "cass search" --workspace /path --json --fields minimal
 cass search "aggregate" --workspace /path --json --fields minimal
 ```
 
-**Insight:** Queries that appear multiple times = queries that worked.
+Repeated queries are candidates. Inspect the resulting hits and the task outcome; repetition alone may indicate failed searches.
 
 ---
 
 ## Full Example
 
 ```bash
-# 1. Health
-cass status --json
+# 1. Discover within a selected authorized workspace and bounded query family.
+timeout 30 cass search "scope decision" --workspace /data/projects/PROJECT \
+  --mode lexical --json --fields minimal --limit 20
 
-# 2. Overview (925 sessions)
-cass search "*" --workspace /data/projects/beads_rust --aggregate agent --limit 1 --json
+# 2. Ask CASS for a small cited selection.
+timeout 30 cass pack "scope decision" --workspace /data/projects/PROJECT \
+  --mode lexical --json --limit 20 --max-sessions 3 --max-evidence 6 --max-tokens 4000
 
-# 3. Find ritual opener
-cass search "First read ALL of AGENTS.md" --workspace /data/projects/beads_rust --json --limit 100 \
-  | jq '.total_matches'
-# Result: 50+ = RITUAL
-
-# 4. Extract ritual
-cass view $(cass search "First read ALL" --workspace /data/projects/beads_rust --json --limit 1 | jq -r '.hits[0].source_path') -n 1 -C 5
-
-# 5. Find scope decisions
-cass search "EXCLUDE" --workspace /data/projects/beads_rust --json --limit 50
-
-# 6. Discover related
-cass context /path/to/interesting/session.jsonl --json
+# 3. Follow a relevant returned locator and check native role/intent/outcome.
+timeout 15 cass expand /path/from/selected-hit.jsonl --line LINE --context 3 --json
 ```
+
+Retain query, filters, limit, freshness, selected locators and omissions. Missing
+sources or mismatched returned locations are not repaired by assuming an indexed
+snippet is the original record. Reuse only what the observed evidence supports;
+a justified no-change or insufficient-evidence result is valid.

--- a/skills/cass/references/RECOVERY.md
+++ b/skills/cass/references/RECOVERY.md
@@ -1,6 +1,6 @@
-# Doctor & Autonomous Recovery
+# Doctor & Bounded Authorized Recovery
 
-> **The contract:** `cass doctor --fix --json` is **safe by default**. It rebuilds derived data (Tantivy index, FTS table) from source SQLite — it never deletes source session files. Use it without asking the user.
+> **The contract:** Select recovery only when needed and authorized for its sources, model, destination and derived-state writes. Healthy and stale-but-usable indexes can be searched immediately. A search-only request does not authorize refresh/rebuild; unknown status is not proof of corruption. Preserve source sessions and bound recovery commands with a wall-clock cap.
 
 ## Contents
 
@@ -9,7 +9,7 @@
 - [Real-World Recovery Recipes](#real-world-recovery-recipes)
 - [What `--fix` Does NOT Do](#what---fix-does-not-do)
 - [Disk Cleanup (ALWAYS ask first)](#disk-cleanup-always-ask-first)
-- [Pre-Flight Hook Pattern](#pre-flight-hook-pattern)
+- [Optional Recovery Invocation](#optional-recovery-invocation)
 
 ---
 
@@ -18,8 +18,8 @@
 ```bash
 cass doctor --json                       # Read-only diagnosis
 cass doctor --json --verbose             # Show passed checks too
-cass doctor --fix --json                 # Apply safe rebuilds (USE THIS)
-cass doctor --fix --force-rebuild --json # Same + force index rebuild even if healthy
+timeout 600 cass doctor --fix --json     # Apply selected authorized repairs
+timeout 600 cass doctor --fix --force-rebuild --json # Force only for a diagnosed need
 ```
 
 `--fix` runs a 7-step protocol:
@@ -64,7 +64,7 @@ Backup format: `agent_search.db.corrupt.20260315_154822_759` (sortable timestamp
 Parse `failures[]` (top-level array of failed check names) for blocking issues. Anything in `auto_fix_actions` happened automatically. **Do not look for a `.summary` key — it doesn't exist.**
 
 ```bash
-cass doctor --fix --json | jq '{
+timeout 600 cass doctor --fix --json | jq '{
   ok: .healthy,
   issues_found, issues_fixed,
   applied: .auto_fix_actions,
@@ -84,7 +84,7 @@ cass status --json | jq '.database.messages, .index.documents'
 # 664027  0
 
 # Fix
-cass doctor --fix --json | jq '.auto_fix_actions'
+timeout 600 cass doctor --fix --json | jq '.auto_fix_actions'
 # ["Rebuilt search index from database"]
 ```
 
@@ -96,7 +96,7 @@ cass status --json | jq '.database.open_error'
 # "database disk image is malformed"
 
 # Fix
-cass doctor --fix --json
+timeout 600 cass doctor --fix --json
 # Backs up bad DB to .corrupt.<ts>, then rebuilds index from corrupt-salvage if possible
 ```
 
@@ -108,7 +108,7 @@ ps -p $(cass status --json | jq -r '.active_index.pid // empty')
 # (no such process)
 
 # Fix (doctor handles >1h-old locks; for fresher locks, force it)
-cass doctor --fix --force-rebuild --json
+timeout 600 cass doctor --fix --force-rebuild --json
 ```
 
 ### Incremental index hangs at current:0 (OPEN issue #196)
@@ -116,7 +116,7 @@ cass doctor --fix --force-rebuild --json
 ```bash
 # Workaround until fixed upstream
 pkill -f "cass index"
-cass index --full --force-rebuild --json
+timeout 600 cass index --full --force-rebuild --json
 ```
 
 `cass status` keeps showing `rebuilding` after the kill? `cass doctor --fix` clears the run lock.
@@ -151,7 +151,7 @@ cass search "common-term-from-your-corpus" --limit 1 --json --robot-meta \
 # Wait for any concurrent cass processes to settle
 sleep 30
 # A trivial incremental run is usually enough to land the timestamp
-cass index --json
+timeout 600 cass index --json
 ```
 
 If a concurrent rebuild is still active (`cass status --json | jq '.rebuild.active'`), the timestamp will be written when it completes. Don't fight it.
@@ -168,7 +168,7 @@ If a concurrent rebuild is still active (`cass status --json | jq '.rebuild.acti
 - **Re-download semantic models** — that requires `cass models install`
 - **Cross network boundaries** — only operates on local data dir
 
-So you can run `cass doctor --fix` autonomously without permission. Document the action in your response, but don't ask first.
+When recovery is already authorized, run the selected bounded repair and report the result without asking again. Source preservation alone does not grant recovery scope or permission to read additional sources.
 
 ---
 
@@ -196,41 +196,19 @@ Surface the disk usage, list candidates with sizes/ages, and let the user decide
 
 ---
 
-## Pre-Flight Hook Pattern
+## Optional Recovery Invocation
 
-For agents that should never run against a broken index:
+Do not install a search hook or start an index watcher as part of retrieval.
+When recovery is needed and its full derived-state scope is already authorized,
+inspect and invoke the existing helper:
 
 ```bash
-#!/usr/bin/env bash
-# pre-cass-search.sh
-# Decision tree: fresh → ok, stale-but-usable → bg refresh + ok, broken → doctor
-set -uo pipefail
-
-# 50ms preflight: exit 0 means already-fresh
-if cass health --json >/dev/null 2>&1; then
-  exit 0
-fi
-
-# Health failed — read full status to differentiate stale vs broken
-state=$(cass status --json 2>/dev/null \
-  | jq -r '"\(.index.stale // false),\(.database.exists // false),\(.database.messages // 0),\(.index.documents // 0)"')
-
-case "$state" in
-  true,true,*)
-    # stale index, DB present — usable; refresh in background
-    cass index --json >/tmp/cass-bg.log 2>&1 &
-    disown || true
-    exit 0
-    ;;
-  *)
-    # broken / uninitialized / DB missing — try to repair (doctor never deletes sources)
-    if cass doctor --fix --json >&2; then
-      cass health --json >/dev/null 2>&1 && exit 0 || exit 1
-    else
-      exit 1
-    fi
-    ;;
-esac
+# This may refresh a stale index or repair/rebuild derived state.
+CASS_STATUS_TIMEOUT=15 CASS_REBUILD_TIMEOUT=600 ./scripts/recover.sh
 ```
 
-Wire into Claude Code as a `PreToolUse` hook scoped to `cass search`. Use the same shape as `scripts/recover.sh` for the inline decision tree.
+The helper's individual index calls are capped. A stale usable index is still
+searchable; refreshing is an optional selected operation, not a prerequisite.
+If a status read is unavailable or an existing rebuild is progressing, retain
+that uncertainty rather than stacking another repair. See
+[OBSERVABILITY.md](OBSERVABILITY.md#authoritative-fallback-and-concurrent-read-latency).

--- a/skills/cass/scripts/prompt_miner.py
+++ b/skills/cass/scripts/prompt_miner.py
@@ -3,8 +3,9 @@
 Prompt Miner — Extract and cluster prompts across agent session logs.
 
 Mines user prompts from Claude Code, Codex CLI, and Gemini CLI sessions,
-clusters them by similarity, and identifies "ritual" prompts (repeated patterns
-that indicate working workflows).
+groups identical text after whitespace normalization, and reports recurring
+candidates. Counts do not establish success; retries and copied instructions
+can recur too. Prefer CASS search/pack for discovery and cited evidence.
 
 Usage:
     python prompt_miner.py --workspace /data/projects/PROJECT [OPTIONS]
@@ -16,7 +17,7 @@ Examples:
     # Mine all sessions with custom glob
     python prompt_miner.py --glob "~/.claude/projects/**/*.jsonl" --top 50
 
-    # Only show rituals (10+ occurrences)
+    # Only show frequent candidates (10+ occurrences; outcomes unassessed)
     python prompt_miner.py --workspace /path --min-count 10
 
     # Output as JSON for further processing
@@ -68,23 +69,19 @@ def parse_iso(ts: str) -> Optional[datetime]:
 
 
 def extract_text_from_content(content) -> str:
-    """Extract text from various content formats."""
+    """Extract explicit user text, excluding tool results nested in user envelopes."""
     if isinstance(content, str):
         return content
     elif isinstance(content, list):
         parts = []
         for c in content:
-            if isinstance(c, dict):
-                if "text" in c:
+            if isinstance(c, dict) and c.get("type") in ("text", "input_text"):
+                if isinstance(c.get("text"), str):
                     parts.append(str(c["text"]))
-                elif "content" in c:
-                    parts.append(extract_text_from_content(c["content"]))
         return " ".join(parts)
     elif isinstance(content, dict):
-        if "text" in content:
+        if content.get("type") in ("text", "input_text") and isinstance(content.get("text"), str):
             return str(content["text"])
-        elif "content" in content:
-            return extract_text_from_content(content["content"])
     return ""
 
 
@@ -141,11 +138,23 @@ def mine_prompts(
                             msg = obj.get("message", {})
                             if not isinstance(msg, dict):
                                 continue
+                            if msg.get("role", "user") != "user":
+                                continue
                             content = msg.get("content", "")
                             text = extract_text_from_content(content)
                             ts = obj.get("timestamp")
 
-                        # Codex/Gemini format
+                        # Current Codex response_item records carry the role in payload.
+                        elif obj.get("type") == "response_item":
+                            payload = obj.get("payload", {})
+                            if not isinstance(payload, dict) or payload.get("role") != "user":
+                                continue
+                            if payload.get("type") != "message":
+                                continue
+                            text = extract_text_from_content(payload.get("content", ""))
+                            ts = obj.get("timestamp")
+
+                        # Flat Codex/Gemini format
                         elif obj.get("role") == "user" and "content" in obj:
                             text = extract_text_from_content(obj["content"])
                             ts = obj.get("timestamp") or obj.get("created_at")
@@ -200,7 +209,7 @@ def find_repeated_prompts(
                 "first_seen": data["first_seen"].isoformat() if data["first_seen"] else None,
                 "last_seen": data["last_seen"].isoformat() if data["last_seen"] else None,
                 "example_paths": data["paths"],
-                "is_ritual": data["count"] >= 10
+                "outcome": "unassessed"
             })
 
     results.sort(key=lambda x: -x["count"])
@@ -260,7 +269,7 @@ Examples:
     parser.add_argument(
         "--rituals-only",
         action="store_true",
-        help="Only show ritual prompts (10+ occurrences)"
+        help="Legacy alias for --min-count 10; recurrence does not establish success"
     )
 
     args = parser.parse_args()
@@ -305,12 +314,11 @@ Examples:
             "repeated_prompts": repeated
         }, indent=2, default=str))
     else:
-        print(f"\nTop {len(repeated)} repeated prompts (count >= {min_count}):\n")
+        print(f"\nTop {len(repeated)} recurring candidates (count >= {min_count}; outcomes unassessed):\n")
         for item in repeated:
-            ritual_marker = " [RITUAL]" if item["is_ritual"] else ""
             display = truncate(item["prompt"], 100)
             agents = ", ".join(item["agents"])
-            print(f"{item['count']:3d}x ({agents}){ritual_marker}: {display}")
+            print(f"{item['count']:3d}x ({agents}): {display}")
 
 
 if __name__ == "__main__":

--- a/skills/cass/scripts/quick_analysis.sh
+++ b/skills/cass/scripts/quick_analysis.sh
@@ -7,31 +7,12 @@
 #
 # Output:
 #     - Index health
-#     - Session counts by agent
+#     - Indexed hits by agent
 #     - Activity by date
-#     - Top 5 ritual opener candidates
 #
-# Requires: cass, jq
+# Read-only. Requires: cass, jq, GNU timeout (or gtimeout).
 
 set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROMPT_MINER="$SCRIPT_DIR/prompt_miner.py"
-
-# Bound `cass index` so a hung or contended rebuild can't stall this overview
-# (SKILL.md doctrine: cass index can hang; always wall-clock cap it). Prefer GNU
-# timeout, fall back to gtimeout (macOS coreutils), else run uncapped with a
-# warning rather than failing outright.
-run_cass_index() {
-  if command -v timeout >/dev/null 2>&1; then
-    timeout 600 cass index --json
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout 600 cass index --json
-  else
-    echo "warning: 'timeout' not found; running cass index uncapped" >&2
-    cass index --json
-  fi
-}
 
 WORKSPACE="${1:-}"
 
@@ -57,6 +38,25 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
+if command -v timeout >/dev/null 2>&1; then
+    CASS_TIMEOUT=timeout
+elif command -v gtimeout >/dev/null 2>&1; then
+    CASS_TIMEOUT=gtimeout
+else
+    echo "Error: GNU timeout or gtimeout is required for bounded reads" >&2
+    exit 1
+fi
+
+failed=0
+read_cass() {
+    local rc
+    "$CASS_TIMEOUT" 15 cass "$@" || {
+        rc=$?
+        echo "CASS observation unavailable (exit $rc): $1" >&2
+        return "$rc"
+    }
+}
+
 echo "=============================================="
 echo "CASS QUICK ANALYSIS: $WORKSPACE"
 echo "=============================================="
@@ -64,54 +64,35 @@ echo ""
 
 # 1. Health check
 echo "--- Index Health ---"
-cass status --robot-format json 2>/dev/null | jq '{
+read_cass status --robot-format json | jq -e '{
     conversations: .database.conversations,
     messages: .database.messages,
     index_fresh: .index.fresh,
     rebuilding: (.index.rebuilding // .rebuild.active // false),
     recommended: .recommended_action
-}' 2>/dev/null || echo "Error: Could not get cass status"
+}' || { echo "Index state unavailable; no recovery attempted" >&2; failed=1; }
 echo ""
 
-# 2. Refresh index (quick, incremental)
-echo "--- Refreshing Index ---"
-run_cass_index 2>/dev/null | jq '.indexed // "Index refreshed"' -r 2>/dev/null || echo "Index refresh attempted"
+# 2. Agent breakdown (aggregation counts are hits, not distinct sessions)
+echo "--- Indexed Hits by Agent ---"
+read_cass search "*" --workspace "$WORKSPACE" --mode lexical --aggregate agent --limit 1 --fields minimal --json \
+    | jq -r '.aggregations.agent.buckets[] | "\(.key): \(.count) hits"' \
+    || { echo "Agent counts unavailable" >&2; failed=1; }
 echo ""
 
-# 3. Agent breakdown
-echo "--- Sessions by Agent ---"
-cass search "*" --workspace "$WORKSPACE" --aggregate agent --limit 1 --json 2>/dev/null \
-    | jq '.aggregations.agent.buckets[] | "\(.key): \(.count) sessions"' -r 2>/dev/null \
-    || echo "No sessions found for this workspace"
-echo ""
-
-# 4. Date breakdown (last 7 days of activity)
+# 3. Date breakdown (last 7 days of activity)
 echo "--- Recent Activity (by date) ---"
-cass search "*" --workspace "$WORKSPACE" --aggregate date --limit 1 --json 2>/dev/null \
-    | jq '.aggregations.date.buckets | sort_by(.key) | reverse | .[0:7] | .[] | "\(.key): \(.count) hits"' -r 2>/dev/null \
-    || echo "No date information available"
+read_cass search "*" --workspace "$WORKSPACE" --mode lexical --aggregate date --limit 1 --fields minimal --json \
+    | jq -r '.aggregations.date.buckets | sort_by(.key) | reverse | .[0:7] | .[] | "\(.key): \(.count) hits"' \
+    || { echo "Date counts unavailable" >&2; failed=1; }
 echo ""
 
-# 5. Ritual opener candidates (prompts at lines 1-3 that appear multiple times)
-echo "--- Ritual Opener Candidates ---"
-echo "(Prompts appearing at session start, sorted by frequency)"
-echo ""
-
-# Search for common ritual opener patterns
-for pattern in "First read ALL" "AGENTS.md" "comprehensive deep dive" "ultrathink" "think super hard"; do
-    count=$(cass search "$pattern" --workspace "$WORKSPACE" --json --limit 100 2>/dev/null \
-        | jq '.total_matches // 0' 2>/dev/null || echo "0")
-    if [ "$count" -gt 2 ]; then
-        printf "  %3dx: \"%s\"\n" "$count" "$pattern"
-    fi
-done
-echo ""
-
-# 6. Quick tips
+# 4. Quick tips
 echo "--- Next Steps ---"
-echo "1. Find ritual opener:    cass search \"First read ALL\" --workspace $WORKSPACE --json --limit 5"
-echo "2. View a session:        cass view /path/to/session.jsonl -n 1 -C 10"
-echo "3. Find user prompts:     cass search \"KEYWORD\" --workspace $WORKSPACE --json | jq '[.hits[] | select(.line_number <= 3)]'"
-echo "4. Mine all prompts:      python \"$PROMPT_MINER\" --workspace $WORKSPACE"
+echo "Search a task-relevant keyword with an explicit workspace, limit and time cap."
+echo "Use cass pack/view/expand for cited excerpts; verify user roles in native records."
+echo "Repetition is a candidate signal, not evidence that an approach worked."
+echo "Empty aggregates describe this indexed workspace only; failed reads are unavailable."
 echo ""
 echo "=============================================="
+exit "$failed"

--- a/skills/cass/scripts/recover.sh
+++ b/skills/cass/scripts/recover.sh
@@ -47,11 +47,19 @@ cass_state() {
     return 2
   fi
   printf '%s' "$out" \
-    | jq -er 'select(type == "object" and (.index | type == "object") and (.database | type == "object")) | [
-        (.index.fresh // false),
-        (.database.exists // false),
-        (.index.documents // 0),
-        (.database.messages // 0),
+    | jq -er 'select(
+        type == "object"
+        and (.index | type == "object")
+        and (.database | type == "object")
+        and (.index.fresh | type == "boolean")
+        and (.database.exists | type == "boolean")
+        and (.index.documents | type == "number" and . >= 0 and floor == .)
+        and (.database.messages | type == "number" and . >= 0 and floor == .)
+      ) | [
+        .index.fresh,
+        .database.exists,
+        .index.documents,
+        .database.messages,
         (.recommended_action // "")
       ] | @tsv' 2>/dev/null \
     || return 2

--- a/skills/cass/scripts/recover.sh
+++ b/skills/cass/scripts/recover.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# recover.sh — autonomous cass recovery, no user prompt required
+# recover.sh — selected authorized cass recovery
 #
 # Decision tree:
 #   1) If healthy: exit 0
@@ -7,9 +7,10 @@
 #   3) If broken: doctor --fix, then verify
 #   4) If still broken after fix: print actionable diagnostic and exit 1
 #
-# Used by: PreToolUse hooks before cass search; cron pre-flight; agent loops.
+# Invoke only for a diagnosed recovery/refresh need with indexing authorized.
+# Search-only requests do not need this helper.
 #
-# Safe by default. Never touches source session files.
+# Preserves source session files; may refresh or rebuild derived index state.
 
 set -uo pipefail
 # NOT -e: a non-zero exit from cass/jq is informational, not fatal — we want
@@ -39,26 +40,25 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 cass_state() {
-  # Always emits 5 tab-separated values, even when cass times out or returns garbage.
+  # Unobserved state must not be converted into an empty/corrupt database.
   local out
-  out=$(timeout "$STATUS_TIMEOUT" cass status --json 2>/dev/null) || out=""
+  out=$(timeout "$STATUS_TIMEOUT" cass status --json 2>/dev/null) || return 2
   if [ -z "$out" ]; then
-    printf 'false\tfalse\t0\t0\t\n'
-    return
+    return 2
   fi
   printf '%s' "$out" \
-    | jq -r '[
+    | jq -er 'select(type == "object" and (.index | type == "object") and (.database | type == "object")) | [
         (.index.fresh // false),
         (.database.exists // false),
         (.index.documents // 0),
         (.database.messages // 0),
         (.recommended_action // "")
       ] | @tsv' 2>/dev/null \
-    || printf 'false\tfalse\t0\t0\t\n'
+    || return 2
 }
 
 # Read state once. Use || true so an empty stream doesn't trip downstream.
-state_line=$(cass_state)
+state_line=$(cass_state) || { echo "UNAVAILABLE: index state not observed; no repair attempted" >&2; exit 2; }
 IFS=$'\t' read -r FRESH DB_EXISTS DOCS MSGS REC <<< "$state_line" || true
 FRESH=${FRESH:-false}
 DB_EXISTS=${DB_EXISTS:-false}
@@ -102,7 +102,7 @@ else
 fi
 
 # Verify
-state_line=$(cass_state)
+state_line=$(cass_state) || { echo "UNAVAILABLE: state after doctor not observed; no further repair attempted" >&2; exit 2; }
 IFS=$'\t' read -r FRESH DB_EXISTS DOCS MSGS REC <<< "$state_line" || true
 
 if [ "${DB_EXISTS:-false}" = "true" ] && [ "${DOCS:-0}" != "0" ]; then
@@ -124,7 +124,7 @@ esac
 
 # Even on exit 0 the JSON may report success:false (the last_indexed_at race
 # documented in coding_agent_session_search-zz8ni). Always verify by re-reading state.
-state_line=$(cass_state)
+state_line=$(cass_state) || { echo "UNAVAILABLE: state after rebuild not observed" >&2; exit 2; }
 IFS=$'\t' read -r FRESH DB_EXISTS DOCS MSGS REC <<< "$state_line" || true
 if [ "${DB_EXISTS:-false}" = "true" ] && [ "${DOCS:-0}" != "0" ]; then
   echo "RECOVERED: index is queryable (fresh marker may still be stale; that's harmless)" >&2

--- a/skills/cass/skill.spec.json
+++ b/skills/cass/skill.spec.json
@@ -5,8 +5,8 @@
   "quality_score": 0.95,
   "sections": [
     { "id": "title",       "title": "cass Session Search",                  "type": "intro",     "priority": "required" },
-    { "id": "goldmine",    "title": "The Goldmine Principle",               "type": "overview",  "priority": "required" },
-    { "id": "discovery",   "title": "THE EXACT PROMPT — Discovery Workflow", "type": "procedure", "priority": "required" },
+    { "id": "history",     "title": "History as Evidence",               "type": "overview",  "priority": "required" },
+    { "id": "discovery",   "title": "Discovery Workflow", "type": "procedure", "priority": "required" },
     { "id": "versionpin",  "title": "Version Pinning Caveat",               "type": "constraints", "priority": "required" },
     { "id": "bootstrap",   "title": "Two-Step Bootstrap",                   "type": "procedure", "priority": "required" },
     { "id": "recovery",    "title": "Stuck-Index & Recovery Decision Tree", "type": "procedure", "priority": "required" },
@@ -25,7 +25,7 @@
   ],
   "references": [
     { "file": "references/COMMANDS.md",            "topic": "complete cass command reference" },
-    { "file": "references/RECOVERY.md",            "topic": "stuck-index recovery and no-permission repair moves" },
+    { "file": "references/RECOVERY.md",            "topic": "bounded authorized recovery for diagnosed index problems" },
     { "file": "references/SEMANTIC_AND_HYBRID.md", "topic": "enabling semantic / hybrid search modes" },
     { "file": "references/REMOTE_SOURCES.md",      "topic": "cross-machine corpus and configured sources" },
     { "file": "references/ANTI_PATTERNS.md",       "topic": "search anti-patterns to avoid" },
@@ -65,7 +65,7 @@
       "full": 5200
     }
   },
-  "output_contract": "Search hits over past agent sessions (prompts, decisions, patterns) via `cass search`, a `cass status`/index-health report, JSON/aggregation output for parsing, or a resume command for a matched session. Index operations are wall-clock-capped so the bootstrap never blocks.",
+  "output_contract": "Search hits over past agent sessions (prompts, decisions, patterns) via `cass search`, a `cass status`/index-health report, JSON/aggregation output for parsing, or a resume command for a matched session. Retrieval is bounded; index recovery is optional, selected and authorized.",
   "evidence": {
     "sources": [
       "skills/cass/SKILL.md",

--- a/skills/ms/SKILL.md
+++ b/skills/ms/SKILL.md
@@ -38,6 +38,26 @@ output_contract: search and load results plus source identity on stdout; the loc
 - Keep `ms` retrieval-only for production skill work. It returns search and load
   results; the caller owns authoring, validation, and every subsequent decision.
 
+## Session evidence and instruction changes
+
+For a requested instruction-improvement task, use CASS to discover relevant
+episodes and `ms` to find existing guidance that could explain the behavior or
+already address it. Load only the relevant skills, then inspect their canonical
+source before proposing an edit. An `AGENTS.md` or task-prompt change does not
+require inventing a skill or loading an unrelated one.
+
+Upstream MS also offers `build --from-cass`; this adapter deliberately does not
+invoke that authoring path. Inspect `ms build --help` if the caller selects it
+separately. A generated skill, search rank,
+repeated prompt, or recorded outcome is not proof of downstream improvement.
+
+CASS search/pack supplies candidate evidence. Use AO's bounded excerpt view only
+when the investigation needs exact raw spans, literal fields or instruction
+identity that the selected CASS output does not establish. These are optional
+capabilities, not a required sequence on every task. The caller owns a supported
+candidate edit or no-change judgment, independent review and later usefulness
+testing; retrieval never awards that outcome itself.
+
 ## Quick Start
 
 Find a skill (MCP-primary — BM25, currently strictly better than CLI search), then load the FULL runnable SKILL.md in one call (always `full: true` when you mean to use it):

--- a/tests/scripts/cass-helpers.bats
+++ b/tests/scripts/cass-helpers.bats
@@ -12,6 +12,10 @@ setup() {
 printf '%s\n' "$*" >> "$CASS_FIXTURE_ROOT/calls"
 case "$1" in
     status)
+        if [ -n "${CASS_FIXTURE_STATUS:-}" ]; then
+            printf '%s\n' "$CASS_FIXTURE_STATUS"
+            exit 0
+        fi
         case "$CASS_FIXTURE_MODE" in
             timeout) exit 124 ;;
             malformed) printf 'not json\n'; exit 0 ;;
@@ -92,6 +96,29 @@ teardown() {
     [[ "$output" == *"RECOVERED: doctor succeeded"* ]]
     [ -f "$TMP_DIR/repaired" ]
     ! grep -q '^index ' "$TMP_DIR/calls"
+}
+
+@test "selected recovery requires observed and correctly typed nested readiness facts" {
+    export CASS_FIXTURE_STATUS
+    local base='{"index":{"fresh":false,"documents":0},"database":{"exists":false,"messages":0}}'
+    local field
+    local invalid
+    for field in index.fresh database.exists index.documents database.messages; do
+        for invalid in null '"unknown"'; do
+            CASS_FIXTURE_STATUS=$(printf '%s' "$base" | jq -c --arg field "$field" --argjson invalid "$invalid" 'setpath($field | split("."); $invalid)')
+            : > "$TMP_DIR/calls"
+            run env PATH="$TMP_DIR/bin:$PATH" bash "$REPO_ROOT/skills/cass/scripts/recover.sh"
+            [ "$status" -eq 2 ]
+            [[ "$output" == *"UNAVAILABLE: index state not observed"* ]]
+            [ "$(cat "$TMP_DIR/calls")" = 'status --json' ]
+        done
+    done
+    CASS_FIXTURE_STATUS='{"index":{},"database":{}}'
+    : > "$TMP_DIR/calls"
+    run env PATH="$TMP_DIR/bin:$PATH" bash "$REPO_ROOT/skills/cass/scripts/recover.sh"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"UNAVAILABLE: index state not observed"* ]]
+    [ "$(cat "$TMP_DIR/calls")" = 'status --json' ]
 }
 
 make_prompt_fixture() {

--- a/tests/scripts/cass-helpers.bats
+++ b/tests/scripts/cass-helpers.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# Synthetic native records and stub CASS only; never reads the operator's corpus.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    TMP_DIR="$(mktemp -d)"
+    export CASS_FIXTURE_ROOT="$TMP_DIR"
+    export CASS_FIXTURE_MODE=fresh
+    mkdir -p "$TMP_DIR/bin" "$TMP_DIR/.claude" "$TMP_DIR/.codex"
+    cat > "$TMP_DIR/bin/cass" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CASS_FIXTURE_ROOT/calls"
+case "$1" in
+    status)
+        case "$CASS_FIXTURE_MODE" in
+            timeout) exit 124 ;;
+            malformed) printf 'not json\n'; exit 0 ;;
+            unknown) printf '{}\n'; exit 0 ;;
+            stale) printf '{"database":{"exists":true,"messages":12},"index":{"fresh":false,"stale":true,"documents":12}}\n' ;;
+            missing)
+                if [ -f "$CASS_FIXTURE_ROOT/repaired" ]; then
+                    printf '{"database":{"exists":true,"messages":12},"index":{"fresh":true,"documents":12}}\n'
+                else
+                    printf '{"database":{"exists":false,"messages":0},"index":{"fresh":false,"documents":0}}\n'
+                fi ;;
+            *) printf '{"database":{"exists":true,"messages":12},"index":{"fresh":true,"documents":12}}\n' ;;
+        esac ;;
+    search)
+        if [ "${CASS_FIXTURE_SEARCH_FAIL:-0}" = 1 ]; then exit 124; fi
+        printf '{"aggregations":{"agent":{"buckets":[{"key":"codex","count":12}]},"date":{"buckets":[{"key":"2026-01-01","count":12}]}},"hits":[],"total_matches":0}\n' ;;
+    doctor)
+        touch "$CASS_FIXTURE_ROOT/repaired"
+        printf '{"healthy":true,"checks":[],"auto_fix_actions":["repaired"]}\n' ;;
+    *) echo "Unexpected CASS mutation: $*" >&2; exit 99 ;;
+esac
+STUB
+    # Exercise the helper's cap plumbing without a live index or background job.
+    cat > "$TMP_DIR/bin/timeout" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CASS_FIXTURE_ROOT/caps"
+shift
+exec "$@"
+STUB
+    chmod +x "$TMP_DIR/bin/cass" "$TMP_DIR/bin/timeout"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "overview searches fresh, stale and missing state without indexing" {
+    for CASS_FIXTURE_MODE in fresh stale missing; do
+        export CASS_FIXTURE_MODE
+        : > "$TMP_DIR/calls"
+        : > "$TMP_DIR/caps"
+        run env PATH="$TMP_DIR/bin:$PATH" bash "$REPO_ROOT/skills/cass/scripts/quick_analysis.sh" "$TMP_DIR"
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"codex: 12 hits"* ]]
+        [ "$(wc -l < "$TMP_DIR/calls" | tr -d ' ')" -eq 3 ]
+        [ "$(wc -l < "$TMP_DIR/caps" | tr -d ' ')" -eq 3 ]
+        ! grep -Eq '^(index|doctor|models|sources) ' "$TMP_DIR/calls"
+        grep -q -- '--mode lexical --aggregate agent --limit 1 --fields minimal' "$TMP_DIR/calls"
+    done
+}
+
+@test "overview preserves failed reads instead of reporting no sessions" {
+    export CASS_FIXTURE_MODE=timeout
+    export CASS_FIXTURE_SEARCH_FAIL=1
+    run env PATH="$TMP_DIR/bin:$PATH" bash "$REPO_ROOT/skills/cass/scripts/quick_analysis.sh" "$TMP_DIR"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"CASS observation unavailable (exit 124)"* ]]
+    [[ "$output" == *"Agent counts unavailable"* ]]
+    [[ "$output" != *"No sessions found"* ]]
+    ! grep -Eq '^(index|doctor) ' "$TMP_DIR/calls"
+}
+
+@test "selected recovery does not rebuild unobserved or malformed state" {
+    for CASS_FIXTURE_MODE in timeout malformed unknown; do
+        export CASS_FIXTURE_MODE
+        : > "$TMP_DIR/calls"
+        run env PATH="$TMP_DIR/bin:$PATH" bash "$REPO_ROOT/skills/cass/scripts/recover.sh"
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"UNAVAILABLE: index state not observed"* ]]
+        [ "$(cat "$TMP_DIR/calls")" = 'status --json' ]
+    done
+}
+
+@test "selected recovery still repairs a diagnosed missing database" {
+    export CASS_FIXTURE_MODE=missing
+    run env PATH="$TMP_DIR/bin:$PATH" bash "$REPO_ROOT/skills/cass/scripts/recover.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RECOVERED: doctor succeeded"* ]]
+    [ -f "$TMP_DIR/repaired" ]
+    ! grep -q '^index ' "$TMP_DIR/calls"
+}
+
+make_prompt_fixture() {
+    python3 - "$TMP_DIR" <<'PY'
+import json
+import pathlib
+import sys
+root = pathlib.Path(sys.argv[1])
+claude = [
+    {"type": "assistant", "message": {"role": "assistant", "content": "early assistant"}},
+    {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "content": "tool output"}]}},
+    {"type": "user", "message": {"role": "assistant", "content": "conflicting role"}},
+]
+claude += [{"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"role": "user", "content": "Retry this failed approach"}}] * 10
+claude += [{"type": "user", "message": {"role": "user", "content": [
+    {"type": "tool_result", "content": [{"type": "text", "text": "nested tool output"}]},
+    {"type": "text", "text": "Actual mixed user text"},
+]}}]
+codex = [{"type": "session_meta", "payload": {"role": "user", "content": "metadata"}}] * 8
+codex += [
+    {"type": "response_item", "payload": {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "assistant reply"}]}},
+    {"type": "event_msg", "payload": {"type": "user_message", "message": "Late user text"}},
+]
+codex += [{"type": "response_item", "timestamp": "2026-01-01T00:00:00Z", "payload": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Late user text"}]}}] * 2
+codex += [{"role": "user", "content": "Flat user text"}]
+for name, records in [(".claude", claude), (".codex", codex)]:
+    (root / name / "fixture.jsonl").write_text("\n".join(json.dumps(record) for record in records) + "\n")
+PY
+}
+
+@test "prompt miner uses native roles including late Codex records and excludes tool results" {
+    make_prompt_fixture
+    run python3 "$REPO_ROOT/skills/cass/scripts/prompt_miner.py" --glob "$TMP_DIR/.*/*.jsonl" --min-count 1 --json
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | jq -e '.total_prompts == 14 and (.repeated_prompts | length == 4)
+        and (.repeated_prompts | map(.prompt) | sort) == ["Actual mixed user text", "Flat user text", "Late user text", "Retry this failed approach"]
+        and (.repeated_prompts[] | select(.prompt == "Late user text") | .count == 2)' >/dev/null
+}
+
+@test "ten retries stay unassessed and legacy frequency flag remains usable" {
+    make_prompt_fixture
+    run python3 "$REPO_ROOT/skills/cass/scripts/prompt_miner.py" --glob "$TMP_DIR/.*/*.jsonl" --rituals-only --json
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | jq -e '(.repeated_prompts | length == 1)
+        and (.repeated_prompts[0] | .count == 10 and .outcome == "unassessed" and (has("is_ritual") | not))' >/dev/null
+}


### PR DESCRIPTION
## What

Use CASS to discover session evidence and MS to find existing skill guidance. Reserve AO exact excerpts for an identified source-precision gap. Correct guidance and helpers that treated repetition as success, inferred user prompts from early line numbers, or refreshed the index before every search.

Repeated failed prompts now remain unassessed. Native message roles identify user prompts, search helpers preserve unavailable reads, and recovery requires observed state before attempting repairs. Existing CASS/MS documentation explains their respective roles without adding another mining framework.

## Validation

- Seven focused helper behavior tests and CASS/MS skill validators pass.
- Generated projections are current. The local aggregate passed 10 groups with no failures; its absent OL integration suite was explicitly skipped. Full AO gates passed all 73 selected checks.
- Fresh independent review caught an incomplete-status recovery edge case. The repair, regression test, and generated copies have been rechecked with no remaining findings; final local checks pass.
- CI passed on the exact final commit, including Linux/Windows correctness, Go race tests, security and the required summary check.
- A bounded private exercise used three CASS query families and MS search/full loads. It reached a justified no-change decision because selected native sources were unavailable or did not match returned locations. Retrieval success was not credited as learning, and no AO extraction was needed. No private session content or locators are included in this PR.

## Limits

This establishes retrieval and evidence-handling behavior. It does not establish that a new instruction improves later task outcomes. The CASS artifact validator deliberately skipped its opt-in live corpus smoke test; the separately bounded retrieval exercise is described above.
