### PR TITLE
Keep skill reviews compact and clarify when judgment is finished

### DIFF
--- a/images/gemini/skills/rpi/SKILL.md
+++ b/images/gemini/skills/rpi/SKILL.md
@@ -73,6 +73,10 @@ needs. A reference link is available context, not a reading list. Search before
 opening large files; expand only for consequential uncertainty. Keep successful
 output compact at the tool boundary; retain full logs for inspection. Reuse the
 worker's component-check list and current receipts instead of rediscovering them.
+Use native completion watches or bounded waits for ongoing checks and helpers.
+At completion, verify the expected subject and required results; a quiet or
+partial status is not success. Inspect further for a failure, suspected stall or
+decision need. Keep required user updates concise rather than narrating each poll.
 
 When delegation is authorized and useful, select the runtime's task-only
 dispatch option for independent work; a short prompt in a full-history fork

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -115,10 +115,19 @@ before/after or equivalent causal evidence. Counts and timestamps alone do not
 establish cause. Known findings return to direct repair; causal stalls use the
 RPI single-helper rule, not repairs delegated to this validator.
 
-Keep the report proportional: cite existing receipts and include only excerpts
-needed to assess a finding. Do not retell the investigation or duplicate logs.
-Brevity must retain every criterion, necessary finding, identity, freshness
-fact and unchecked surface.
+Keep the report proportional: cite the exact subject, complete bound manifest
+and existing receipts instead of copying path or digest inventories. Group
+generated companions by source owner and verified equivalence; still verify
+every changed path and cited binding. Include excerpts only to assess a finding.
+Retain every criterion, necessary finding, identity, freshness fact and unchecked
+surface. Complete coverage does not require a second copy of the evidence.
+
+Return candidate judgment when its accepted review scope is verified. When
+delivery is outside that scope, the caller checks native delivery facts without
+another semantic review of unchanged content. Delivery inside acceptance stays
+unverified until its evidence exists: do not issue complete PASS early or remove
+the criterion. Use the existing result for any pending delivery update, without
+repeating the investigation or creating another report.
 
 Validate is the sole semantic author of `verdict.v2`.
 Only when the caller requests machine-readable evidence or a declared consumer

--- a/images/gemini/skills/validate/SKILL.md
+++ b/images/gemini/skills/validate/SKILL.md
@@ -122,8 +122,8 @@ every changed path and cited binding. Include excerpts only to assess a finding.
 Retain every criterion, necessary finding, identity, freshness fact and unchecked
 surface. Complete coverage does not require a second copy of the evidence.
 
-Return candidate judgment when its accepted review scope is verified. When
-delivery is outside that scope, the caller checks native delivery facts without
+Return the candidate verdict promptly when the judgment is complete. When
+delivery is outside the accepted review scope, the caller checks its native facts without
 another semantic review of unchanged content. Delivery inside acceptance stays
 unverified until its evidence exists: do not issue complete PASS early or remove
 the criterion. Use the existing result for any pending delivery update, without

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -609,8 +609,8 @@
     {
       "name": "rpi",
       "source_skill": "skills/rpi",
-      "source_hash": "fd5a6deaff8240607040c50e75958f4ea94c9ce11e73628cac29d0b73771c2b6",
-      "generated_hash": "fa475c8695a6116f245788325c0f3098a1b8ddf2d131637de65b2331dd937652"
+      "source_hash": "efa190f331618cbaf64ac8514ffbee15dcd24477098988dcb14bf810cb5319cd",
+      "generated_hash": "4138edb1de9e7af6a4f6f29143b0721acd596a6eb4b70f19cac5a47ad00961c6"
     },
     {
       "name": "sbh",
@@ -687,8 +687,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "d458f6c3ccc510825984c9decff2eae90e8aca5111e8561be6e06bd12c2c17b6",
-      "generated_hash": "f8aabaed14d3e61c1f9b23376c7f79fb3b28751567418fe3a2e043efa53b30f7"
+      "source_hash": "e9761efa9cfb989dd540c34bc4d017d555c49ae9ed3cca0a01a61b06d25389cb",
+      "generated_hash": "85bee238ed330c9ad283682609dc1c5bcd0c0dfd64ffca14a34f846fe2224a41"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -687,8 +687,8 @@
     {
       "name": "validate",
       "source_skill": "skills/validate",
-      "source_hash": "e9761efa9cfb989dd540c34bc4d017d555c49ae9ed3cca0a01a61b06d25389cb",
-      "generated_hash": "85bee238ed330c9ad283682609dc1c5bcd0c0dfd64ffca14a34f846fe2224a41"
+      "source_hash": "39f09892724ae7abaa90464adee56361fa8812fb41fddf480d24ecd17da51e14",
+      "generated_hash": "e1297aed23917b1afa2aff4830051b0e8b0b218ef3c760dff0b487785c8d43d3"
     },
     {
       "name": "workflow-builder",

--- a/skills-codex/rpi/.agentops-generated.json
+++ b/skills-codex/rpi/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/rpi",
   "layout": "modular",
-  "source_hash": "fd5a6deaff8240607040c50e75958f4ea94c9ce11e73628cac29d0b73771c2b6",
-  "generated_hash": "fa475c8695a6116f245788325c0f3098a1b8ddf2d131637de65b2331dd937652"
+  "source_hash": "efa190f331618cbaf64ac8514ffbee15dcd24477098988dcb14bf810cb5319cd",
+  "generated_hash": "4138edb1de9e7af6a4f6f29143b0721acd596a6eb4b70f19cac5a47ad00961c6"
 }

--- a/skills-codex/rpi/SKILL.md
+++ b/skills-codex/rpi/SKILL.md
@@ -43,6 +43,10 @@ needs. A reference link is available context, not a reading list. Search before
 opening large files; expand only for consequential uncertainty. Keep successful
 output compact at the tool boundary; retain full logs for inspection. Reuse the
 worker's component-check list and current receipts instead of rediscovering them.
+Use native completion watches or bounded waits for ongoing checks and helpers.
+At completion, verify the expected subject and required results; a quiet or
+partial status is not success. Inspect further for a failure, suspected stall or
+decision need. Keep required user updates concise rather than narrating each poll.
 
 When delegation is authorized and useful, select the runtime's task-only
 dispatch option for independent work; a short prompt in a full-history fork

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "e9761efa9cfb989dd540c34bc4d017d555c49ae9ed3cca0a01a61b06d25389cb",
-  "generated_hash": "85bee238ed330c9ad283682609dc1c5bcd0c0dfd64ffca14a34f846fe2224a41"
+  "source_hash": "39f09892724ae7abaa90464adee56361fa8812fb41fddf480d24ecd17da51e14",
+  "generated_hash": "e1297aed23917b1afa2aff4830051b0e8b0b218ef3c760dff0b487785c8d43d3"
 }

--- a/skills-codex/validate/.agentops-generated.json
+++ b/skills-codex/validate/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/validate",
   "layout": "modular",
-  "source_hash": "d458f6c3ccc510825984c9decff2eae90e8aca5111e8561be6e06bd12c2c17b6",
-  "generated_hash": "f8aabaed14d3e61c1f9b23376c7f79fb3b28751567418fe3a2e043efa53b30f7"
+  "source_hash": "e9761efa9cfb989dd540c34bc4d017d555c49ae9ed3cca0a01a61b06d25389cb",
+  "generated_hash": "85bee238ed330c9ad283682609dc1c5bcd0c0dfd64ffca14a34f846fe2224a41"
 }

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -87,10 +87,19 @@ before/after or equivalent causal evidence. Counts and timestamps alone do not
 establish cause. Known findings return to direct repair; causal stalls use the
 RPI single-helper rule, not repairs delegated to this validator.
 
-Keep the report proportional: cite existing receipts and include only excerpts
-needed to assess a finding. Do not retell the investigation or duplicate logs.
-Brevity must retain every criterion, necessary finding, identity, freshness
-fact and unchecked surface.
+Keep the report proportional: cite the exact subject, complete bound manifest
+and existing receipts instead of copying path or digest inventories. Group
+generated companions by source owner and verified equivalence; still verify
+every changed path and cited binding. Include excerpts only to assess a finding.
+Retain every criterion, necessary finding, identity, freshness fact and unchecked
+surface. Complete coverage does not require a second copy of the evidence.
+
+Return candidate judgment when its accepted review scope is verified. When
+delivery is outside that scope, the caller checks native delivery facts without
+another semantic review of unchanged content. Delivery inside acceptance stays
+unverified until its evidence exists: do not issue complete PASS early or remove
+the criterion. Use the existing result for any pending delivery update, without
+repeating the investigation or creating another report.
 
 Validate is the sole semantic author of `verdict.v2`.
 Only when the caller requests machine-readable evidence or a declared consumer

--- a/skills-codex/validate/SKILL.md
+++ b/skills-codex/validate/SKILL.md
@@ -94,8 +94,8 @@ every changed path and cited binding. Include excerpts only to assess a finding.
 Retain every criterion, necessary finding, identity, freshness fact and unchecked
 surface. Complete coverage does not require a second copy of the evidence.
 
-Return candidate judgment when its accepted review scope is verified. When
-delivery is outside that scope, the caller checks native delivery facts without
+Return the candidate verdict promptly when the judgment is complete. When
+delivery is outside the accepted review scope, the caller checks its native facts without
 another semantic review of unchanged content. Delivery inside acceptance stays
 unverified until its evidence exists: do not issue complete PASS early or remove
 the criterion. Use the existing result for any pending delivery update, without

--- a/skills/rpi/SKILL.md
+++ b/skills/rpi/SKILL.md
@@ -73,6 +73,10 @@ needs. A reference link is available context, not a reading list. Search before
 opening large files; expand only for consequential uncertainty. Keep successful
 output compact at the tool boundary; retain full logs for inspection. Reuse the
 worker's component-check list and current receipts instead of rediscovering them.
+Use native completion watches or bounded waits for ongoing checks and helpers.
+At completion, verify the expected subject and required results; a quiet or
+partial status is not success. Inspect further for a failure, suspected stall or
+decision need. Keep required user updates concise rather than narrating each poll.
 
 When delegation is authorized and useful, select the runtime's task-only
 dispatch option for independent work; a short prompt in a full-history fork

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -115,10 +115,19 @@ before/after or equivalent causal evidence. Counts and timestamps alone do not
 establish cause. Known findings return to direct repair; causal stalls use the
 RPI single-helper rule, not repairs delegated to this validator.
 
-Keep the report proportional: cite existing receipts and include only excerpts
-needed to assess a finding. Do not retell the investigation or duplicate logs.
-Brevity must retain every criterion, necessary finding, identity, freshness
-fact and unchecked surface.
+Keep the report proportional: cite the exact subject, complete bound manifest
+and existing receipts instead of copying path or digest inventories. Group
+generated companions by source owner and verified equivalence; still verify
+every changed path and cited binding. Include excerpts only to assess a finding.
+Retain every criterion, necessary finding, identity, freshness fact and unchecked
+surface. Complete coverage does not require a second copy of the evidence.
+
+Return candidate judgment when its accepted review scope is verified. When
+delivery is outside that scope, the caller checks native delivery facts without
+another semantic review of unchanged content. Delivery inside acceptance stays
+unverified until its evidence exists: do not issue complete PASS early or remove
+the criterion. Use the existing result for any pending delivery update, without
+repeating the investigation or creating another report.
 
 Validate is the sole semantic author of `verdict.v2`.
 Only when the caller requests machine-readable evidence or a declared consumer

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -122,8 +122,8 @@ every changed path and cited binding. Include excerpts only to assess a finding.
 Retain every criterion, necessary finding, identity, freshness fact and unchecked
 surface. Complete coverage does not require a second copy of the evidence.
 
-Return candidate judgment when its accepted review scope is verified. When
-delivery is outside that scope, the caller checks native delivery facts without
+Return the candidate verdict promptly when the judgment is complete. When
+delivery is outside the accepted review scope, the caller checks its native facts without
 another semantic review of unchanged content. Delivery inside acceptance stays
 unverified until its evidence exists: do not issue complete PASS early or remove
 the criterion. Use the existing result for any pending delivery update, without


### PR DESCRIPTION
The preceding implementation caught a real defect through fresh review, but its review report duplicated scope and digest inventories and closeout waited for a second report after merge. Most of that overhead contradicted existing guidance; this change clarifies the ambiguous parts in two existing skills.

Validate now allows a concise report referencing the complete bound manifest and receipts, while retaining full inspection, every criterion, findings, identity, freshness and unchecked scope. It distinguishes candidate judgment from native delivery facts without allowing early PASS when delivery belongs to accepted review scope. RPI uses native completion watches or bounded waits and checks the expected subject and required results before treating completion as success.

Generated companions are regenerated. No new skills, gates, schemas or workflow machinery. These are narrow guidance corrections; later use must demonstrate any reduction in wasted effort.

Validation: both existing skill validators pass; aggregate: 10 passed / 0 failed with the existing absent OL integration suite skipped; all 73 selected full gates pass; generated projections are current; exact-head CI passed all 6 jobs. Fresh author-distinct review passed the complete nine-path subject with no findings and empty unchecked scope. No new phrase-matching tests were added for this documentation change.
