### PR TITLE
fix: protect session mining and ground skill feedback in evidence

### DIFF
--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -1,12 +1,16 @@
 # Go Conventions
 
-> Canonical source with full examples: `skills/standards/references/go.md`
+> Canonical source with full examples: `skills/domain/references/standards/go.md`
 > This file is kept self-contained for sessions that don't invoke skills.
 
 ## Complexity Budget
 
 - Warn at cyclomatic complexity 15, fail at 25.
-- Run `golangci-lint run` to check.
+- Use the repository's actual complexity/CI check; lint alone does not establish
+  this budget. In AgentOps, run from the repository root:
+  `bash scripts/check-go-complexity.sh --base <accepted-base>`.
+  It discovers changed paths from committed `<accepted-base>...HEAD`; a
+  no-files/skip result does not validate uncommitted changes.
 
 ## Before Committing Go Changes
 
@@ -21,7 +25,7 @@ Or equivalently: `cd cli && make build && make test`
 
 ## Testing (AI-Native Test Shape)
 
-**L2 first, L1 always.** Write L2 integration tests first (where bugs are found), then L1 unit tests for regression safety. AI agents write both. See `skills/standards/references/test-pyramid.md` for the full AI-native test shape.
+**L2 first, L1 always.** Write L2 integration tests first (where bugs are found), then L1 unit tests for regression safety. AI agents write both. See `skills/domain/references/standards/test-pyramid.md` for the full AI-native test shape.
 
 - Test file naming: `<source>_test.go` (e.g., `goals_test.go`). NEVER `cov*_test.go` or `*_extra_test.go`.
 - Test function naming: `Test<Uppercase>` (e.g., `TestFoo_Bar`). Go requires uppercase after `Test`.
@@ -32,7 +36,7 @@ Or equivalently: `cd cli && make build && make test`
 - Prefer table-driven tests for multi-case functions.
 - Test low-level functions directly; don't depend on external CLIs (`bd`, `ao`) in tests.
 - **Prefer L2 integration tests** that call a command/workflow entry point over L1 tests that mock dependencies.
-- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must build fixtures by round-tripping a real persisted sample (serialize with the production writer, read back with the production reader) or asserting against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never produces (e.g. `consumed` at the item level when `next-work.jsonl` marks it at the batch level). A fixture of a shape production can't emit gives a false green (ag-mjlg / PR #652). Full rationale: `skills/standards/references/test-pyramid.md` → "Fixture Fidelity".
+- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must build fixtures by round-tripping a real persisted sample (serialize with the production writer, read back with the production reader) or asserting against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never produces (e.g. `consumed` at the item level when `next-work.jsonl` marks it at the batch level). A fixture of a shape production can't emit gives a false green (ag-mjlg / PR #652). Related fixture guidance: `skills/domain/references/standards/test-pyramid.md` → "Regression design".
 - **Test isolation — restore shared global/process state via `t.Cleanup`.** `cli/cmd/ao` tests share one `rootCmd` + package-global cobra flag vars and run inside the repo tree, so a test that mutates shared state without restoring it leaks into whatever test the `-shuffle=on` order runs next. This is a recurring flake class (goals `goalsMeasureScenariosOnly` cobra-global → `a9dab21c4`; `core.bare` git-env → ek8v; cwd floor → hvb).
   - A test that sets a package-global cobra flag MUST restore it via `t.Cleanup` — a self-cleaning `setFoo(t, v)` helper at every set-site is the durable shape, not a reset only on the happy path.
   - A test that mutates process state MUST scope it: `t.Chdir(t.TempDir())`, `t.Setenv`, and `git -C <tempRepo>` with `cmd.Dir` set. Never run a state-mutating `git` op against the real repo via an unset `cmd.Dir` / leaked `GIT_DIR`.

--- a/cli/internal/commands/provenance/mine_excerpts_test.go
+++ b/cli/internal/commands/provenance/mine_excerpts_test.go
@@ -110,3 +110,74 @@ func TestMineSessionDefaultRetainsEventsAndCheckpoint(t *testing.T) {
 		t.Fatalf("checkpoint replay: output=%q err=%v", out, err)
 	}
 }
+
+func TestMineSessionDryRunPreservesCheckpoint(t *testing.T) {
+	for _, existing := range []bool{false, true} {
+		name := "missing"
+		if existing {
+			name = "existing"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			source, state := filepath.Join(dir, "session.jsonl"), filepath.Join(dir, "state.json")
+			const first = "{\"type\":\"tool_use\",\"tool_name\":\"Read\",\"tool_input\":{}}\n"
+			const second = "{\"type\":\"tool_use\",\"tool_name\":\"Bash\",\"tool_input\":{}}\n"
+			if err := os.WriteFile(source, []byte(first), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			run := func(dry bool) string {
+				t.Helper()
+				root := NewModule(clicontract.HostOptions{DryRun: func() bool { return dry }}).Command()
+				var out bytes.Buffer
+				root.SetOut(&out)
+				root.SetArgs([]string{"mine-session", "--file", source, "--state", state})
+				if err := root.Execute(); err != nil {
+					t.Fatal(err)
+				}
+				return out.String()
+			}
+			var before []byte
+			wantTools := "Read,Bash"
+			if existing {
+				run(false)
+				var err error
+				before, err = os.ReadFile(state)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantTools = "Bash"
+			}
+			if err := os.WriteFile(source, []byte(first+second), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			preview := run(true)
+			var tools []string
+			for _, line := range strings.Split(strings.TrimSpace(preview), "\n") {
+				var event struct {
+					Tool string `json:"tool"`
+				}
+				if err := json.Unmarshal([]byte(line), &event); err != nil {
+					t.Fatal(err)
+				}
+				tools = append(tools, event.Tool)
+			}
+			if got := strings.Join(tools, ","); got != wantTools {
+				t.Errorf("dry-run tools = %q, want %q", got, wantTools)
+			}
+			after, err := os.ReadFile(state)
+			if existing {
+				if err != nil || !bytes.Equal(after, before) {
+					t.Errorf("dry-run changed checkpoint: before %q, after %q, error %v", before, after, err)
+				}
+			} else if !os.IsNotExist(err) {
+				t.Errorf("dry-run created checkpoint: %q, error %v", after, err)
+			}
+			if normal := run(false); normal != preview {
+				t.Errorf("normal run = %q, want preview %q", normal, preview)
+			}
+			if repeat := run(false); repeat != "" {
+				t.Errorf("normal repeat replayed events: %q", repeat)
+			}
+		})
+	}
+}

--- a/cli/internal/commands/provenance/module.go
+++ b/cli/internal/commands/provenance/module.go
@@ -712,9 +712,10 @@ only excerpt serialization; measured output limits cannot prove host delivery.`,
 
 func (m *Module) runMineSession(cmd *cobra.Command, _ []string) error {
 	return provenanceapp.MineSession(provenanceapp.MineOptions{
-		File:  m.mineFile,
-		State: m.mineState,
-		JSON:  m.mineJSON,
+		File:   m.mineFile,
+		State:  m.mineState,
+		JSON:   m.mineJSON,
+		DryRun: m.host.DryRun != nil && m.host.DryRun(),
 	}, cmd.OutOrStdout())
 }
 

--- a/cli/internal/parser/parser.go
+++ b/cli/internal/parser/parser.go
@@ -113,11 +113,12 @@ type codexTokenUsage struct {
 }
 
 type codexResponseItem struct {
-	Type      string `json:"type"`
-	Role      string `json:"role"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
-	Output    string `json:"output"`
+	Type      string  `json:"type"`
+	Role      string  `json:"role"`
+	Name      string  `json:"name"`
+	Arguments string  `json:"arguments"`
+	Input     *string `json:"input"`
+	Output    string  `json:"output"`
 	Content   []struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
@@ -576,6 +577,12 @@ func (p *Parser) parseCodexResponseItem(raw rawMessage, lineNum int) (*types.Tra
 			MessageIndex: lineNum,
 		}, nil
 	case "function_call", "custom_tool_call":
+		input := parseCodexToolInput(item.Arguments)
+		if item.Type == "custom_tool_call" && item.Input != nil {
+			// Native custom input is literal text, including empty or JSON-like
+			// strings. Only calls without it use the legacy arguments decoder.
+			input = map[string]any{"raw": *item.Input}
+		}
 		return &types.TranscriptMessage{
 			Type:         msgTypeToolUse,
 			Role:         msgTypeAssistant,
@@ -584,7 +591,7 @@ func (p *Parser) parseCodexResponseItem(raw rawMessage, lineNum int) (*types.Tra
 			MessageIndex: lineNum,
 			Tools: []types.ToolCall{{
 				Name:  coalesce(item.Name, item.Type),
-				Input: parseCodexToolInput(item.Arguments),
+				Input: input,
 			}},
 		}, nil
 	case "function_call_output", "custom_tool_call_output":

--- a/cli/internal/parser/parser_test.go
+++ b/cli/internal/parser/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -247,6 +248,68 @@ func TestParser_Parse_CodexArchivedSessionShape(t *testing.T) {
 	}
 	if len(result.Messages[4].Tools) != 1 || !strings.Contains(result.Messages[4].Tools[0].Output, "/worktree") {
 		t.Fatalf("unexpected function_call_output message: %+v", result.Messages[4])
+	}
+}
+
+func TestParser_Parse_CodexToolCallInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload string
+		want    map[string]any
+	}{
+		{
+			name:    "native custom input",
+			payload: `{"type":"custom_tool_call","name":"apply_patch","call_id":"c2","input":"*** literal patch ***"}`,
+			want:    map[string]any{"raw": "*** literal patch ***"},
+		},
+		{
+			name:    "native custom JSON text stays literal",
+			payload: `{"type":"custom_tool_call","name":"apply_patch","input":"{ \"key\": \"value\" }"}`,
+			want:    map[string]any{"raw": `{ "key": "value" }`},
+		},
+		{
+			name:    "native custom empty input overrides legacy arguments",
+			payload: `{"type":"custom_tool_call","name":"apply_patch","input":"","arguments":"legacy"}`,
+			want:    map[string]any{"raw": ""},
+		},
+		{
+			name:    "ordinary function arguments",
+			payload: `{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}","input":"ignored"}`,
+			want:    map[string]any{"cmd": "pwd"},
+		},
+		{
+			name:    "legacy custom raw arguments",
+			payload: `{"type":"custom_tool_call","name":"my_tool","arguments":"not-json"}`,
+			want:    map[string]any{"raw": "not-json"},
+		},
+		{
+			name:    "legacy custom object arguments",
+			payload: `{"type":"custom_tool_call","name":"my_tool","arguments":"{\"key\":\"value\"}"}`,
+			want:    map[string]any{"key": "value"},
+		},
+		{
+			name:    "legacy custom scalar arguments",
+			payload: `{"type":"custom_tool_call","name":"my_tool","arguments":"42"}`,
+			want:    map[string]any{"value": float64(42)},
+		},
+		{
+			name:    "legacy custom empty arguments",
+			payload: `{"type":"custom_tool_call","name":"my_tool","arguments":""}`,
+			want:    nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := NewParser().Parse(strings.NewReader(`{"type":"response_item","payload":` + tc.payload + `}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Messages) != 1 || len(result.Messages[0].Tools) != 1 {
+				t.Fatalf("expected one tool call, got %+v", result)
+			}
+			if got := result.Messages[0].Tools[0].Input; !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("input = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cli/internal/provenanceapp/mine_session.go
+++ b/cli/internal/provenanceapp/mine_session.go
@@ -70,8 +70,12 @@ func MineSession(opts MineOptions, out io.Writer) error {
 	if mineFile == "" {
 		return fmt.Errorf("mine-session: --file is required")
 	}
-	if _, err := os.Stat(mineFile); err != nil {
+	sourceInfo, err := os.Stat(mineFile)
+	if err != nil {
 		return fmt.Errorf("mine-session: cannot read --file %s: %w", mineFile, err)
+	}
+	if mineStateAliasesSource(mineStatePath, sourceInfo) {
+		return fmt.Errorf("mine-session: --state %s must not refer to --file %s", mineStatePath, mineFile)
 	}
 
 	p := parser.NewParser()
@@ -275,6 +279,14 @@ func sameFile(a, b string) bool {
 		return a == b
 	}
 	return aa == bb
+}
+
+// mineStateAliasesSource compares filesystem identity, including symlinks and
+// hardlinks, before mining can emit events or replace a source with checkpoint
+// data. Missing or inaccessible checkpoints retain their existing validation.
+func mineStateAliasesSource(path string, source os.FileInfo) bool {
+	state, err := os.Stat(path)
+	return err == nil && os.SameFile(source, state)
 }
 
 func writeMineState(path string, st mineState) error {

--- a/cli/internal/provenanceapp/mine_session.go
+++ b/cli/internal/provenanceapp/mine_session.go
@@ -53,9 +53,10 @@ type mineState struct {
 
 // MineOptions carries the mine-session flag inputs from the command module.
 type MineOptions struct {
-	File  string
-	State string
-	JSON  bool
+	File   string
+	State  string
+	JSON   bool
+	DryRun bool // Preview pending events without changing State.
 }
 
 // MineSession parses a Claude Code or Codex session transcript and emits the
@@ -132,7 +133,8 @@ func MineSession(opts MineOptions, out io.Writer) error {
 	}
 
 	// --- persist the watermark ------------------------------------------------
-	if mineStatePath != "" {
+	// Dry-run uses the same prior watermark and events, but leaves them pending.
+	if mineStatePath != "" && !opts.DryRun {
 		highest := startAfter
 		for _, m := range result.Messages {
 			if m.MessageIndex > highest {

--- a/cli/internal/provenanceapp/mine_session.go
+++ b/cli/internal/provenanceapp/mine_session.go
@@ -135,30 +135,7 @@ func MineSession(opts MineOptions, out io.Writer) error {
 	// --- persist the watermark ------------------------------------------------
 	// Dry-run uses the same prior watermark and events, but leaves them pending.
 	if mineStatePath != "" && !opts.DryRun {
-		highest := startAfter
-		for _, m := range result.Messages {
-			if m.MessageIndex > highest {
-				highest = m.MessageIndex
-			}
-		}
-		minedCount := len(events)
-		if prior != nil && startAfter == prior.LastLine {
-			minedCount += prior.MinedCount // incremental: accumulate
-		}
-		// Store the ABSOLUTE path: the File binding must be cwd-independent. Storing
-		// the raw (possibly relative) --file value lets the same relative name from a
-		// different cwd compare equal to a physically different transcript, defeating
-		// the binding and dropping that file's events.
-		storedFile := mineFile
-		if abs, aerr := filepath.Abs(mineFile); aerr == nil {
-			storedFile = abs
-		}
-		next := mineState{
-			File:           storedFile,
-			LastLine:       highest,
-			PrefixChecksum: prefixChecksum(result, highest),
-			MinedCount:     minedCount,
-		}
+		next := nextMineState(mineFile, result, prior, startAfter, len(events))
 		if err := writeMineState(mineStatePath, next); err != nil {
 			return fmt.Errorf("mine-session: write state %s: %w", mineStatePath, err)
 		}
@@ -166,6 +143,34 @@ func MineSession(opts MineOptions, out io.Writer) error {
 
 	fmt.Fprintf(os.Stderr, "mine-session: %d new event(s) from %s\n", len(events), mineFile)
 	return nil
+}
+
+// nextMineState builds the checkpoint for the parsed prefix and accumulates
+// prior events only when the prior watermark was honored.
+func nextMineState(file string, result *parser.ParseResult, prior *mineState, startAfter, minedCount int) mineState {
+	highest := startAfter
+	for _, m := range result.Messages {
+		if m.MessageIndex > highest {
+			highest = m.MessageIndex
+		}
+	}
+	if prior != nil && startAfter == prior.LastLine {
+		minedCount += prior.MinedCount // incremental: accumulate
+	}
+	// Store the ABSOLUTE path: the File binding must be cwd-independent. Storing
+	// the raw (possibly relative) --file value lets the same relative name from a
+	// different cwd compare equal to a physically different transcript, defeating
+	// the binding and dropping that file's events.
+	storedFile := file
+	if abs, aerr := filepath.Abs(file); aerr == nil {
+		storedFile = abs
+	}
+	return mineState{
+		File:           storedFile,
+		LastLine:       highest,
+		PrefixChecksum: prefixChecksum(result, highest),
+		MinedCount:     minedCount,
+	}
 }
 
 // mineToolCallEvents emits one tool_call event per tool use in messages whose

--- a/cli/internal/provenanceapp/mine_session_test.go
+++ b/cli/internal/provenanceapp/mine_session_test.go
@@ -302,6 +302,91 @@ func TestMineSession_CodexFunctionCalls(t *testing.T) {
 	}
 }
 
+func TestMineSession_CheckpointSourceAliasesRejected(t *testing.T) {
+	for _, name := range []string{
+		"identical_absolute", "identical_relative", "relative_source_absolute_state",
+		"absolute_source_relative_state", "normalized_relative_state", "source_symlink",
+		"checkpoint_symlink", "parent_directory_symlink", "hardlink",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			const content = "{\"type\":\"tool_use\",\"tool_name\":\"Read\",\"tool_input\":{}}\n"
+			sess := writeMineSession(t, dir, "source.jsonl", content)
+			source, state := sess, sess
+			switch name {
+			case "identical_relative":
+				source, state = "source.jsonl", "source.jsonl"
+			case "relative_source_absolute_state":
+				source = "./source.jsonl"
+			case "absolute_source_relative_state":
+				state = "./source.jsonl"
+			case "normalized_relative_state":
+				if err := os.Mkdir("nested", 0o700); err != nil {
+					t.Fatal(err)
+				}
+				state = "./nested/../source.jsonl"
+			case "source_symlink", "checkpoint_symlink":
+				alias := filepath.Join(dir, "alias.jsonl")
+				if err := os.Symlink(sess, alias); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				if name == "source_symlink" {
+					source = alias
+				} else {
+					state = alias
+				}
+			case "parent_directory_symlink":
+				if err := os.Symlink(dir, "alias-dir"); err != nil {
+					t.Skipf("directory symlinks unavailable: %v", err)
+				}
+				state = filepath.Join("alias-dir", "source.jsonl")
+			case "hardlink":
+				state = filepath.Join(dir, "alias.jsonl")
+				if err := os.Link(sess, state); err != nil {
+					t.Skipf("hardlinks unavailable: %v", err)
+				}
+			}
+			before, err := os.Lstat(state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err := mine(t, MineOptions{File: source, State: state})
+			if err == nil || out != "" {
+				t.Errorf("source alias must fail before emission: output %q, error %v", out, err)
+			}
+			for _, path := range []string{source, state} {
+				if got, err := os.ReadFile(path); err != nil || string(got) != content {
+					t.Errorf("source alias %s changed: %q, error %v", path, got, err)
+				}
+			}
+			if after, err := os.Lstat(state); err != nil || !os.SameFile(before, after) {
+				t.Errorf("checkpoint entry replaced: %v", err)
+			}
+		})
+	}
+}
+
+func TestMineSession_DistinctCheckpointSameContent(t *testing.T) {
+	dir := t.TempDir()
+	const content = "{\"type\":\"tool_use\",\"tool_name\":\"Read\",\"tool_input\":{}}\n"
+	sess := writeMineSession(t, dir, "source.jsonl", content)
+	state := writeMineSession(t, dir, "state.json", content)
+	out, err := mine(t, MineOptions{File: sess, State: state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if events := parseMineEvents(t, out); len(events) != 1 || events[0].Tool != "Read" {
+		t.Fatalf("distinct checkpoint must allow one Read event: %+v", events)
+	}
+	if again, err := mine(t, MineOptions{File: sess, State: state}); err != nil || again != "" {
+		t.Fatalf("distinct checkpoint did not preserve incremental mining: %q, %v", again, err)
+	}
+	if got, err := os.ReadFile(sess); err != nil || string(got) != content {
+		t.Fatalf("source changed with distinct checkpoint: %q, %v", got, err)
+	}
+}
+
 func TestMineSession_IncrementalIdempotentRollback(t *testing.T) {
 	dir := t.TempDir()
 	state := filepath.Join(dir, "state.json")

--- a/cli/internal/provenanceapp/mine_session_test.go
+++ b/cli/internal/provenanceapp/mine_session_test.go
@@ -387,6 +387,51 @@ func TestMineSession_DistinctCheckpointSameContent(t *testing.T) {
 	}
 }
 
+func TestMineSession_DryRunPreservesInputs(t *testing.T) {
+	dir := t.TempDir()
+	const first = "{\"type\":\"tool_use\",\"tool_name\":\"Read\",\"tool_input\":{}}\n"
+	const second = "{\"type\":\"tool_use\",\"tool_name\":\"Bash\",\"tool_input\":{}}\n"
+	sess := writeMineSession(t, dir, "session.jsonl", first)
+	state := filepath.Join(dir, "state.json")
+	opts := MineOptions{File: sess, State: state}
+	if _, err := mine(t, opts); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeMineSession(t, dir, "session.jsonl", first+second)
+	opts.DryRun = true
+	var silent bytes.Buffer
+	if err := MineSession(opts, &silent); err != nil || silent.Len() != 0 {
+		t.Fatalf("dry-run without JSON: output %q, error %v", silent.String(), err)
+	}
+	preview, err := mine(t, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if events := parseMineEvents(t, preview); len(events) != 1 || events[0].Tool != "Bash" || events[0].SourceLine != 2 {
+		t.Errorf("dry-run must honor prior watermark: %+v", events)
+	}
+	if repeated, err := mine(t, opts); err != nil || repeated != preview {
+		t.Errorf("repeated dry-run changed pending events: %q, error %v", repeated, err)
+	}
+	if after, err := os.ReadFile(state); err != nil || !bytes.Equal(after, before) {
+		t.Errorf("dry-run changed checkpoint: before %q, after %q, error %v", before, after, err)
+	}
+	if after, err := os.ReadFile(sess); err != nil || string(after) != first+second {
+		t.Errorf("dry-run changed source: %q, error %v", after, err)
+	}
+	opts.DryRun = false
+	if normal, err := mine(t, opts); err != nil || normal != preview {
+		t.Errorf("normal run = %q, want preview %q, error %v", normal, preview, err)
+	}
+	if repeated, err := mine(t, opts); err != nil || repeated != "" {
+		t.Errorf("normal repeat replayed events: %q, error %v", repeated, err)
+	}
+}
+
 func TestMineSession_IncrementalIdempotentRollback(t *testing.T) {
 	dir := t.TempDir()
 	state := filepath.Join(dir, "state.json")

--- a/cli/internal/provenanceapp/mine_session_test.go
+++ b/cli/internal/provenanceapp/mine_session_test.go
@@ -190,6 +190,45 @@ func TestMineSession_RollbackOnContentRewrite(t *testing.T) {
 	}
 }
 
+func TestMineSession_CodexCustomInputRewrite(t *testing.T) {
+	// age-85vu.5: native custom calls carry freeform input, not arguments.
+	// Round-trip the production checkpoint before changing only that input.
+	dir := t.TempDir()
+	const original = `{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","call_id":"c2","input":"*** Begin Patch\n*** Add File: example.txt\n+before\n*** End Patch"}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c2","output":"done"}}
+`
+	sess := writeMineSession(t, dir, "custom.jsonl", original)
+	opts := MineOptions{File: sess, State: filepath.Join(dir, "state.json")}
+
+	for _, step := range []struct {
+		name       string
+		content    string
+		wantEvents int
+	}{
+		{"first mine", original, 1},
+		{"unchanged original", original, 0},
+		{"input-only rewrite", strings.Replace(original, "+before", "+after", 1), 1},
+		{"unchanged rewrite", strings.Replace(original, "+before", "+after", 1), 0},
+	} {
+		if err := os.WriteFile(sess, []byte(step.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, err := mine(t, opts)
+		if err != nil {
+			t.Fatalf("%s: %v", step.name, err)
+		}
+		events := parseMineEvents(t, out)
+		if len(events) != step.wantEvents {
+			t.Fatalf("%s: got %d events, want %d: %+v", step.name, len(events), step.wantEvents, events)
+		}
+		for _, event := range events {
+			if event.Kind != "tool_call" || event.Tool != "apply_patch" || event.SourceLine != 1 || event.SessionID != "custom" {
+				t.Errorf("%s: unexpected custom call event: %+v", step.name, event)
+			}
+		}
+	}
+}
+
 // TestMineSession_StateBoundToFile (DROP-CASE regression): a --state watermark is
 // bound to ONE transcript. Reusing it against a DIFFERENT file (whose line-prefix
 // happens to line up) must NOT trust the stale line watermark and silently drop

--- a/docs/contracts/context-map.md
+++ b/docs/contracts/context-map.md
@@ -76,7 +76,6 @@
 | `ntm` | consumes | `pane-command-request` |
 | `ntm` | produces | `ntm-robot-state` |
 | `ntm` | produces | `agent-worker-transcript` |
-| `postmortem` | consumes | `verdict.v2` |
 | `postmortem` | produces | `postmortem-report.md` |
 | `premortem` | produces | `premortem-plan-review.v1` |
 | `reality-check` | consumes | `caller-question` |

--- a/images/gemini/skills/domain/references/standards/go.md
+++ b/images/gemini/skills/domain/references/standards/go.md
@@ -258,7 +258,7 @@ func TestClassifyServeArg(t *testing.T) {
 - **Assert exact expected values:** Use `== expected`, never `!= wrong`. (See Exact Assertion Rule above.)
 - **Table-driven tests** preferred for multi-case functions. (See example above.)
 - **Test low-level functions directly;** don't depend on external CLIs (`bd`, `ao`) in tests. (See CI-Safe Test Pattern above.)
-- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Full rationale: `test-pyramid.md` → "Fixture Fidelity".
+- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Related fixture guidance: `test-pyramid.md` → "Regression design".
 - **Test isolation — restore shared global/process state via `t.Cleanup`.** `cli/cmd/ao` tests share one `rootCmd` + package-global cobra flag vars and run inside the repo tree, so a test that mutates shared state without restoring it leaks into whatever test the `-shuffle=on` order runs next. This is a recurring flake class: goals `goalsMeasureScenariosOnly` cobra-global (`a9dab21c4`), `core.bare` git-env (ek8v), cwd floor (hvb).
   - Set a package-global cobra flag only through a self-cleaning helper, so every set-site auto-restores and no order can leak it:
 
@@ -352,7 +352,11 @@ func TestRejectsPathTraversal(t *testing.T) {
 ### Complexity Budget
 
 - **Warn** at cyclomatic complexity 15, **fail** at 25.
-- Run `golangci-lint run` to check.
+- Use the repository's actual complexity/CI check; lint alone does not establish
+  this budget. In AgentOps, run from the repository root:
+  `bash scripts/check-go-complexity.sh --base <accepted-base>`.
+  It discovers changed paths from committed `<accepted-base>...HEAD`; a
+  no-files/skip result does not validate uncommitted changes.
 
 ### Before Committing Go Changes
 

--- a/images/gemini/skills/implement/SKILL.md
+++ b/images/gemini/skills/implement/SKILL.md
@@ -33,34 +33,37 @@ owns source changes and factual checks; the runtime derives identity and receipt
 
 ## Workflow
 
-1. Read intent, acceptance, scope and the RPI [boundaries](../rpi/references/boundaries.md)
-   before the first write; reuse contracts already loaded in this context.
-   When the caller selected episode tracking, obtain permitted work/source
-   references before execution and return observed runtime/context identity at
-   startup through the native recording channel. Unknowns and recording failures
-   stay explicit; do not invent parentage or a second tracker. The optional
+1. Read intent, acceptance, scope and repository boundaries before the first
+   write; reuse loaded contracts. RPI [boundaries](../rpi/references/boundaries.md)
+   apply when that workflow is explicitly selected.
+   For caller-selected episode tracking, obtain permitted work/source references
+   and return observed runtime/context identity at startup through the native
+   recording channel. Keep unknowns and failures explicit; invent no parentage
+   or second tracker. The
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
 2. Carry the accepted behavior examples forward unchanged. Use repository
    domain names in symbols and tests; check observable outcomes through the
-   relevant interface. Find nearby validation scripts and tests that consume the edited paths or
-   contract wording. Keep their exact commands and the required integration
-   recipe in one short check list in the existing handoff; reuse it, updating
-   only when inputs or scope change. Run the smallest applicable check before
-   editing and after the change. Behavioral changes preserve RED for
-   the expected missing behavior; a pure refactor, relocation or documentation
-   change may have an honest green baseline. Avoid building elaborate fixtures
-   when an existing test or small discriminating probe answers the question.
+   relevant interface. Find actual consumers of edited paths or wording and
+   their checks. For retirement, inspect live code, tests, schemas, instructions,
+   installations and lookups as relevant; verify new guidance and old-name
+   lookup behavior, preserving historical provenance. Keep exact check commands
+   and the required integration recipe in the existing handoff. Run the smallest
+   applicable check before and after editing. Behavioral changes preserve RED
+   for the expected missing behavior; pure refactors, relocations or docs may
+   have an honest green baseline. Prefer existing tests or small discriminating probes.
 3. Make the smallest in-scope change. When repairing discovery or checks,
    preserve the consumer's existing input selection; fixing an error path does
    not authorize a wider scan. Use a negative control when exclusion matters.
-   Fix known failures directly and rerun the affected check. A disproved
-   assumption may change the approach within accepted scope; use Plan only
-   for consequential uncertainty.
+   Check a representative change against existing constraints before bulk
+   propagation; check the authored source set before broad regeneration.
+   Repair known failures directly and verify the exact result (such as a cited
+   file, assertion or returned record) before another review. A disproved assumption
+   may change the approach within scope; use Plan only for consequential uncertainty.
 4. Use targeted tests and applicable repository lint/static checks before
    broad integration. Read the repository's actual check recipe, including
    instrumentation and environment, rather than reconstructing it from memory.
-   Run required full checks at integration, not after each small edit. Reuse
+   Run required full checks at integration. Reuse
    exact-input receipts only while source, tool and relevant environment match.
    Distinguish repository-mandated hook checks from discretionary repeats;
    neither bypass required hooks nor replay a check just to rename its receipt.
@@ -79,8 +82,8 @@ owns source changes and factual checks; the runtime derives identity and receipt
    <path>` per derived path and retain its actual output. Refresh affected
    bindings after repairs; never invent or suppress the orphan list.
 7. Return identity, check commands/results, useful failures and accessible
-   evidence references through the native handoff, then stop. Full logs stay
-   at their source; do not copy them into another inventory or status document.
+   evidence references through the native handoff, then stop. Keep full logs
+   at their source, without duplicating inventories or status documents.
    Missing or truncated evidence stays explicit.
 
 ## Diagnosis, scaffolding and delegated work
@@ -118,13 +121,14 @@ continue independent authorized work. Generated companions already included as
 scope require no new approval. Acceptance changes always require caller authority.
 
 Specialists advise only. Known defects stay implementation work; a genuine
-causal stall follows RPI's at-most-one bounded helper rule. Respect remaining
-caller/native bounds and reserve finishing capacity. No retry resets them.
+causal stall permits at most one bounded fresh helper within caller authority.
+Respect remaining caller/native bounds and reserve finishing capacity; retries reset neither.
 
 Return facts, not semantic PASS. An implement-only handoff does not authorize
 Git, tracker or delivery transitions; existing caller authority remains usable.
-A full outcome request uses RPI through fresh final judgment. Success is working
-behavior with usable evidence, not volume of logs or process artifacts.
+A full outcome request continues through fresh independent final judgment;
+RPI is optional and explicitly selected. Success is working behavior with usable
+evidence, not volume of logs or process artifacts.
 
 [Generic scaffold examples](references/scaffold/generic-templates.md) are
 optional starting points when the repository has no suitable existing pattern.

--- a/images/gemini/skills/postmortem/SKILL.md
+++ b/images/gemini/skills/postmortem/SKILL.md
@@ -5,8 +5,7 @@ practices:
 - sre
 - lean-startup
 hexagonal_role: domain
-consumes:
-- verdict.v2
+consumes: []
 produces:
 - postmortem-report.md
 context_rel: []
@@ -27,69 +26,58 @@ context:
   sections:
     exclude:
     - HISTORY
-output_contract: 'YYYY-MM-DD-postmortem-<topic>.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
+output_contract: 'concise inline causal analysis; a requested durable report is YYYY-MM-DD-postmortem-<topic>.md in caller-selected protected external non-Git storage'
 ---
 
 # Postmortem
 
-> **Purpose:** Answer an explicit retrospective causal question using the
-> already-validated outcome and evidence.
+Answer an explicit retrospective causal question about a completed or stopped
+goal, session or change using its actual intent, outcome and judgment evidence.
 
 ## Prompt
 
 ```text
-Postmortem: verdict .agents/ao/verdicts/2026-08-30-cli-regen.json shows
-NOT_PROVEN then PASS after we added a mutating-check guard to
-skills/validate/scripts/validate.sh. Did that guard actually cause the
-fix, or did the flaky CI runner just stop flaking that day?
+Postmortem this stopped change using its accepted intent, native session,
+check results and reviewer messages. Which correction cycles were avoidable,
+and which checks were necessary? No verdict file was saved. Answer inline.
 ```
-
-## It's working if
-
-Observable in the trace, without reading the prose:
-
-- The report pins the exact `verdict.v2` id and the causal question before
-  the timeline section.
-- A claim promoted to cause cites its mechanism, evidence, and
-  counterfactual together under the report's `hypotheses` list.
-- A claim resting only on symptom cessation is listed under `unknowns`,
-  not promoted to cause.
-- The report lands at
-  `.agents/scratch/postmortem/YYYY-MM-DD-postmortem-<topic>.md` and
-  `bash skills/postmortem/scripts/validate.sh` exits 0.
 
 ## Critical Constraints
 
-- Because proof and causal inference are different judgments, Postmortem is retrospective causal analysis, not the general learning umbrella and not a completion gate.
-- It consumes immutable Validate verdict evidence and does not re-run acceptance validation because Validate already owns that proof.
-- Treat causal statements as hypotheses because causal confidence must survive
-  alternatives. Separate observed sequence, contributing conditions,
-  counterfactuals, and unknowns.
-- A correlation is not promoted to cause without evidence that discriminates
-  plausible alternatives.
-- Because the caller owns delivery decisions, do not rewrite proof, operate
-  tracker state, change the remaining plan, or promote a rule. Return evidence
-  to the caller.
-- Empty or inconclusive analysis is valid; manufacture neither certainty nor a
-  lesson to make the retrospective feel useful.
+- Postmortem is retrospective causal analysis, not the general learning umbrella
+  or a completion gate: acceptance proof and causal inference are different judgments.
+- Existing verdicts and native judgments remain unchanged. It does not re-run acceptance validation
+  or fabricate missing proof to enable a retrospective. An existing `verdict.v2`
+  is optional evidence; its absence does not exclude a stopped or unvalidated subject.
+- Because the caller owns subsequent action, do not rewrite proof, operate
+  tracker state, change the remaining plan, reopen work or promote a rule.
+- Empty or inconclusive analysis is valid; recommend no change when warranted.
+  Manufacture neither certainty nor a lesson.
 
 ## Workflow
 
-1. Pin the verdict, subject evidence, and explicit causal
-   question.
-2. Reconstruct the evidence-backed timeline without importing hidden author
-   reasoning as fact.
-3. List candidate contributing conditions and at least one plausible
-   alternative explanation.
-4. Test each claim against cited evidence and a counterfactual: what should
-   differ if the claim were false?
-5. Optionally use independent judges to challenge contested causal claims.
-6. Emit a report containing supported claims, rejected claims, unknowns,
-   evidence references, and suggested experiments. Stop.
+1. Pin the explicit question, accepted intent, subject identity, actual outcome
+   and available judgment. Cite native work/session references, commits, checks
+   and reviewer messages as applicable; cite an existing verdict by exact id.
+   Keep missing evidence explicit before drawing conclusions.
+2. Reconstruct only the relevant evidence-backed timeline. Keep delivered
+   behavior, failed/stopped work and process output distinct; hidden author
+   reasoning is not fact. Missing judgment is not a PASS or a FAIL.
+3. Separate delivered facts from causal hypotheses. Test contributing conditions
+   against cited evidence, at least one
+   plausible alternative and a counterfactual. Distinguish necessary validation
+   and compatibility work from avoidable rework; repeated review alone proves no waste.
+4. For time/token claims, state source, interval, units, included/excluded actors
+   and uncertainty. Separate elapsed time, overlapping work and accounting scopes;
+   never equate totals with waste, savings or money without supporting evidence.
+5. Optionally seek independent support or challenge for contested causal claims
+   within caller authority. Return supported/rejected claims, unknowns and at
+   most three supported changes with limits or small suggested experiments. Stop;
+   suggestions do not authorize implementation.
 
 ## Correlation-to-cause discrimination
 
-A fix is proven when the mechanism is demonstrated, not when symptoms stop.
+Treat causal statements as hypotheses until the mechanism is demonstrated.
 Promoting a claim from correlation to cause requires all three:
 
 - a stated mechanism — the specific path by which the condition produced the
@@ -99,31 +87,31 @@ Promoting a claim from correlation to cause requires all three:
 - a counterfactual test — what should have differed if the claim were false,
   with the cited evidence showing it did differ.
 
-Symptom disappearance after a change satisfies none of these on its own: the
-change and the recovery may share an unobserved cause, or the symptom may be
-intermittent. The named failure mode is post-hoc fix attribution — "we
-changed X and the failure stopped, therefore X was the cause." Claims backed
-only by symptom cessation stay in the report as correlations with the
-untested alternatives listed, and the suggested experiment is the
-discrimination that would settle them. Stop condition: every supported causal
-claim in the report carries all three elements with citations; anything less
-is filed under correlations or unknowns, never silently promoted.
+Post-hoc fix attribution — "we changed X and the failure stopped, therefore X
+was the cause" — satisfies none of these alone. The symptom may be intermittent,
+or recovery and the change may share an unobserved cause. Keep such claims as
+correlations with untested alternatives and a suggested discriminating experiment.
+Every supported causal claim needs all three elements with citations; anything
+less stays a correlation or unknown.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/scratch/postmortem/`.
-- **Filename convention:** `YYYY-MM-DD-postmortem-<topic>.md`.
-- **Serialization/schema format:** Markdown with causal question, pinned inputs,
-  timeline, hypotheses, evidence, counterfactuals, unknowns, and experiments.
-- **Validator command:** `bash skills/postmortem/scripts/validate.sh`.
-- **Downstream handoff:** Learn or the caller may consume the analysis; they own
-  any bookkeeping, promotion, planning, or delivery decision.
+- Default to concise inline Markdown: question, pinned inputs, relevant timeline,
+  hypotheses/evidence/counterfactuals, unknowns and bounded suggestions. No mandatory report or worksheet.
+- Only when requested, save `YYYY-MM-DD-postmortem-<topic>.md` in caller-selected
+  protected external non-Git storage. Missing routing does not authorize a
+  repository fallback; preserve existing requested evidence under owner policy.
+- `bash skills/postmortem/scripts/validate.sh` checks package structure and
+  contract markers. It does not inspect report truth, causal support or acceptance.
+- The caller owns bookkeeping, planning and delivery. Optional
+  [Memory](../memory/SKILL.md) owns any separately authorized curation, support
+  and destination-disclosure review; retrospective evidence cannot promote itself.
 
 ## Quality Checklist
 
-- [ ] The causal question and immutable inputs are pinned.
+- [ ] The causal question and actual inputs are pinned; gaps are explicit.
 - [ ] Supported and rejected claims cite discriminating evidence.
 - [ ] Alternatives, counterfactuals, and unknowns remain visible.
 - [ ] The report stops short of proof, planning, tracker, and delivery authority.
 
-Executable behavior is in [postmortem.feature](references/postmortem.feature).
+Behavior examples are in [postmortem.feature](references/postmortem.feature).

--- a/images/gemini/skills/postmortem/references/postmortem.feature
+++ b/images/gemini/skills/postmortem/references/postmortem.feature
@@ -1,17 +1,22 @@
 Feature: Postmortem tests retrospective causal claims
-  As an engineer learning from a validated outcome
+  As an engineer learning from a completed or stopped goal, session or change
   I want causal hypotheses challenged against evidence and counterfactuals
   So that retrospective stories do not become unsupported doctrine
 
   Scenario: An explicit causal question receives bounded analysis
-    Given an immutable Validate verdict
+    Given actual intent, outcome and available native judgment evidence
     And an explicit retrospective causal question
     When Postmortem reconstructs the evidence-backed timeline
     Then it distinguishes supported claims, rejected claims, and unknowns
     And it cites evidence and counterfactuals
+    And it distinguishes delivered facts, necessary checks and avoidable rework
+    And uncertain time and token accounting remains explicit
+    And it returns at most three supported changes or no-change inline by default
 
   Scenario: Postmortem does not repeat validation
-    Given the acceptance verdict is already immutable
+    Given an existing immutable verdict or no saved verdict
     When Postmortem begins
     Then it does not re-run acceptance validation
+    And it does not fabricate missing judgment evidence
     And it does not change proof, bookkeeping, planning, tracker, or delivery state
+    And it saves a report only on request in protected external non-Git storage

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -309,8 +309,8 @@
     {
       "name": "domain",
       "source_skill": "skills/domain",
-      "source_hash": "17cf1fed0fc75cf99d51b74564ea66b86870613af9f7aa9f29f101b5c4070361",
-      "generated_hash": "3a8ab250ef588a8bf989c1553550a145d74f00969751d7508ca4f427b39cba0a"
+      "source_hash": "3a40c3d2bb61fe1bc09060f695bff2291b8f3a530267073225d7b70288281d78",
+      "generated_hash": "3e6d2676aa3238ce9bbbca971f15daed09f74ad10cd9dec1a8398386429484df"
     },
     {
       "name": "idea-genie",

--- a/skills-codex/.agentops-manifest.json
+++ b/skills-codex/.agentops-manifest.json
@@ -321,8 +321,8 @@
     {
       "name": "implement",
       "source_skill": "skills/implement",
-      "source_hash": "7e37fb379de17fbd31e16cf93511713765d070413515720c5636584698d0bc62",
-      "generated_hash": "6c2f4e4f63a32a23eedf61753d588aeac84cd86b033a3b441fc4bae7fa582fe2"
+      "source_hash": "af41fa112d21870677ed165e70c28f4e5b923bbb07f986cceab6abd016ee6e0a",
+      "generated_hash": "47556d3d595cbb739d5ea6c4b244849acc09246e3b1b71a1ee76d346344f4ce2"
     },
     {
       "name": "memory",
@@ -351,8 +351,8 @@
     {
       "name": "postmortem",
       "source_skill": "skills/postmortem",
-      "source_hash": "92f7b2e76704eac10e9099f18400faf2d430101c85ad2c031045929e70995644",
-      "generated_hash": "cedb3c17ddf726729b3c43521fba546f0fda3003e14c06b78216b548e9a29480"
+      "source_hash": "16f80995fc7bc81c9711f66d47d17d1acb74caa1d49f9bc7db963a4916f1632d",
+      "generated_hash": "e83306969ec80722d9367c01e1e7d307643f63e593b642612a250fcffea19503"
     },
     {
       "name": "premortem",

--- a/skills-codex/domain/.agentops-generated.json
+++ b/skills-codex/domain/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/domain",
   "layout": "modular",
-  "source_hash": "17cf1fed0fc75cf99d51b74564ea66b86870613af9f7aa9f29f101b5c4070361",
-  "generated_hash": "3a8ab250ef588a8bf989c1553550a145d74f00969751d7508ca4f427b39cba0a"
+  "source_hash": "3a40c3d2bb61fe1bc09060f695bff2291b8f3a530267073225d7b70288281d78",
+  "generated_hash": "3e6d2676aa3238ce9bbbca971f15daed09f74ad10cd9dec1a8398386429484df"
 }

--- a/skills-codex/domain/references/standards/go.md
+++ b/skills-codex/domain/references/standards/go.md
@@ -258,7 +258,7 @@ func TestClassifyServeArg(t *testing.T) {
 - **Assert exact expected values:** Use `== expected`, never `!= wrong`. (See Exact Assertion Rule above.)
 - **Table-driven tests** preferred for multi-case functions. (See example above.)
 - **Test low-level functions directly;** don't depend on external CLIs (`bd`, `ao`) in tests. (See CI-Safe Test Pattern above.)
-- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Full rationale: `test-pyramid.md` → "Fixture Fidelity".
+- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Related fixture guidance: `test-pyramid.md` → "Regression design".
 - **Test isolation — restore shared global/process state via `t.Cleanup`.** `cli/cmd/ao` tests share one `rootCmd` + package-global cobra flag vars and run inside the repo tree, so a test that mutates shared state without restoring it leaks into whatever test the `-shuffle=on` order runs next. This is a recurring flake class: goals `goalsMeasureScenariosOnly` cobra-global (`a9dab21c4`), `core.bare` git-env (ek8v), cwd floor (hvb).
   - Set a package-global cobra flag only through a self-cleaning helper, so every set-site auto-restores and no order can leak it:
 
@@ -352,7 +352,11 @@ func TestRejectsPathTraversal(t *testing.T) {
 ### Complexity Budget
 
 - **Warn** at cyclomatic complexity 15, **fail** at 25.
-- Run `golangci-lint run` to check.
+- Use the repository's actual complexity/CI check; lint alone does not establish
+  this budget. In AgentOps, run from the repository root:
+  `bash scripts/check-go-complexity.sh --base <accepted-base>`.
+  It discovers changed paths from committed `<accepted-base>...HEAD`; a
+  no-files/skip result does not validate uncommitted changes.
 
 ### Before Committing Go Changes
 

--- a/skills-codex/implement/.agentops-generated.json
+++ b/skills-codex/implement/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/implement",
   "layout": "modular",
-  "source_hash": "7e37fb379de17fbd31e16cf93511713765d070413515720c5636584698d0bc62",
-  "generated_hash": "6c2f4e4f63a32a23eedf61753d588aeac84cd86b033a3b441fc4bae7fa582fe2"
+  "source_hash": "af41fa112d21870677ed165e70c28f4e5b923bbb07f986cceab6abd016ee6e0a",
+  "generated_hash": "47556d3d595cbb739d5ea6c4b244849acc09246e3b1b71a1ee76d346344f4ce2"
 }

--- a/skills-codex/implement/SKILL.md
+++ b/skills-codex/implement/SKILL.md
@@ -10,34 +10,37 @@ owns source changes and factual checks; the runtime derives identity and receipt
 
 ## Workflow
 
-1. Read intent, acceptance, scope and the RPI [boundaries](../rpi/references/boundaries.md)
-   before the first write; reuse contracts already loaded in this context.
-   When the caller selected episode tracking, obtain permitted work/source
-   references before execution and return observed runtime/context identity at
-   startup through the native recording channel. Unknowns and recording failures
-   stay explicit; do not invent parentage or a second tracker. The optional
+1. Read intent, acceptance, scope and repository boundaries before the first
+   write; reuse loaded contracts. RPI [boundaries](../rpi/references/boundaries.md)
+   apply when that workflow is explicitly selected.
+   For caller-selected episode tracking, obtain permitted work/source references
+   and return observed runtime/context identity at startup through the native
+   recording channel. Keep unknowns and failures explicit; invent no parentage
+   or second tracker. The
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
 2. Carry the accepted behavior examples forward unchanged. Use repository
    domain names in symbols and tests; check observable outcomes through the
-   relevant interface. Find nearby validation scripts and tests that consume the edited paths or
-   contract wording. Keep their exact commands and the required integration
-   recipe in one short check list in the existing handoff; reuse it, updating
-   only when inputs or scope change. Run the smallest applicable check before
-   editing and after the change. Behavioral changes preserve RED for
-   the expected missing behavior; a pure refactor, relocation or documentation
-   change may have an honest green baseline. Avoid building elaborate fixtures
-   when an existing test or small discriminating probe answers the question.
+   relevant interface. Find actual consumers of edited paths or wording and
+   their checks. For retirement, inspect live code, tests, schemas, instructions,
+   installations and lookups as relevant; verify new guidance and old-name
+   lookup behavior, preserving historical provenance. Keep exact check commands
+   and the required integration recipe in the existing handoff. Run the smallest
+   applicable check before and after editing. Behavioral changes preserve RED
+   for the expected missing behavior; pure refactors, relocations or docs may
+   have an honest green baseline. Prefer existing tests or small discriminating probes.
 3. Make the smallest in-scope change. When repairing discovery or checks,
    preserve the consumer's existing input selection; fixing an error path does
    not authorize a wider scan. Use a negative control when exclusion matters.
-   Fix known failures directly and rerun the affected check. A disproved
-   assumption may change the approach within accepted scope; use Plan only
-   for consequential uncertainty.
+   Check a representative change against existing constraints before bulk
+   propagation; check the authored source set before broad regeneration.
+   Repair known failures directly and verify the exact result (such as a cited
+   file, assertion or returned record) before another review. A disproved assumption
+   may change the approach within scope; use Plan only for consequential uncertainty.
 4. Use targeted tests and applicable repository lint/static checks before
    broad integration. Read the repository's actual check recipe, including
    instrumentation and environment, rather than reconstructing it from memory.
-   Run required full checks at integration, not after each small edit. Reuse
+   Run required full checks at integration. Reuse
    exact-input receipts only while source, tool and relevant environment match.
    Distinguish repository-mandated hook checks from discretionary repeats;
    neither bypass required hooks nor replay a check just to rename its receipt.
@@ -56,8 +59,8 @@ owns source changes and factual checks; the runtime derives identity and receipt
    <path>` per derived path and retain its actual output. Refresh affected
    bindings after repairs; never invent or suppress the orphan list.
 7. Return identity, check commands/results, useful failures and accessible
-   evidence references through the native handoff, then stop. Full logs stay
-   at their source; do not copy them into another inventory or status document.
+   evidence references through the native handoff, then stop. Keep full logs
+   at their source, without duplicating inventories or status documents.
    Missing or truncated evidence stays explicit.
 
 ## Diagnosis, scaffolding and delegated work
@@ -95,13 +98,14 @@ continue independent authorized work. Generated companions already included as
 scope require no new approval. Acceptance changes always require caller authority.
 
 Specialists advise only. Known defects stay implementation work; a genuine
-causal stall follows RPI's at-most-one bounded helper rule. Respect remaining
-caller/native bounds and reserve finishing capacity. No retry resets them.
+causal stall permits at most one bounded fresh helper within caller authority.
+Respect remaining caller/native bounds and reserve finishing capacity; retries reset neither.
 
 Return facts, not semantic PASS. An implement-only handoff does not authorize
 Git, tracker or delivery transitions; existing caller authority remains usable.
-A full outcome request uses RPI through fresh final judgment. Success is working
-behavior with usable evidence, not volume of logs or process artifacts.
+A full outcome request continues through fresh independent final judgment;
+RPI is optional and explicitly selected. Success is working behavior with usable
+evidence, not volume of logs or process artifacts.
 
 [Generic scaffold examples](references/scaffold/generic-templates.md) are
 optional starting points when the repository has no suitable existing pattern.

--- a/skills-codex/postmortem/.agentops-generated.json
+++ b/skills-codex/postmortem/.agentops-generated.json
@@ -2,6 +2,6 @@
   "generator": "codex-sync",
   "source_skill": "skills/postmortem",
   "layout": "modular",
-  "source_hash": "92f7b2e76704eac10e9099f18400faf2d430101c85ad2c031045929e70995644",
-  "generated_hash": "cedb3c17ddf726729b3c43521fba546f0fda3003e14c06b78216b548e9a29480"
+  "source_hash": "16f80995fc7bc81c9711f66d47d17d1acb74caa1d49f9bc7db963a4916f1632d",
+  "generated_hash": "e83306969ec80722d9367c01e1e7d307643f63e593b642612a250fcffea19503"
 }

--- a/skills-codex/postmortem/SKILL.md
+++ b/skills-codex/postmortem/SKILL.md
@@ -4,64 +4,53 @@ description: 'Test a retrospective causal question against outcome evidence. Use
 ---
 # Postmortem
 
-> **Purpose:** Answer an explicit retrospective causal question using the
-> already-validated outcome and evidence.
+Answer an explicit retrospective causal question about a completed or stopped
+goal, session or change using its actual intent, outcome and judgment evidence.
 
 ## Prompt
 
 ```text
-Postmortem: verdict .agents/ao/verdicts/2026-08-30-cli-regen.json shows
-NOT_PROVEN then PASS after we added a mutating-check guard to
-skills/validate/scripts/validate.sh. Did that guard actually cause the
-fix, or did the flaky CI runner just stop flaking that day?
+Postmortem this stopped change using its accepted intent, native session,
+check results and reviewer messages. Which correction cycles were avoidable,
+and which checks were necessary? No verdict file was saved. Answer inline.
 ```
-
-## It's working if
-
-Observable in the trace, without reading the prose:
-
-- The report pins the exact `verdict.v2` id and the causal question before
-  the timeline section.
-- A claim promoted to cause cites its mechanism, evidence, and
-  counterfactual together under the report's `hypotheses` list.
-- A claim resting only on symptom cessation is listed under `unknowns`,
-  not promoted to cause.
-- The report lands at
-  `.agents/scratch/postmortem/YYYY-MM-DD-postmortem-<topic>.md` and
-  `bash skills/postmortem/scripts/validate.sh` exits 0.
 
 ## Critical Constraints
 
-- Because proof and causal inference are different judgments, Postmortem is retrospective causal analysis, not the general learning umbrella and not a completion gate.
-- It consumes immutable Validate verdict evidence and does not re-run acceptance validation because Validate already owns that proof.
-- Treat causal statements as hypotheses because causal confidence must survive
-  alternatives. Separate observed sequence, contributing conditions,
-  counterfactuals, and unknowns.
-- A correlation is not promoted to cause without evidence that discriminates
-  plausible alternatives.
-- Because the caller owns delivery decisions, do not rewrite proof, operate
-  tracker state, change the remaining plan, or promote a rule. Return evidence
-  to the caller.
-- Empty or inconclusive analysis is valid; manufacture neither certainty nor a
-  lesson to make the retrospective feel useful.
+- Postmortem is retrospective causal analysis, not the general learning umbrella
+  or a completion gate: acceptance proof and causal inference are different judgments.
+- Existing verdicts and native judgments remain unchanged. It does not re-run acceptance validation
+  or fabricate missing proof to enable a retrospective. An existing `verdict.v2`
+  is optional evidence; its absence does not exclude a stopped or unvalidated subject.
+- Because the caller owns subsequent action, do not rewrite proof, operate
+  tracker state, change the remaining plan, reopen work or promote a rule.
+- Empty or inconclusive analysis is valid; recommend no change when warranted.
+  Manufacture neither certainty nor a lesson.
 
 ## Workflow
 
-1. Pin the verdict, subject evidence, and explicit causal
-   question.
-2. Reconstruct the evidence-backed timeline without importing hidden author
-   reasoning as fact.
-3. List candidate contributing conditions and at least one plausible
-   alternative explanation.
-4. Test each claim against cited evidence and a counterfactual: what should
-   differ if the claim were false?
-5. Optionally use independent judges to challenge contested causal claims.
-6. Emit a report containing supported claims, rejected claims, unknowns,
-   evidence references, and suggested experiments. Stop.
+1. Pin the explicit question, accepted intent, subject identity, actual outcome
+   and available judgment. Cite native work/session references, commits, checks
+   and reviewer messages as applicable; cite an existing verdict by exact id.
+   Keep missing evidence explicit before drawing conclusions.
+2. Reconstruct only the relevant evidence-backed timeline. Keep delivered
+   behavior, failed/stopped work and process output distinct; hidden author
+   reasoning is not fact. Missing judgment is not a PASS or a FAIL.
+3. Separate delivered facts from causal hypotheses. Test contributing conditions
+   against cited evidence, at least one
+   plausible alternative and a counterfactual. Distinguish necessary validation
+   and compatibility work from avoidable rework; repeated review alone proves no waste.
+4. For time/token claims, state source, interval, units, included/excluded actors
+   and uncertainty. Separate elapsed time, overlapping work and accounting scopes;
+   never equate totals with waste, savings or money without supporting evidence.
+5. Optionally seek independent support or challenge for contested causal claims
+   within caller authority. Return supported/rejected claims, unknowns and at
+   most three supported changes with limits or small suggested experiments. Stop;
+   suggestions do not authorize implementation.
 
 ## Correlation-to-cause discrimination
 
-A fix is proven when the mechanism is demonstrated, not when symptoms stop.
+Treat causal statements as hypotheses until the mechanism is demonstrated.
 Promoting a claim from correlation to cause requires all three:
 
 - a stated mechanism — the specific path by which the condition produced the
@@ -71,31 +60,31 @@ Promoting a claim from correlation to cause requires all three:
 - a counterfactual test — what should have differed if the claim were false,
   with the cited evidence showing it did differ.
 
-Symptom disappearance after a change satisfies none of these on its own: the
-change and the recovery may share an unobserved cause, or the symptom may be
-intermittent. The named failure mode is post-hoc fix attribution — "we
-changed X and the failure stopped, therefore X was the cause." Claims backed
-only by symptom cessation stay in the report as correlations with the
-untested alternatives listed, and the suggested experiment is the
-discrimination that would settle them. Stop condition: every supported causal
-claim in the report carries all three elements with citations; anything less
-is filed under correlations or unknowns, never silently promoted.
+Post-hoc fix attribution — "we changed X and the failure stopped, therefore X
+was the cause" — satisfies none of these alone. The symptom may be intermittent,
+or recovery and the change may share an unobserved cause. Keep such claims as
+correlations with untested alternatives and a suggested discriminating experiment.
+Every supported causal claim needs all three elements with citations; anything
+less stays a correlation or unknown.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/scratch/postmortem/`.
-- **Filename convention:** `YYYY-MM-DD-postmortem-<topic>.md`.
-- **Serialization/schema format:** Markdown with causal question, pinned inputs,
-  timeline, hypotheses, evidence, counterfactuals, unknowns, and experiments.
-- **Validator command:** `bash skills/postmortem/scripts/validate.sh`.
-- **Downstream handoff:** Learn or the caller may consume the analysis; they own
-  any bookkeeping, promotion, planning, or delivery decision.
+- Default to concise inline Markdown: question, pinned inputs, relevant timeline,
+  hypotheses/evidence/counterfactuals, unknowns and bounded suggestions. No mandatory report or worksheet.
+- Only when requested, save `YYYY-MM-DD-postmortem-<topic>.md` in caller-selected
+  protected external non-Git storage. Missing routing does not authorize a
+  repository fallback; preserve existing requested evidence under owner policy.
+- `bash skills/postmortem/scripts/validate.sh` checks package structure and
+  contract markers. It does not inspect report truth, causal support or acceptance.
+- The caller owns bookkeeping, planning and delivery. Optional
+  [Memory](../memory/SKILL.md) owns any separately authorized curation, support
+  and destination-disclosure review; retrospective evidence cannot promote itself.
 
 ## Quality Checklist
 
-- [ ] The causal question and immutable inputs are pinned.
+- [ ] The causal question and actual inputs are pinned; gaps are explicit.
 - [ ] Supported and rejected claims cite discriminating evidence.
 - [ ] Alternatives, counterfactuals, and unknowns remain visible.
 - [ ] The report stops short of proof, planning, tracker, and delivery authority.
 
-Executable behavior is in [postmortem.feature](references/postmortem.feature).
+Behavior examples are in [postmortem.feature](references/postmortem.feature).

--- a/skills-codex/postmortem/references/postmortem.feature
+++ b/skills-codex/postmortem/references/postmortem.feature
@@ -1,17 +1,22 @@
 Feature: Postmortem tests retrospective causal claims
-  As an engineer learning from a validated outcome
+  As an engineer learning from a completed or stopped goal, session or change
   I want causal hypotheses challenged against evidence and counterfactuals
   So that retrospective stories do not become unsupported doctrine
 
   Scenario: An explicit causal question receives bounded analysis
-    Given an immutable Validate verdict
+    Given actual intent, outcome and available native judgment evidence
     And an explicit retrospective causal question
     When Postmortem reconstructs the evidence-backed timeline
     Then it distinguishes supported claims, rejected claims, and unknowns
     And it cites evidence and counterfactuals
+    And it distinguishes delivered facts, necessary checks and avoidable rework
+    And uncertain time and token accounting remains explicit
+    And it returns at most three supported changes or no-change inline by default
 
   Scenario: Postmortem does not repeat validation
-    Given the acceptance verdict is already immutable
+    Given an existing immutable verdict or no saved verdict
     When Postmortem begins
     Then it does not re-run acceptance validation
+    And it does not fabricate missing judgment evidence
     And it does not change proof, bookkeeping, planning, tracker, or delivery state
+    And it saves a report only on request in protected external non-Git storage

--- a/skills-codex/postmortem/scripts/validate.sh
+++ b/skills-codex/postmortem/scripts/validate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Static package/contract checks only; no report or causal claim is evaluated.
 
 skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -15,4 +16,4 @@ if grep -Eiq 'ao (pawl|land)|git (commit|push)|br (close|update)' "$skill_dir/SK
   exit 1
 fi
 
-echo 'postmortem skill contract: PASS'
+echo 'postmortem static package contract: PASS (report truth not checked)'

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -613,9 +613,7 @@
         "postmortem"
       ],
       "codex_override_present": true,
-      "consumes": [
-        "verdict.v2"
-      ],
+      "consumes": [],
       "context_rel": [],
       "dependencies": [],
       "description": "Test a retrospective causal question against outcome evidence. Use when: a postmortem is explicitly requested; finishing a task does not require a report or lesson.",

--- a/skills/domain/references/standards/go.md
+++ b/skills/domain/references/standards/go.md
@@ -258,7 +258,7 @@ func TestClassifyServeArg(t *testing.T) {
 - **Assert exact expected values:** Use `== expected`, never `!= wrong`. (See Exact Assertion Rule above.)
 - **Table-driven tests** preferred for multi-case functions. (See example above.)
 - **Test low-level functions directly;** don't depend on external CLIs (`bd`, `ao`) in tests. (See CI-Safe Test Pattern above.)
-- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Full rationale: `test-pyramid.md` → "Fixture Fidelity".
+- **Guard-test fixtures must use the real persisted shape.** Skip/dedup/consumed/idempotency/regression guard tests must round-trip a real persisted sample (production writer → production reader) or assert against a checked-in real example — never a hand-built in-memory constructor that sets a marker at a granularity the on-disk format never emits (e.g. `consumed` at item-level when `next-work.jsonl` marks it at batch-level). A fixture of a shape production can't produce gives a false green (ag-mjlg / PR #652). Related fixture guidance: `test-pyramid.md` → "Regression design".
 - **Test isolation — restore shared global/process state via `t.Cleanup`.** `cli/cmd/ao` tests share one `rootCmd` + package-global cobra flag vars and run inside the repo tree, so a test that mutates shared state without restoring it leaks into whatever test the `-shuffle=on` order runs next. This is a recurring flake class: goals `goalsMeasureScenariosOnly` cobra-global (`a9dab21c4`), `core.bare` git-env (ek8v), cwd floor (hvb).
   - Set a package-global cobra flag only through a self-cleaning helper, so every set-site auto-restores and no order can leak it:
 
@@ -352,7 +352,11 @@ func TestRejectsPathTraversal(t *testing.T) {
 ### Complexity Budget
 
 - **Warn** at cyclomatic complexity 15, **fail** at 25.
-- Run `golangci-lint run` to check.
+- Use the repository's actual complexity/CI check; lint alone does not establish
+  this budget. In AgentOps, run from the repository root:
+  `bash scripts/check-go-complexity.sh --base <accepted-base>`.
+  It discovers changed paths from committed `<accepted-base>...HEAD`; a
+  no-files/skip result does not validate uncommitted changes.
 
 ### Before Committing Go Changes
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -33,34 +33,37 @@ owns source changes and factual checks; the runtime derives identity and receipt
 
 ## Workflow
 
-1. Read intent, acceptance, scope and the RPI [boundaries](../rpi/references/boundaries.md)
-   before the first write; reuse contracts already loaded in this context.
-   When the caller selected episode tracking, obtain permitted work/source
-   references before execution and return observed runtime/context identity at
-   startup through the native recording channel. Unknowns and recording failures
-   stay explicit; do not invent parentage or a second tracker. The optional
+1. Read intent, acceptance, scope and repository boundaries before the first
+   write; reuse loaded contracts. RPI [boundaries](../rpi/references/boundaries.md)
+   apply when that workflow is explicitly selected.
+   For caller-selected episode tracking, obtain permitted work/source references
+   and return observed runtime/context identity at startup through the native
+   recording channel. Keep unknowns and failures explicit; invent no parentage
+   or second tracker. The
    [session association reference](../cass/references/SESSION_FORMATS.md#work-to-session-associations)
    supplies mechanics for that selected workflow.
 2. Carry the accepted behavior examples forward unchanged. Use repository
    domain names in symbols and tests; check observable outcomes through the
-   relevant interface. Find nearby validation scripts and tests that consume the edited paths or
-   contract wording. Keep their exact commands and the required integration
-   recipe in one short check list in the existing handoff; reuse it, updating
-   only when inputs or scope change. Run the smallest applicable check before
-   editing and after the change. Behavioral changes preserve RED for
-   the expected missing behavior; a pure refactor, relocation or documentation
-   change may have an honest green baseline. Avoid building elaborate fixtures
-   when an existing test or small discriminating probe answers the question.
+   relevant interface. Find actual consumers of edited paths or wording and
+   their checks. For retirement, inspect live code, tests, schemas, instructions,
+   installations and lookups as relevant; verify new guidance and old-name
+   lookup behavior, preserving historical provenance. Keep exact check commands
+   and the required integration recipe in the existing handoff. Run the smallest
+   applicable check before and after editing. Behavioral changes preserve RED
+   for the expected missing behavior; pure refactors, relocations or docs may
+   have an honest green baseline. Prefer existing tests or small discriminating probes.
 3. Make the smallest in-scope change. When repairing discovery or checks,
    preserve the consumer's existing input selection; fixing an error path does
    not authorize a wider scan. Use a negative control when exclusion matters.
-   Fix known failures directly and rerun the affected check. A disproved
-   assumption may change the approach within accepted scope; use Plan only
-   for consequential uncertainty.
+   Check a representative change against existing constraints before bulk
+   propagation; check the authored source set before broad regeneration.
+   Repair known failures directly and verify the exact result (such as a cited
+   file, assertion or returned record) before another review. A disproved assumption
+   may change the approach within scope; use Plan only for consequential uncertainty.
 4. Use targeted tests and applicable repository lint/static checks before
    broad integration. Read the repository's actual check recipe, including
    instrumentation and environment, rather than reconstructing it from memory.
-   Run required full checks at integration, not after each small edit. Reuse
+   Run required full checks at integration. Reuse
    exact-input receipts only while source, tool and relevant environment match.
    Distinguish repository-mandated hook checks from discretionary repeats;
    neither bypass required hooks nor replay a check just to rename its receipt.
@@ -79,8 +82,8 @@ owns source changes and factual checks; the runtime derives identity and receipt
    <path>` per derived path and retain its actual output. Refresh affected
    bindings after repairs; never invent or suppress the orphan list.
 7. Return identity, check commands/results, useful failures and accessible
-   evidence references through the native handoff, then stop. Full logs stay
-   at their source; do not copy them into another inventory or status document.
+   evidence references through the native handoff, then stop. Keep full logs
+   at their source, without duplicating inventories or status documents.
    Missing or truncated evidence stays explicit.
 
 ## Diagnosis, scaffolding and delegated work
@@ -118,13 +121,14 @@ continue independent authorized work. Generated companions already included as
 scope require no new approval. Acceptance changes always require caller authority.
 
 Specialists advise only. Known defects stay implementation work; a genuine
-causal stall follows RPI's at-most-one bounded helper rule. Respect remaining
-caller/native bounds and reserve finishing capacity. No retry resets them.
+causal stall permits at most one bounded fresh helper within caller authority.
+Respect remaining caller/native bounds and reserve finishing capacity; retries reset neither.
 
 Return facts, not semantic PASS. An implement-only handoff does not authorize
 Git, tracker or delivery transitions; existing caller authority remains usable.
-A full outcome request uses RPI through fresh final judgment. Success is working
-behavior with usable evidence, not volume of logs or process artifacts.
+A full outcome request continues through fresh independent final judgment;
+RPI is optional and explicitly selected. Success is working behavior with usable
+evidence, not volume of logs or process artifacts.
 
 [Generic scaffold examples](references/scaffold/generic-templates.md) are
 optional starting points when the repository has no suitable existing pattern.

--- a/skills/postmortem/SKILL.md
+++ b/skills/postmortem/SKILL.md
@@ -5,8 +5,7 @@ practices:
 - sre
 - lean-startup
 hexagonal_role: domain
-consumes:
-- verdict.v2
+consumes: []
 produces:
 - postmortem-report.md
 context_rel: []
@@ -27,69 +26,58 @@ context:
   sections:
     exclude:
     - HISTORY
-output_contract: 'YYYY-MM-DD-postmortem-<topic>.md — markdown causal analysis (causal question, pinned inputs, timeline, hypotheses, counterfactuals, unknowns, experiments)'
+output_contract: 'concise inline causal analysis; a requested durable report is YYYY-MM-DD-postmortem-<topic>.md in caller-selected protected external non-Git storage'
 ---
 
 # Postmortem
 
-> **Purpose:** Answer an explicit retrospective causal question using the
-> already-validated outcome and evidence.
+Answer an explicit retrospective causal question about a completed or stopped
+goal, session or change using its actual intent, outcome and judgment evidence.
 
 ## Prompt
 
 ```text
-Postmortem: verdict .agents/ao/verdicts/2026-08-30-cli-regen.json shows
-NOT_PROVEN then PASS after we added a mutating-check guard to
-skills/validate/scripts/validate.sh. Did that guard actually cause the
-fix, or did the flaky CI runner just stop flaking that day?
+Postmortem this stopped change using its accepted intent, native session,
+check results and reviewer messages. Which correction cycles were avoidable,
+and which checks were necessary? No verdict file was saved. Answer inline.
 ```
-
-## It's working if
-
-Observable in the trace, without reading the prose:
-
-- The report pins the exact `verdict.v2` id and the causal question before
-  the timeline section.
-- A claim promoted to cause cites its mechanism, evidence, and
-  counterfactual together under the report's `hypotheses` list.
-- A claim resting only on symptom cessation is listed under `unknowns`,
-  not promoted to cause.
-- The report lands at
-  `.agents/scratch/postmortem/YYYY-MM-DD-postmortem-<topic>.md` and
-  `bash skills/postmortem/scripts/validate.sh` exits 0.
 
 ## Critical Constraints
 
-- Because proof and causal inference are different judgments, Postmortem is retrospective causal analysis, not the general learning umbrella and not a completion gate.
-- It consumes immutable Validate verdict evidence and does not re-run acceptance validation because Validate already owns that proof.
-- Treat causal statements as hypotheses because causal confidence must survive
-  alternatives. Separate observed sequence, contributing conditions,
-  counterfactuals, and unknowns.
-- A correlation is not promoted to cause without evidence that discriminates
-  plausible alternatives.
-- Because the caller owns delivery decisions, do not rewrite proof, operate
-  tracker state, change the remaining plan, or promote a rule. Return evidence
-  to the caller.
-- Empty or inconclusive analysis is valid; manufacture neither certainty nor a
-  lesson to make the retrospective feel useful.
+- Postmortem is retrospective causal analysis, not the general learning umbrella
+  or a completion gate: acceptance proof and causal inference are different judgments.
+- Existing verdicts and native judgments remain unchanged. It does not re-run acceptance validation
+  or fabricate missing proof to enable a retrospective. An existing `verdict.v2`
+  is optional evidence; its absence does not exclude a stopped or unvalidated subject.
+- Because the caller owns subsequent action, do not rewrite proof, operate
+  tracker state, change the remaining plan, reopen work or promote a rule.
+- Empty or inconclusive analysis is valid; recommend no change when warranted.
+  Manufacture neither certainty nor a lesson.
 
 ## Workflow
 
-1. Pin the verdict, subject evidence, and explicit causal
-   question.
-2. Reconstruct the evidence-backed timeline without importing hidden author
-   reasoning as fact.
-3. List candidate contributing conditions and at least one plausible
-   alternative explanation.
-4. Test each claim against cited evidence and a counterfactual: what should
-   differ if the claim were false?
-5. Optionally use independent judges to challenge contested causal claims.
-6. Emit a report containing supported claims, rejected claims, unknowns,
-   evidence references, and suggested experiments. Stop.
+1. Pin the explicit question, accepted intent, subject identity, actual outcome
+   and available judgment. Cite native work/session references, commits, checks
+   and reviewer messages as applicable; cite an existing verdict by exact id.
+   Keep missing evidence explicit before drawing conclusions.
+2. Reconstruct only the relevant evidence-backed timeline. Keep delivered
+   behavior, failed/stopped work and process output distinct; hidden author
+   reasoning is not fact. Missing judgment is not a PASS or a FAIL.
+3. Separate delivered facts from causal hypotheses. Test contributing conditions
+   against cited evidence, at least one
+   plausible alternative and a counterfactual. Distinguish necessary validation
+   and compatibility work from avoidable rework; repeated review alone proves no waste.
+4. For time/token claims, state source, interval, units, included/excluded actors
+   and uncertainty. Separate elapsed time, overlapping work and accounting scopes;
+   never equate totals with waste, savings or money without supporting evidence.
+5. Optionally seek independent support or challenge for contested causal claims
+   within caller authority. Return supported/rejected claims, unknowns and at
+   most three supported changes with limits or small suggested experiments. Stop;
+   suggestions do not authorize implementation.
 
 ## Correlation-to-cause discrimination
 
-A fix is proven when the mechanism is demonstrated, not when symptoms stop.
+Treat causal statements as hypotheses until the mechanism is demonstrated.
 Promoting a claim from correlation to cause requires all three:
 
 - a stated mechanism — the specific path by which the condition produced the
@@ -99,31 +87,31 @@ Promoting a claim from correlation to cause requires all three:
 - a counterfactual test — what should have differed if the claim were false,
   with the cited evidence showing it did differ.
 
-Symptom disappearance after a change satisfies none of these on its own: the
-change and the recovery may share an unobserved cause, or the symptom may be
-intermittent. The named failure mode is post-hoc fix attribution — "we
-changed X and the failure stopped, therefore X was the cause." Claims backed
-only by symptom cessation stay in the report as correlations with the
-untested alternatives listed, and the suggested experiment is the
-discrimination that would settle them. Stop condition: every supported causal
-claim in the report carries all three elements with citations; anything less
-is filed under correlations or unknowns, never silently promoted.
+Post-hoc fix attribution — "we changed X and the failure stopped, therefore X
+was the cause" — satisfies none of these alone. The symptom may be intermittent,
+or recovery and the change may share an unobserved cause. Keep such claims as
+correlations with untested alternatives and a suggested discriminating experiment.
+Every supported causal claim needs all three elements with citations; anything
+less stays a correlation or unknown.
 
 ## Output Specification
 
-- **Artifact directory:** `.agents/scratch/postmortem/`.
-- **Filename convention:** `YYYY-MM-DD-postmortem-<topic>.md`.
-- **Serialization/schema format:** Markdown with causal question, pinned inputs,
-  timeline, hypotheses, evidence, counterfactuals, unknowns, and experiments.
-- **Validator command:** `bash skills/postmortem/scripts/validate.sh`.
-- **Downstream handoff:** Learn or the caller may consume the analysis; they own
-  any bookkeeping, promotion, planning, or delivery decision.
+- Default to concise inline Markdown: question, pinned inputs, relevant timeline,
+  hypotheses/evidence/counterfactuals, unknowns and bounded suggestions. No mandatory report or worksheet.
+- Only when requested, save `YYYY-MM-DD-postmortem-<topic>.md` in caller-selected
+  protected external non-Git storage. Missing routing does not authorize a
+  repository fallback; preserve existing requested evidence under owner policy.
+- `bash skills/postmortem/scripts/validate.sh` checks package structure and
+  contract markers. It does not inspect report truth, causal support or acceptance.
+- The caller owns bookkeeping, planning and delivery. Optional
+  [Memory](../memory/SKILL.md) owns any separately authorized curation, support
+  and destination-disclosure review; retrospective evidence cannot promote itself.
 
 ## Quality Checklist
 
-- [ ] The causal question and immutable inputs are pinned.
+- [ ] The causal question and actual inputs are pinned; gaps are explicit.
 - [ ] Supported and rejected claims cite discriminating evidence.
 - [ ] Alternatives, counterfactuals, and unknowns remain visible.
 - [ ] The report stops short of proof, planning, tracker, and delivery authority.
 
-Executable behavior is in [postmortem.feature](references/postmortem.feature).
+Behavior examples are in [postmortem.feature](references/postmortem.feature).

--- a/skills/postmortem/references/postmortem.feature
+++ b/skills/postmortem/references/postmortem.feature
@@ -1,17 +1,22 @@
 Feature: Postmortem tests retrospective causal claims
-  As an engineer learning from a validated outcome
+  As an engineer learning from a completed or stopped goal, session or change
   I want causal hypotheses challenged against evidence and counterfactuals
   So that retrospective stories do not become unsupported doctrine
 
   Scenario: An explicit causal question receives bounded analysis
-    Given an immutable Validate verdict
+    Given actual intent, outcome and available native judgment evidence
     And an explicit retrospective causal question
     When Postmortem reconstructs the evidence-backed timeline
     Then it distinguishes supported claims, rejected claims, and unknowns
     And it cites evidence and counterfactuals
+    And it distinguishes delivered facts, necessary checks and avoidable rework
+    And uncertain time and token accounting remains explicit
+    And it returns at most three supported changes or no-change inline by default
 
   Scenario: Postmortem does not repeat validation
-    Given the acceptance verdict is already immutable
+    Given an existing immutable verdict or no saved verdict
     When Postmortem begins
     Then it does not re-run acceptance validation
+    And it does not fabricate missing judgment evidence
     And it does not change proof, bookkeeping, planning, tracker, or delivery state
+    And it saves a report only on request in protected external non-Git storage

--- a/skills/postmortem/scripts/validate.sh
+++ b/skills/postmortem/scripts/validate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Static package/contract checks only; no report or causal claim is evaluated.
 
 skill_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -15,4 +16,4 @@ if grep -Eiq 'ao (pawl|land)|git (commit|push)|br (close|update)' "$skill_dir/SK
   exit 1
 fi
 
-echo 'postmortem skill contract: PASS'
+echo 'postmortem static package contract: PASS (report truth not checked)'


### PR DESCRIPTION
Session mining could overwrite its source when the checkpoint referred to the same file, consume pending events during `--dry-run`, and miss native Codex custom-tool input edits when checking for transcript rewrites. The CLI now rejects source/checkpoint aliases before output or writes, previews from the current watermark without persisting it, and preserves native custom input so edits invalidate the checkpoint. Regression controls retain normal incremental mining and legacy argument handling.

Postmortem now accepts real goal/session evidence without requiring a fabricated verdict file, uses current Memory ownership and protected external storage, and separates structural checks from causal support. Implement guidance emphasizes early representative checks and exact repair verification. The Go standard and its local rule now point to the actual CI complexity gate and explain its committed-file scope. Normal projections are regenerated; no skill roots, framework or gate thresholds were added or weakened.

The bounded evaluation used three useful coding tasks with fixed behavior acceptance. Trial two exposed a real workflow defect: lint and fast checks passed while CI rejected complexity 25. Checkpoint construction was extracted, reducing MineSession to 20, and the Go guidance was corrected before the third task. The failed attempt stays in the evidence; this is an observational result, not proof of token savings or superiority over native prompting. Final local Go build/vet/test, lint, strict whole-campaign complexity and 37 selected gates pass. [CI run 34628874411](https://github.com/boshu2/agentops/actions/runs/34628874411) is green on `62205367e91946f84723147763662ca39ad4b580`, including Linux race/shuffle tests, Windows, Bats and security. The independent review checked all 27 changed paths and returned PASS with no unresolved findings or unchecked acceptance; its earlier complexity FAIL remains preserved. The local aggregate retains its existing skip for the absent legacy OL test directory.
